### PR TITLE
chore: migrate rollup-plugin-virtual

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This repository houses plugins that Rollup considers critical to every day use o
 | [strip](packages/strip)               | Remove debugger statements and functions like assert.equal and console.log from your code |
 | [wasm](packages/wasm)                 | Import WebAssembly code with Rollup                                                       |
 | [yaml](packages/yaml)                 | Convert YAML files to ES6 modules                                                         |
+| [virtual](packages/virtual)           | Load virtual modules from memory                                                          |
 |                                       |                                                                                           |
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ This repository houses plugins that Rollup considers critical to every day use o
 | [json](packages/json)                 | Convert .json files to ES6 modules                                                        |
 | [replace](packages/replace)           | Replace strings in files while bundling                                                   |
 | [strip](packages/strip)               | Remove debugger statements and functions like assert.equal and console.log from your code |
+| [virtual](packages/virtual)           | Load virtual modules from memory                                                          |
 | [wasm](packages/wasm)                 | Import WebAssembly code with Rollup                                                       |
 | [yaml](packages/yaml)                 | Convert YAML files to ES6 modules                                                         |
-| [virtual](packages/virtual)           | Load virtual modules from memory                                                          |
 |                                       |                                                                                           |
 
 ## Contributing

--- a/packages/virtual/CHANGELOG.md
+++ b/packages/virtual/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @rollup/plugin-virtual Change Log
 
+## 2.0.0
+
+- **Breaking:** Minimum compatible Rollup version is 1.2.0
+- **Breaking:** Minimum supported Node version is 8.0.0
+- Published under @rollup/plugins-virtual
+
 ## 1.0.1
 
 - Add missing `dist` files

--- a/packages/virtual/CHANGELOG.md
+++ b/packages/virtual/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @rollup/plugin-virtual Change Log
+
+## 1.0.1
+
+- Add missing `dist` files
+
+## 1.0.0
+
+- First release

--- a/packages/virtual/README.md
+++ b/packages/virtual/README.md
@@ -1,0 +1,57 @@
+# rollup-plugin-virtual
+
+Load modules from memory.
+
+## Usage
+
+Suppose you have an input file like this, and you want to load `foo` and `src/bar.js` from memory:
+
+```js
+// src.main.js
+import foo from 'foo';
+import bar from './bar.js';
+
+console.log(foo, bar);
+```
+
+```js
+// rollup.config.js
+import virtual from 'rollup-plugin-virtual';
+
+export default {
+  entry: 'src/main.js',
+  // ...
+  plugins: [
+    virtual({
+      foo: 'export default 1',
+      'src/bar.js': 'export default 2'
+    })
+  ]
+};
+```
+
+If there were named exports:
+
+```js
+// src.main.js
+export { foo, bar } from 'foobar';
+
+console.log(foo, bar);
+```
+
+```js
+// rollup.config.js
+// ...
+virtual({
+  foobar: `
+        export const foo = vendor._foobar.foo;
+        export const bar = vendor._foobar.bar;
+      `
+});
+```
+
+Use this plugin **before** any other one like node-resolve or commonjs so they do not alter the output.
+
+## License
+
+[MIT](LICENSE)

--- a/packages/virtual/README.md
+++ b/packages/virtual/README.md
@@ -1,56 +1,64 @@
-# rollup-plugin-virtual
+[npm]: https://img.shields.io/npm/v/@rollup/plugin-virtual
+[npm-url]: https://www.npmjs.com/package/@rollup/plugin-virtual
+[size]: https://packagephobia.now.sh/badge?p=@rollup/plugin-virtual
+[size-url]: https://packagephobia.now.sh/result?p=@rollup/plugin-virtual
 
-Load modules from memory.
+[![npm][npm]][npm-url]
+[![size][size]][size-url]
+[![libera manifesto](https://img.shields.io/badge/libera-manifesto-lightgrey.svg)](https://liberamanifesto.com)
+
+# @rollup/plugin-virtual
+
+🍣 A Rollup plugin which loads virtual modules from memory.
+
+## Requirements
+
+This plugin requires an [LTS](https://github.com/nodejs/Release) Node version (v8.0.0+) and Rollup v1.20.0+.
+
+## Install
+
+Using npm:
+
+```console
+npm install @rollup/plugin-yaml --save-dev
+```
 
 ## Usage
 
-Suppose you have an input file like this, and you want to load `foo` and `src/bar.js` from memory:
+_Note. Use this plugin **before** any others such as node-resolve or commonjs, so they do not alter the output._
+
+Suppose an entry file containing the snippet below exists at `src/entry.js`, and attempts to load `batman` and `src/robin.js` from memory:
 
 ```js
-// src.main.js
-import foo from 'foo';
-import bar from './bar.js';
+// src/input.js
+import batman from 'batman';
+import robin from './robin.js';
 
-console.log(foo, bar);
+console.log(batman, robin);
 ```
 
+Create a `rollup.config.js` [configuration file](https://www.rollupjs.org/guide/en/#configuration-files) and import the plugin:
+
 ```js
-// rollup.config.js
 import virtual from 'rollup-plugin-virtual';
 
 export default {
-  entry: 'src/main.js',
+  entry: 'src/entry.js',
   // ...
   plugins: [
     virtual({
-      foo: 'export default 1',
-      'src/bar.js': 'export default 2'
+      batman: `export default 'na na na na na'`,
+      'src/robin.js': `export default 'batmannnnn'`
     })
   ]
 };
 ```
 
-If there were named exports:
+Then call `rollup` either via the [CLI](https://www.rollupjs.org/guide/en/#command-line-reference) or the [API](https://www.rollupjs.org/guide/en/#javascript-api).
 
-```js
-// src.main.js
-export { foo, bar } from 'foobar';
+## Options
 
-console.log(foo, bar);
-```
-
-```js
-// rollup.config.js
-// ...
-virtual({
-  foobar: `
-        export const foo = vendor._foobar.foo;
-        export const bar = vendor._foobar.bar;
-      `
-});
-```
-
-Use this plugin **before** any other one like node-resolve or commonjs so they do not alter the output.
+This plugin has no formal options. The lone parameter for this plugin is an `Object` containing properties that correspond to a `String` containing the virtual module's code.
 
 ## License
 

--- a/packages/virtual/package.json
+++ b/packages/virtual/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "rollup-plugin-virtual",
+  "version": "1.0.1",
+  "description": "Load modules from memory",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rollup/rollup-plugin-virtual.git"
+  },
+  "author": "Rich Harris",
+  "homepage": "https://github.com/rollup/rollup-plugin-virtual#readme",
+  "bugs": {
+    "url": "https://github.com/rollup/rollup-plugin-virtual/issues"
+  },
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "rollup -c",
+    "lint": "eslint src",
+    "pretest": "npm run build",
+    "test": "ava"
+  },
+  "files": [
+    "dist"
+  ],
+  "keywords": [
+    "rollup"
+  ],
+  "devDependencies": {
+    "rollup": "^1.20.0",
+    "rollup-plugin-node-resolve": "^5.2.0"
+  },
+  "module": "dist/index.es.js"
+}

--- a/packages/virtual/package.json
+++ b/packages/virtual/package.json
@@ -1,33 +1,61 @@
 {
   "name": "rollup-plugin-virtual",
-  "version": "1.0.1",
-  "description": "Load modules from memory",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/rollup/rollup-plugin-virtual.git"
+  "version": "2.0.0",
+  "publishConfig": {
+    "access": "public"
   },
+  "description": "Load virtual modules from memory",
+  "license": "MIT",
+  "repository": "rollup/plugins",
   "author": "Rich Harris",
   "homepage": "https://github.com/rollup/rollup-plugin-virtual#readme",
-  "bugs": {
-    "url": "https://github.com/rollup/rollup-plugin-virtual/issues"
-  },
+  "bugs": "https://github.com/rollup/rollup-plugin-virtual/issues",
   "main": "dist/index.js",
   "scripts": {
     "build": "rollup -c",
-    "lint": "eslint src",
-    "pretest": "npm run build",
+    "ci:coverage": "nyc pnpm run test && nyc report --reporter=text-lcov > coverage.lcov",
+    "ci:lint": "pnpm run build && pnpm run lint && pnpm run security",
+    "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
+    "ci:test": "pnpm run test -- --verbose",
+    "lint": "pnpm run lint:js && pnpm run lint:docs && pnpm run lint:package",
+    "lint:docs": "prettier --single-quote --write README.md",
+    "lint:js": "eslint --fix --cache src test",
+    "lint:package": "prettier --write package.json --plugin=prettier-plugin-package",
+    "prebuild": "del-cli dist",
+    "prepare": "pnpm run build",
+    "prepublishOnly": "pnpm run lint",
+    "pretest": "pnpm run build",
+    "security": "echo 'pnpm needs `npm audit` support'",
     "test": "ava"
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md",
+    "LICENSE"
   ],
   "keywords": [
-    "rollup"
+    "rollup",
+    "plugin",
+    "memory",
+    "module",
+    "modules",
+    "virtual"
   ],
+  "peerDependencies": {
+    "rollup": "^1.20.0"
+  },
   "devDependencies": {
     "rollup": "^1.20.0",
     "rollup-plugin-node-resolve": "^5.2.0"
   },
+  "ava": {
+    "files": [
+      "!**/fixtures/**",
+      "!**/helpers/**",
+      "!**/recipes/**",
+      "!**/types.ts"
+    ]
+  },
+  "jsnext:main": "dist/index.es.js",
   "module": "dist/index.es.js"
 }

--- a/packages/virtual/rollup.config.js
+++ b/packages/virtual/rollup.config.js
@@ -1,0 +1,13 @@
+import resolve from 'rollup-plugin-node-resolve';
+
+import pkg from './package.json';
+
+export default {
+  input: 'src/index.js',
+  plugins: [resolve()],
+  external: ['path'],
+  output: [
+    { format: 'cjs', file: pkg.main },
+    { format: 'esm', file: pkg.module }
+  ]
+};

--- a/packages/virtual/src/index.js
+++ b/packages/virtual/src/index.js
@@ -1,0 +1,34 @@
+/* eslint-disable consistent-return */
+import path from 'path';
+
+const PREFIX = `\0virtual:`;
+
+export default function virtual(modules) {
+  const resolvedIds = new Map();
+
+  Object.keys(modules).forEach((id) => {
+    resolvedIds.set(path.resolve(id), modules[id]);
+  });
+
+  return {
+    name: 'virtual',
+
+    resolveId(id, importer) {
+      if (id in modules) return PREFIX + id;
+
+      if (importer) {
+        if (importer.startsWith(PREFIX)) importer = importer.slice(PREFIX.length);
+        const resolved = path.resolve(path.dirname(importer), id);
+        if (resolvedIds.has(resolved)) return PREFIX + resolved;
+      }
+    },
+
+    load(id) {
+      if (id.startsWith(PREFIX)) {
+        id = id.slice(PREFIX.length);
+
+        return id in modules ? modules[id] : resolvedIds.get(id);
+      }
+    }
+  };
+}

--- a/packages/virtual/src/index.js
+++ b/packages/virtual/src/index.js
@@ -17,6 +17,7 @@ export default function virtual(modules) {
       if (id in modules) return PREFIX + id;
 
       if (importer) {
+        // eslint-disable-next-line no-param-reassign
         if (importer.startsWith(PREFIX)) importer = importer.slice(PREFIX.length);
         const resolved = path.resolve(path.dirname(importer), id);
         if (resolvedIds.has(resolved)) return PREFIX + resolved;
@@ -25,6 +26,7 @@ export default function virtual(modules) {
 
     load(id) {
       if (id.startsWith(PREFIX)) {
+        // eslint-disable-next-line no-param-reassign
         id = id.slice(PREFIX.length);
 
         return id in modules ? modules[id] : resolvedIds.get(id);

--- a/packages/virtual/test/test.js
+++ b/packages/virtual/test/test.js
@@ -1,0 +1,27 @@
+const path = require('path');
+
+const test = require('ava');
+
+const virtual = require('..');
+
+test('loads a bare module ID from memory', (t) => {
+  const plugin = virtual({
+    foo: 'export default 42'
+  });
+
+  const resolved = plugin.resolveId('foo');
+
+  t.is(resolved, '\0virtual:foo');
+  t.is(plugin.load(resolved), 'export default 42');
+});
+
+test('loads an absolute path from memory', (t) => {
+  const plugin = virtual({
+    'src/foo.js': 'export default 42'
+  });
+
+  const resolved = plugin.resolveId('./foo.js', 'src/main.js');
+
+  t.is(resolved, `\0virtual:${path.resolve('src/foo.js')}`);
+  t.is(plugin.load(resolved), 'export default 42');
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ importers:
       pnpm: 4.3.0
       prettier: 1.19.1
       prettier-plugin-package: 0.3.1_prettier@1.19.1
-      rollup: 1.27.2
+      rollup: 1.27.3
       tslib: 1.10.0
       tslint: 5.20.1_typescript@3.7.2
       typescript: 3.7.2
@@ -179,6 +179,13 @@ importers:
       magic-string: ^0.25.1
       rollup: ^1.20.0
       rollup-pluginutils: ^2.8.1
+  packages/virtual:
+    devDependencies:
+      rollup: 1.27.3
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.3
+    specifiers:
+      rollup: ^1.20.0
+      rollup-plugin-node-resolve: ^5.2.0
   packages/wasm:
     devDependencies:
       del-cli: 3.0.0
@@ -1036,7 +1043,7 @@ packages:
     dependencies:
       '@types/events': 3.0.0
       '@types/minimatch': 3.0.3
-      '@types/node': 12.12.8
+      '@types/node': 12.12.11
     dev: true
     resolution:
       integrity: sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==
@@ -4708,6 +4715,19 @@ packages:
       rollup: '>=1.11.0'
     resolution:
       integrity: sha512-jUlyaDXts7TW2CqQ4GaO5VJ4PwwaV8VUGA7+km3n6k6xtOEacf61u0VXwN80phY/evMcaS+9eIeJ9MOyDxt5Zw==
+  /rollup-plugin-node-resolve/5.2.0_rollup@1.27.3:
+    dependencies:
+      '@types/resolve': 0.0.8
+      builtin-modules: 3.1.0
+      is-module: 1.0.0
+      resolve: 1.12.0
+      rollup: 1.27.3
+      rollup-pluginutils: 2.8.2
+    dev: true
+    peerDependencies:
+      rollup: '>=1.11.0'
+    resolution:
+      integrity: sha512-jUlyaDXts7TW2CqQ4GaO5VJ4PwwaV8VUGA7+km3n6k6xtOEacf61u0VXwN80phY/evMcaS+9eIeJ9MOyDxt5Zw==
   /rollup-pluginutils/1.5.2:
     dependencies:
       estree-walker: 0.2.1
@@ -4738,6 +4758,15 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-sD3iyd0zlvgK1S3MmICi6F/Y+R/QWY5XxzsTGN4pAd+nCasDUizmAhgq2hdh1t2eLux974NHU2TW41fhuGPv+Q==
+  /rollup/1.27.3:
+    dependencies:
+      '@types/estree': 0.0.39
+      '@types/node': 12.12.11
+      acorn: 7.1.0
+    dev: true
+    hasBin: true
+    resolution:
+      integrity: sha512-79AEh4m5NPCz97GTuIoXpSFIMPyk2AiqVQp040baSRPXk/I4YMGt5/CR9GX5oEYEkxwBZoWLheaS1/w/FidfJw==
   /run-async/2.3.0:
     dependencies:
       is-promise: 2.1.0


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->
## Rollup Plugin Name: `@rollup/plugin-virtual`

This PR contains:
- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [x] yes (*breaking changes will not be merged unless absolutely necessary*)
- [ ] no

- **Breaking:** Minimum compatible Rollup version is 1.2.0
- **Breaking:** Minimum supported Node version is 8.0.0

List any relevant issue numbers:

### Description

This PR merges rollup-plugin-virtual. Pretty basic. 