### PR TITLE
feat(alias): customResolver instead of built-in resolving algorithm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ output/
 .eslintcache
 coverage.lcov
 pnpm-debug.log
+.idea

--- a/packages/alias/README.md
+++ b/packages/alias/README.md
@@ -60,6 +60,13 @@ Then call `rollup` either via the [CLI](https://www.rollupjs.org/guide/en/#comma
 
 ## Options
 
+### `customResolver`
+
+Type: `Function | Object`<br>
+Default: `null`
+
+Instructs the plugin to use an alternative resolving algorithm, rather than the built-in resolver. Please refer to the [Rollup documentation](https://rollupjs.org/guide/en/#hooks) for more information about the `resolveId` hook. For a detailed example, see: [Custom Resolvers](#custom-resolvers).
+
 ### `entries`
 
 Type: `Object | Array[Object]`<br>
@@ -102,17 +109,6 @@ Specifies an array of file extensions to use when attempting to resolve an `impo
 alias({ resolve: ['.jsx', '.js'] });
 ```
 
-### `customResolver`
-
-Type: `Function | Object`<br>
-Default: `null`
-
-Specifies a different resolving algorithm instead of built-in should be used.
-`customResolver` could be any of Rollup plugins that makes module resolving.
-Or if you want to pass your custom function, please refer to [Rollup docs](https://rollupjs.org/guide/en/#hooks) for more info on `resolveId` hook.
-Please find detailed example in [Custom resolver instead of built-in algorithm](#custom-resolver-instead-of-built-in-algorithm) section below.
-
-
 ## Regular Expression Aliases
 
 Regular Expressions can be used to search in a more distinct and complex manner. e.g. To perform partial replacements via sub-pattern matching.
@@ -133,10 +129,9 @@ To replace extensions with another, a pattern like the following might be used:
 
 This would replace the file extension for all imports ending with `.js` to `.wasm`.
 
-## Custom resolver instead of built-in algorithm
+## Custom Resolvers
 
-In some situations you would like to keep preferred resolving method together with aliasing.
-It could be done with `customResolver` option.
+The `customResolver` option can be leveraged to provide separate module resolution for an invidudual alias.
 
 Example:
 ```javascript
@@ -169,10 +164,7 @@ export default {
 };
 ```
 
-In above example we made an alias `src` and still keep `node-resolve` algorithm for your files that are "aliased" with `src` by passing `customResolver` option.
-Also we keep `resolve()` plugin separately in plugins list for other files that are not aliased with `src`.
-
-`customResolver` option can be passed inside each entree too for granular control over resolving. It allows to choose preferred algorithm for each alias.
+In the example above the alias `src` is used, which uses the `node-resolve` algorithm for files _aliased_ with `src`, by passing the `customResolver` option. The `resolve()` plugin is kept separate in the plugins list for other files which are not _aliased_ with `src`. The `customResolver` option can be passed inside each `entries` item for granular control over resolving allowing each alias a preferred resolver.
 
 
 ## Meta

--- a/packages/alias/README.md
+++ b/packages/alias/README.md
@@ -102,6 +102,17 @@ Specifies an array of file extensions to use when attempting to resolve an `impo
 alias({ resolve: ['.jsx', '.js'] });
 ```
 
+### `customResolver`
+
+Type: `Function | Object`<br>
+Default: `null`
+
+Specifies a different resolving algorithm instead of built-in should be used.
+`customResolver` could be any of Rollup plugins that makes module resolving.
+Or if you want to pass your custom function, please refer to [Rollup docs](https://rollupjs.org/guide/en/#hooks) for more info on `resolveId` hook.
+Please find detailed example in [Custom resolver instead of built-in algorithm](#custom-resolver-instead-of-built-in-algorithm) section below.
+
+
 ## Regular Expression Aliases
 
 Regular Expressions can be used to search in a more distinct and complex manner. e.g. To perform partial replacements via sub-pattern matching.
@@ -149,21 +160,19 @@ export default {
             replacement: path.resolve(projectRootDir, "src")
             // OR place `customResolver` here. See explanation below.
           }
-        ]
-      },
-      customResolver
+        ],
+        customResolver
+      }
     ),
     resolve()
   ]
 };
 ```
 
-In example below we made an alias `src` and still keep `node-resolve` algorithm for your files that are "aliased" with `src` by passing `customResolver` option.
+In above example we made an alias `src` and still keep `node-resolve` algorithm for your files that are "aliased" with `src` by passing `customResolver` option.
 Also we keep `resolve()` plugin separately in plugins list for other files that are not aliased with `src`.
 
-`customResolver` option can be passed inside each entree too for granular control over resolving.
-
-`customResolver` also can be your own function, not plugin. Please refer to [Rollup docs](https://rollupjs.org/guide/en/#hooks) for more info.
+`customResolver` option can be passed inside each entree too for granular control over resolving. It allows to choose preferred algorithm for each alias.
 
 
 ## Meta

--- a/packages/alias/README.md
+++ b/packages/alias/README.md
@@ -122,6 +122,50 @@ To replace extensions with another, a pattern like the following might be used:
 
 This would replace the file extension for all imports ending with `.js` to `.wasm`.
 
+## Custom resolver instead of built-in algorithm
+
+In some situations you would like to keep preferred resolving method together with aliasing.
+It could be done with `customResolver` option.
+
+Example:
+```javascript
+// rollup.config.js
+import alias from "@rollup/plugin-alias";
+import resolve from "rollup-plugin-node-resolve";
+
+const customResolver = resolve({
+  extensions: [".mjs", ".js", ".jsx", ".json", ".sass", ".scss"]
+});
+const projectRootDir = path.resolve(__dirname);
+
+export default {
+  // ...
+  plugins: [
+    alias(
+      {
+        entries: [
+          {
+            find: "src",
+            replacement: path.resolve(projectRootDir, "src")
+            // OR place `customResolver` here. See explanation below.
+          }
+        ]
+      },
+      customResolver
+    ),
+    resolve()
+  ]
+};
+```
+
+In example below we made an alias `src` and still keep `node-resolve` algorithm for your files that are "aliased" with `src` by passing `customResolver` option.
+Also we keep `resolve()` plugin separately in plugins list for other files that are not aliased with `src`.
+
+`customResolver` option can be passed inside each entree too for granular control over resolving.
+
+`customResolver` also can be your own function, not plugin. Please refer to [Rollup docs](https://rollupjs.org/guide/en/#hooks) for more info.
+
+
 ## Meta
 
 [CONTRIBUTING](./.github/CONTRIBUTING.md)

--- a/packages/alias/src/index.js
+++ b/packages/alias/src/index.js
@@ -78,6 +78,27 @@ export default function alias(options = {}) {
 
       let updatedId = normalizeId(importeeId.replace(matchedEntry.find, matchedEntry.replacement));
 
+      let customResolver = null;
+      if (typeof matchedEntry.customResolver === 'function') {
+        customResolver = matchedEntry.customResolver;
+      } else if (
+        typeof matchedEntry.customResolver === 'object' &&
+        typeof matchedEntry.customResolver.resolveId === 'function'
+      ) {
+        customResolver = options.customResolver.resolveId;
+      } else if (typeof options.customResolver === 'function') {
+        customResolver = options.customResolver;
+      } else if (
+        typeof options.customResolver === 'object' &&
+        typeof options.customResolver.resolveId === 'function'
+      ) {
+        customResolver = options.customResolver.resolveId;
+      }
+
+      if (customResolver) {
+        return customResolver(updatedId, importerId);
+      }
+
       if (isFilePath(updatedId)) {
         const directory = posix.dirname(importerId);
 

--- a/packages/alias/test/test.js
+++ b/packages/alias/test/test.js
@@ -272,3 +272,41 @@ test('Works in rollup', (t) =>
           )
         );
     }));
+
+test('Global customResolver function', (t) => {
+  const customResult = 'customResult';
+  const result = alias({
+    entries: [
+      {
+        find: 'test',
+        replacement: path.resolve('./test/files/folder/hipster.jsx')
+      }
+    ],
+    resolve: ['.js', '.jsx'],
+    customResolver: () => customResult
+  });
+
+  const resolved = result.resolveId('test', posix.resolve(DIRNAME, './files/index.js'));
+
+  t.is(resolved, customResult);
+});
+
+test('Local customResolver function', (t) => {
+  const customResult = 'customResult';
+  const localCustomResult = 'localCustomResult';
+  const result = alias({
+    entries: [
+      {
+        find: 'test',
+        replacement: path.resolve('./test/files/folder/hipster.jsx'),
+        customResolver: () => localCustomResult
+      }
+    ],
+    resolve: ['.js', '.jsx'],
+    customResolver: () => customResult
+  });
+
+  const resolved = result.resolveId('test', posix.resolve(DIRNAME, './files/index.js'));
+
+  t.is(resolved, localCustomResult);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,7 +23,7 @@ importers:
       execa: ^2.0.4
       lint-staged: ^9.2.0
       nyc: ^14.1.1
-      pnpm: ^4.0.0
+      pnpm: ^4.1.5
       pre-commit: ^1.2.2
       prettier: ^1.18.2
       prettier-plugin-package: ^0.3.1
@@ -85,6 +85,29 @@ importers:
       rollup-pluginutils: ^2.6.0
       source-map: ^0.7.3
       typescript: ^3.4.3
+  packages/strip:
+    dependencies:
+      estree-walker: 0.6.1
+      magic-string: 0.25.4
+      rollup-pluginutils: 2.8.2
+    devDependencies:
+      acorn: 6.3.0
+      rollup: 1.26.0
+    specifiers:
+      acorn: ^6.0.2
+      estree-walker: ^0.6.0
+      magic-string: ^0.25.1
+      rollup: ^1.20.0
+      rollup-pluginutils: ^2.8.1
+  packages/wasm:
+    devDependencies:
+      del-cli: 3.0.0
+      rollup: 1.26.0
+      source-map: 0.7.3
+    specifiers:
+      del-cli: ^3.0.0
+      rollup: ^1.20.0
+      source-map: ^0.7.3
 lockfileVersion: 5.1
 packages:
   /@ava/babel-plugin-throws-helper/4.0.0:


### PR DESCRIPTION
- Rollup Plugin Name: alias

This PR contains:
- [ ] bugfix
- [x] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
https://github.com/rollup/plugins/issues/14

### Description

New feature related to my discussion with @lukastaegert.
`customResolver` option allows to pass plugin or function to be used instead of built-in algorithm for files resolving. Most common expected usage - together with `node-resolve` plugin.