### PR TITLE
feat(alias) add backwards compatible mapping options

### DIFF
--- a/packages/alias/src/index.js
+++ b/packages/alias/src/index.js
@@ -40,18 +40,19 @@ const normalizeId = (id) => {
   return id;
 };
 
-const getEntries = ({ entries }) => {
-  if (!entries) {
-    return [];
-  }
-
+const getEntries = (options) => {
+  let { entries } = options;
   if (Array.isArray(entries)) {
     return entries;
   }
 
-  return Object.keys(entries).map((key) => {
-    return { find: key, replacement: entries[key] };
-  });
+  // entries might contain the "resolve" property, so filter out array values
+  entries = (typeof entries === 'object' && entries) || options;
+  return Object.keys(entries)
+    .map((key) => {
+      return { find: key, replacement: entries[key] };
+    })
+    .filter((entry) => !Array.isArray(entry.replacement));
 };
 
 export default function alias(options = {}) {

--- a/packages/alias/test/test.js
+++ b/packages/alias/test/test.js
@@ -62,6 +62,28 @@ test('Simple aliasing (object)', (t) => {
   t.is(resolved3, 'global');
 });
 
+test('Simple aliasing (object) (v1)', (t) => {
+  const result = alias({
+    foo: 'bar',
+    pony: 'paradise',
+    './local': 'global',
+    resolve: ['.mjs', '.js'],
+    entries: 'string'
+  });
+
+  const resolved = result.resolveId('foo', '/src/importer.js');
+  const resolved2 = result.resolveId('pony', '/src/importer.js');
+  const resolved3 = result.resolveId('./local', '/src/importer.js');
+  const resolved4 = result.resolveId('resolve', '/src/importer.js');
+  const resolved5 = result.resolveId('entries', '/src/importer.js');
+
+  t.is(resolved, 'bar');
+  t.is(resolved2, 'paradise');
+  t.is(resolved3, 'global');
+  t.is(resolved4, null);
+  t.is(resolved5, 'string');
+});
+
 test('RegExp aliasing', (t) => {
   const result = alias({
     entries: [


### PR DESCRIPTION
Resolve rollup/plugins#27

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

- Rollup Plugin Name: alias

This PR contains:
- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description

Add support for `alias({ src: __dirname + '/src' })`
https://github.com/rollup/plugins/issues/27