### PR TITLE
chore: migrate rollup-plugin-legacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This repository houses plugins that Rollup considers critical to every day use o
 | [image](packages/image)               | Import JPG, PNG, GIF, SVG, and WebP files                                                 |
 | [inject](packages/inject)             | Scan modules for global variables and injects `import` statements where necessary         |
 | [json](packages/json)                 | Convert .json files to ES6 modules                                                        |
+| [legacy](packages/legacy)             | Add `export` declarations to legacy non-module scripts.                                   |
 | [replace](packages/replace)           | Replace strings in files while bundling                                                   |
 | [strip](packages/strip)               | Remove debugger statements and functions like assert.equal and console.log from your code |
 | [url](packages/url)                   | Import files as data-URIs or ES Modules                                                   |

--- a/packages/legacy/CHANGELOG.md
+++ b/packages/legacy/CHANGELOG.md
@@ -1,0 +1,15 @@
+# @rollup/plugin-legacy changelog
+
+## 2.0.0
+
+_2019-11-24_
+
+- **Breaking:** Minimum compatible Rollup version is 1.2.0
+- **Breaking:** Minimum supported Node version is 8.0.0
+- Published under @rollup/plugins-legacy
+
+## 1.0.0
+
+_2016-12-28_
+
+- First release

--- a/packages/legacy/README.md
+++ b/packages/legacy/README.md
@@ -1,0 +1,120 @@
+[npm]: https://img.shields.io/npm/v/@rollup/plugin-legacy
+[npm-url]: https://www.npmjs.com/package/@rollup/plugin-legacy
+[size]: https://packagephobia.now.sh/badge?p=@rollup/plugin-legacy
+[size-url]: https://packagephobia.now.sh/result?p=@rollup/plugin-legacy
+
+[![npm][npm]][npm-url]
+[![size][size]][size-url]
+[![libera manifesto](https://img.shields.io/badge/libera-manifesto-lightgrey.svg)](https://liberamanifesto.com)
+
+# @rollup/plugin-legacy
+
+🍣 A Rollup plugin which adds `export` declarations to legacy non-module scripts.
+
+## Requirements
+
+This plugin requires an [LTS](https://github.com/nodejs/Release) Node version (v8.0.0+) and Rollup v1.20.0+.
+
+## Install
+
+Using npm:
+
+```console
+npm install @rollup/plugin-legacy --save-dev
+```
+
+## Usage
+
+Create a `rollup.config.js` [configuration file](https://www.rollupjs.org/guide/en/#configuration-files) and import the plugin:
+
+```js
+import legacy from '@rollup/plugin-legacy';
+
+export default {
+  entry: 'src/main.js',
+  output: {
+    dir: 'output',
+    format: 'cjs'
+  },
+  plugins: [legacy({ 'vendor/some-library.js': 'someLibrary' })]
+};
+```
+
+Then call `rollup` either via the [CLI](https://www.rollupjs.org/guide/en/#command-line-reference) or the [API](https://www.rollupjs.org/guide/en/#javascript-api).
+
+## Options
+
+Type: `Object`<br>
+Default: `null`
+
+Specifies an `Object` which defines exports used when importing corresponding scripts. The `Object` allows specifying script paths as a key, and the corresponding value as the `export`s for that script. For example:
+
+#### `Object` Format
+
+The `Object` format allows specifying aliases as a key, and the corresponding value as the actual `import` value. For example:
+
+```js
+legacy({
+  'vendor/some-library.js': 'someLibrary',
+
+  'vendor/another-library.js': {
+    foo: 'anotherLib.foo',
+    bar: 'anotherLib.bar',
+    baz: 'anotherLib.baz'
+  }
+});
+```
+
+The configuration above will create a default export when importing `'vendor/some-library.js'` that corresponds with the `someLibrary` variable that it creates. It will also create named exports when importing `'vendor/another-library.js'`.
+
+## Motivation
+
+Occasionally you'll find a useful snippet of code from the Old Days, before newfangled technology like npm. These scripts will typically expose themselves as `var someLibrary = ...` or `window.someLibrary = ...`, the expectation being that other scripts will grab a reference to the library from the global namespace.
+
+It's usually easy enough to convert these to modules. But why bother? You can just add the `legacy` plugin, configure it accordingly, and it will be turned into a module automatically. With the example config below, the following code...
+
+```js
+// vendor/some-library.js
+var someLibrary = {
+  square: function(n) {
+    return n * n;
+  },
+  cube: function(n) {
+    return n * n * n;
+  }
+};
+```
+
+...will have a default export appended to it, allowing other modules to access it:
+
+```js
+export default someLibrary;
+```
+
+It can also handle named exports. Using the same config, this...
+
+```js
+// vendor/another-library.js
+var anotherLibrary = {
+  foo: ...,
+  bar: ...,
+  baz: ...
+};
+```
+
+...will get the following appended:
+
+```js
+var __export0 = anotherLibrary.foo;
+export { __export0 as foo };
+var __export0 = anotherLibrary.bar;
+export { __export0 as bar };
+var __export0 = anotherLibrary.baz;
+export { __export0 as baz };
+```
+
+## Meta
+
+[CONTRIBUTING](/.github/CONTRIBUTING.md)
+
+[LICENSE (MIT)](/LICENSE)

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@rollup/plugin-legacy",
+  "version": "2.0.0",
+  "publishConfig": {
+    "access": "public"
+  },
+  "description": "Add export statements to plain scripts",
+  "license": "MIT",
+  "repository": "rollup/plugins",
+  "author": "Rich Harris",
+  "homepage": "https://github.com/rollup/plugins/packages/legacy/#readme",
+  "bugs": "https://github.com/rollup/plugins/issues",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "rollup -c",
+    "ci:coverage": "nyc pnpm run test && nyc report --reporter=text-lcov > coverage.lcov",
+    "ci:lint": "pnpm run build && pnpm run lint && pnpm run security",
+    "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
+    "ci:test": "pnpm run test -- --verbose",
+    "lint": "pnpm run lint:js && pnpm run lint:docs && pnpm run lint:package",
+    "lint:docs": "prettier --single-quote --write README.md",
+    "lint:js": "eslint --fix --cache src test",
+    "lint:package": "prettier --write package.json --plugin=prettier-plugin-package",
+    "prebuild": "del-cli dist",
+    "prepare": "pnpm run build",
+    "prepublishOnly": "pnpm run lint",
+    "pretest": "pnpm run build",
+    "security": "echo 'pnpm needs `npm audit` support'",
+    "test": "ava"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "keywords": [
+    "rollup",
+    "plugin"
+  ],
+  "peerDependencies": {
+    "rollup": "^1.20.0"
+  },
+  "devDependencies": {
+    "@rollup/plugin-buble": "^0.20.0",
+    "del-cli": "^3.0.0",
+    "rollup": "^1.27.2"
+  },
+  "ava": {
+    "files": [
+      "!**/fixtures/**",
+      "!**/helpers/**",
+      "!**/recipes/**",
+      "!**/types.ts"
+    ]
+  },
+  "jsnext:main": "dist/index.es.js",
+  "module": "dist/index.es.js"
+}

--- a/packages/legacy/rollup.config.js
+++ b/packages/legacy/rollup.config.js
@@ -1,0 +1,12 @@
+import buble from '@rollup/plugin-buble';
+
+import pkg from './package.json';
+
+export default {
+  input: 'src/index.js',
+  plugins: [buble()],
+  output: [
+    { file: pkg.main, format: 'cjs', sourcemap: true },
+    { file: pkg.module, format: 'es', sourcemap: true }
+  ]
+};

--- a/packages/legacy/src/index.js
+++ b/packages/legacy/src/index.js
@@ -1,0 +1,49 @@
+import { resolve } from 'path';
+
+const validName = /^[a-zA-Z_$][a-zA-Z$_0-9]*$/;
+
+export default function legacy(options) {
+  const exports = {};
+  Object.keys(options).forEach((file) => {
+    exports[resolve(file)] = options[file];
+  });
+
+  return {
+    name: 'legacy',
+
+    transform(content, id) {
+      if (id in exports) {
+        let code = content;
+        const value = exports[id];
+
+        if (typeof value === 'string') {
+          // default export
+          code += `\nexport default ${value};`;
+        } else {
+          const statements = [];
+          let i = 1;
+
+          Object.entries(value).forEach(([key, name]) => {
+            if (name === key) {
+              statements.push(`export { ${key} };`);
+            } else if (validName.test(name)) {
+              statements.push(`export { ${name} as ${key} };`);
+            } else {
+              statements.push(`var __export${i} = ${name};\nexport { __export${i} as ${key} };`);
+              i += 1;
+            }
+          });
+
+          code += `\n${statements.join('\n')}`;
+        }
+
+        // TODO need a way to say 'sourcemap hasn't changed
+        return {
+          code,
+          map: { mappings: '' }
+        };
+      }
+      return null;
+    }
+  };
+}

--- a/packages/legacy/test/fixtures/.eslintrc
+++ b/packages/legacy/test/fixtures/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "globals": {
+    "t": "readonly"
+  }
+}

--- a/packages/legacy/test/fixtures/default-export/answer.js
+++ b/packages/legacy/test/fixtures/default-export/answer.js
@@ -1,0 +1,3 @@
+/* eslint-disable no-var, no-unused-vars */
+
+var answer = 42;

--- a/packages/legacy/test/fixtures/default-export/answer.js
+++ b/packages/legacy/test/fixtures/default-export/answer.js
@@ -1,3 +1,3 @@
-/* eslint-disable no-var, no-unused-vars */
+/* eslint-disable */
 
 var answer = 42;

--- a/packages/legacy/test/fixtures/default-export/main.js
+++ b/packages/legacy/test/fixtures/default-export/main.js
@@ -1,0 +1,3 @@
+import answer from './answer';
+
+t.is(answer, 42);

--- a/packages/legacy/test/fixtures/named-exports-changed/answer.js
+++ b/packages/legacy/test/fixtures/named-exports-changed/answer.js
@@ -1,0 +1,3 @@
+/* eslint-disable no-var, no-unused-vars */
+
+var answerToLifeTheUniverseAndEverything = 42;

--- a/packages/legacy/test/fixtures/named-exports-changed/answer.js
+++ b/packages/legacy/test/fixtures/named-exports-changed/answer.js
@@ -1,3 +1,3 @@
-/* eslint-disable no-var, no-unused-vars */
+/* eslint-disable */
 
 var answerToLifeTheUniverseAndEverything = 42;

--- a/packages/legacy/test/fixtures/named-exports-changed/main.js
+++ b/packages/legacy/test/fixtures/named-exports-changed/main.js
@@ -1,0 +1,3 @@
+import { answer } from './answer';
+
+t.is(answer, 42);

--- a/packages/legacy/test/fixtures/named-exports-nested/answer.js
+++ b/packages/legacy/test/fixtures/named-exports-nested/answer.js
@@ -1,0 +1,5 @@
+/* eslint-disable no-var, no-unused-vars */
+
+var obj = {
+  answer: 42
+};

--- a/packages/legacy/test/fixtures/named-exports-nested/answer.js
+++ b/packages/legacy/test/fixtures/named-exports-nested/answer.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-var, no-unused-vars */
+/* eslint-disable */
 
 var obj = {
   answer: 42

--- a/packages/legacy/test/fixtures/named-exports-nested/main.js
+++ b/packages/legacy/test/fixtures/named-exports-nested/main.js
@@ -1,0 +1,3 @@
+import { answer } from './answer';
+
+t.is(answer, 42);

--- a/packages/legacy/test/fixtures/named-exports-unchanged/answer.js
+++ b/packages/legacy/test/fixtures/named-exports-unchanged/answer.js
@@ -1,0 +1,3 @@
+/* eslint-disable no-var, no-unused-vars */
+
+var answer = 42;

--- a/packages/legacy/test/fixtures/named-exports-unchanged/answer.js
+++ b/packages/legacy/test/fixtures/named-exports-unchanged/answer.js
@@ -1,3 +1,3 @@
-/* eslint-disable no-var, no-unused-vars */
+/* eslint-disable */
 
 var answer = 42;

--- a/packages/legacy/test/fixtures/named-exports-unchanged/main.js
+++ b/packages/legacy/test/fixtures/named-exports-unchanged/main.js
@@ -1,0 +1,3 @@
+import { answer } from './answer';
+
+t.is(answer, 42);

--- a/packages/legacy/test/test.js
+++ b/packages/legacy/test/test.js
@@ -1,0 +1,66 @@
+const test = require('ava');
+const { rollup } = require('rollup');
+
+const { testBundle } = require('../../../util/test');
+
+const legacy = require('..');
+
+process.chdir(__dirname);
+
+test('adds a default export', async (t) => {
+  const bundle = await rollup({
+    input: 'fixtures/default-export/main.js',
+    plugins: [
+      legacy({
+        './fixtures/default-export/answer.js': 'answer'
+      })
+    ]
+  });
+  t.plan(1);
+  await testBundle(t, bundle);
+});
+
+test('adds a changed named export', async (t) => {
+  const bundle = await rollup({
+    input: 'fixtures/named-exports-changed/main.js',
+    plugins: [
+      legacy({
+        './fixtures/named-exports-changed/answer.js': {
+          answer: 'answerToLifeTheUniverseAndEverything'
+        }
+      })
+    ]
+  });
+  t.plan(1);
+  await testBundle(t, bundle);
+});
+
+test('adds a nested named export', async (t) => {
+  const bundle = await rollup({
+    input: 'fixtures/named-exports-nested/main.js',
+    plugins: [
+      legacy({
+        './fixtures/named-exports-nested/answer.js': {
+          answer: 'obj.answer'
+        }
+      })
+    ]
+  });
+  t.plan(1);
+  await testBundle(t, bundle);
+});
+
+test('adds a unchanged named export', async (t) => {
+  const bundle = await rollup({
+    input: 'fixtures/named-exports-unchanged/main.js',
+    plugins: [
+      legacy({
+        './fixtures/named-exports-unchanged/answer.js': {
+          answer: 'answer'
+        }
+      })
+    ]
+  });
+  t.plan(1);
+  await testBundle(t, bundle);
+});

--- a/packages/replace/README.md
+++ b/packages/replace/README.md
@@ -9,7 +9,7 @@
 
 # @rollup/plugin-replace
 
-🍣 A Rollup which replaces strings in files while bundling.
+🍣 A Rollup plugin which replaces strings in files while bundling.
 
 ## Requirements
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1100,6 +1100,17 @@ packages:
       node: '>= 8'
     resolution:
       integrity: sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==
+  /@rollup/plugin-buble/0.20.0_rollup@1.27.2:
+    dependencies:
+      buble: 0.19.8
+      rollup: 1.27.2
+      rollup-pluginutils: 2.8.2
+      typescript: 3.7.2
+    dev: true
+    peerDependencies:
+      rollup: ^1.20.0
+    resolution:
+      integrity: sha512-3Qkoa3n+6NjQggLkN5R6ouVL3/jveyqjJjJXxbk04HEig/97YyOwoimWYIOC5vlQ60Z+xLhnAvGd6mM0gFY2wQ==
   /@samverschueren/stream-to-observable/0.3.0:
     dependencies:
       any-observable: 0.3.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,6 +160,15 @@ importers:
       source-map-support: ^0.5.11
   packages/json/test/fixtures/named:
     specifiers: {}
+  packages/legacy:
+    devDependencies:
+      '@rollup/plugin-buble': 0.20.0_rollup@1.27.5
+      del-cli: 3.0.0
+      rollup: 1.27.5
+    specifiers:
+      '@rollup/plugin-buble': ^0.20.0
+      del-cli: ^3.0.0
+      rollup: ^1.27.2
   packages/pluginutils:
     dependencies:
       estree-walker: 0.6.1
@@ -1100,10 +1109,10 @@ packages:
       node: '>= 8'
     resolution:
       integrity: sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==
-  /@rollup/plugin-buble/0.20.0_rollup@1.27.2:
+  /@rollup/plugin-buble/0.20.0_rollup@1.27.5:
     dependencies:
       buble: 0.19.8
-      rollup: 1.27.2
+      rollup: 1.27.5
       rollup-pluginutils: 2.8.2
       typescript: 3.7.2
     dev: true
@@ -1180,6 +1189,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
+  /@types/estree/0.0.40:
+    dev: true
+    resolution:
+      integrity: sha512-p3KZgMto/JyxosKGmnLDJ/dG5wf+qTRMUjHJcspC2oQKa4jP7mz+tv0ND56lLBu3ojHlhzY33Ol+khLyNmilkA==
   /@types/events/3.0.0:
     dev: true
     resolution:
@@ -1333,9 +1346,9 @@ packages:
         optional: true
     resolution:
       integrity: sha512-v6btSPXEWCP594eZbM+JCXuFoXWXyF/z8kaSBSdCb83DF+Y7+xItW29SsKtSULgLemqJBT+LpT+0ZqdfH7QVmA==
-  /acorn-dynamic-import/4.0.0_acorn@6.3.0:
+  /acorn-dynamic-import/4.0.0_acorn@6.4.0:
     dependencies:
-      acorn: 6.3.0
+      acorn: 6.4.0
     peerDependencies:
       acorn: ^6.0.0
     resolution:
@@ -1346,9 +1359,9 @@ packages:
     dev: true
     resolution:
       integrity: sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=
-  /acorn-jsx/5.1.0_acorn@6.3.0:
+  /acorn-jsx/5.1.0_acorn@6.4.0:
     dependencies:
-      acorn: 6.3.0
+      acorn: 6.4.0
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0
     resolution:
@@ -1375,11 +1388,18 @@ packages:
     resolution:
       integrity: sha1-ReN/s56No/JbruP/U2niu18iAXo=
   /acorn/6.3.0:
+    dev: true
     engines:
       node: '>=0.4.0'
     hasBin: true
     resolution:
       integrity: sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==
+  /acorn/6.4.0:
+    engines:
+      node: '>=0.4.0'
+    hasBin: true
+    resolution:
+      integrity: sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==
   /acorn/7.1.0:
     dev: true
     engines:
@@ -1758,9 +1778,9 @@ packages:
       integrity: sha1-PGjwzl+CgB/zUVGle0hw6VExBdc=
   /buble/0.19.8:
     dependencies:
-      acorn: 6.3.0
-      acorn-dynamic-import: 4.0.0_acorn@6.3.0
-      acorn-jsx: 5.1.0_acorn@6.3.0
+      acorn: 6.4.0
+      acorn-dynamic-import: 4.0.0_acorn@6.4.0
+      acorn-jsx: 5.1.0_acorn@6.4.0
       chalk: 2.4.2
       magic-string: 0.25.4
       minimist: 1.2.0
@@ -5966,8 +5986,8 @@ packages:
       integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==
   /rollup/1.27.5:
     dependencies:
-      '@types/estree': 0.0.39
-      '@types/node': 12.12.12
+      '@types/estree': 0.0.40
+      '@types/node': 12.12.14
       acorn: 7.1.0
     dev: true
     hasBin: true


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->
## Rollup Plugin Name: `@rollup/plugin-legacy`

This PR contains:
- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [x] yes (*breaking changes will not be merged unless absolutely necessary*)
- [ ] no

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

This PR migrates the rollup-plugin-legacy plugin.
