### PR TITLE
feat(alias): add plugin name

### DIFF
--- a/packages/alias/README.md
+++ b/packages/alias/README.md
@@ -134,38 +134,36 @@ This would replace the file extension for all imports ending with `.js` to `.ali
 The `customResolver` option can be leveraged to provide separate module resolution for an invidudual alias.
 
 Example:
+
 ```javascript
 // rollup.config.js
-import alias from "@rollup/plugin-alias";
-import resolve from "rollup-plugin-node-resolve";
+import alias from '@rollup/plugin-alias';
+import resolve from 'rollup-plugin-node-resolve';
 
 const customResolver = resolve({
-  extensions: [".mjs", ".js", ".jsx", ".json", ".sass", ".scss"]
+  extensions: ['.mjs', '.js', '.jsx', '.json', '.sass', '.scss']
 });
 const projectRootDir = path.resolve(__dirname);
 
 export default {
   // ...
   plugins: [
-    alias(
-      {
-        entries: [
-          {
-            find: "src",
-            replacement: path.resolve(projectRootDir, "src")
-            // OR place `customResolver` here. See explanation below.
-          }
-        ],
-        customResolver
-      }
-    ),
+    alias({
+      entries: [
+        {
+          find: 'src',
+          replacement: path.resolve(projectRootDir, 'src')
+          // OR place `customResolver` here. See explanation below.
+        }
+      ],
+      customResolver
+    }),
     resolve()
   ]
 };
 ```
 
 In the example above the alias `src` is used, which uses the `node-resolve` algorithm for files _aliased_ with `src`, by passing the `customResolver` option. The `resolve()` plugin is kept separate in the plugins list for other files which are not _aliased_ with `src`. The `customResolver` option can be passed inside each `entries` item for granular control over resolving allowing each alias a preferred resolver.
-
 
 ## Meta
 

--- a/packages/alias/src/index.js
+++ b/packages/alias/src/index.js
@@ -66,6 +66,7 @@ export default function alias(options = {}) {
   }
 
   return {
+    name: 'alias',
     resolveId(importee, importer) {
       const importeeId = normalizeId(importee);
       const importerId = normalizeId(importer);
@@ -80,14 +81,14 @@ export default function alias(options = {}) {
 
       let customResolver = null;
       if (typeof matchedEntry.customResolver === 'function') {
-        customResolver = matchedEntry.customResolver;
+        ({ customResolver } = matchedEntry);
       } else if (
         typeof matchedEntry.customResolver === 'object' &&
         typeof matchedEntry.customResolver.resolveId === 'function'
       ) {
         customResolver = matchedEntry.customResolver.resolveId;
       } else if (typeof options.customResolver === 'function') {
-        customResolver = options.customResolver;
+        ({ customResolver } = options);
       } else if (
         typeof options.customResolver === 'object' &&
         typeof options.customResolver.resolveId === 'function'

--- a/packages/alias/test/test.js
+++ b/packages/alias/test/test.js
@@ -86,7 +86,10 @@ test('RegExp aliasing', (t) => {
 
 test('Will not confuse modules with similar names', (t) => {
   const result = alias({
-    entries: [{ find: 'foo', replacement: 'bar' }, { find: './foo', replacement: 'bar' }]
+    entries: [
+      { find: 'foo', replacement: 'bar' },
+      { find: './foo', replacement: 'bar' }
+    ]
   });
 
   const resolved = result.resolveId('foo2', '/src/importer.js');
@@ -100,7 +103,10 @@ test('Will not confuse modules with similar names', (t) => {
 
 test('Local aliasing', (t) => {
   const result = alias({
-    entries: [{ find: 'foo', replacement: './bar' }, { find: 'pony', replacement: './par/a/di/se' }]
+    entries: [
+      { find: 'foo', replacement: './bar' },
+      { find: 'pony', replacement: './par/a/di/se' }
+    ]
   });
 
   const resolved = result.resolveId('foo', '/src/importer.js');
@@ -321,7 +327,7 @@ test('Global customResolver plugin-like object', (t) => {
       }
     ],
     resolve: ['.js', '.jsx'],
-    customResolver: {resolveId: () => customResult}
+    customResolver: { resolveId: () => customResult }
   });
 
   const resolved = result.resolveId('test', posix.resolve(DIRNAME, './files/index.js'));
@@ -337,11 +343,11 @@ test('Local customResolver plugin-like object', (t) => {
       {
         find: 'test',
         replacement: path.resolve('./test/files/folder/hipster.jsx'),
-        customResolver: {resolveId: () => localCustomResult}
+        customResolver: { resolveId: () => localCustomResult }
       }
     ],
     resolve: ['.js', '.jsx'],
-    customResolver: {resolveId: () => customResult}
+    customResolver: { resolveId: () => customResult }
   });
 
   const resolved = result.resolveId('test', posix.resolve(DIRNAME, './files/index.js'));


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

- Rollup Plugin Name: <!-- the plugin(s) this PR is for -->

This PR contains:
- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no


### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

Adding name to `alias` plugin as recommended inside rollup's plugin development guidelines: https://rollupjs.org/guide/en/#plugin-development

Technically it is a feature? but writing test for it sounds silly. If required I'll gladly add it. :bowtie: