### PR TITLE
feat: export Rollup*Options interfaces

### DIFF
--- a/packages/buble/index.d.ts
+++ b/packages/buble/index.d.ts
@@ -24,7 +24,7 @@ interface TransformOptions {
   unicodeRegExp?: boolean;
 }
 
-interface RollupBubleOptions {
+export interface RollupBubleOptions {
   /**
    * A minimatch pattern, or array of patterns, of files that should be
    * processed by this plugin (if omitted, all files are included by default)

--- a/packages/buble/test/types.ts
+++ b/packages/buble/test/types.ts
@@ -1,5 +1,5 @@
 // @ts-check
-import buble from '..';
+import buble, { RollupBubleOptions } from '..';
 
 /** @type {import("rollup").RollupOptions} */
 const config = {

--- a/packages/inject/index.d.ts
+++ b/packages/inject/index.d.ts
@@ -2,7 +2,7 @@ import { Plugin } from "rollup";
 
 type Injectment = string | [string, string];
 
-interface RollupInjectOptions {
+export interface RollupInjectOptions {
   /**
    * A minimatch pattern, or array of patterns, of files that should be
    * processed by this plugin (if omitted, all files are included by default)

--- a/packages/inject/test/types.ts
+++ b/packages/inject/test/types.ts
@@ -1,7 +1,7 @@
 // @ts-check
 import { dirname } from "path";
 
-import inject from "..";
+import inject, { RollupInjectOptions } from "..";
 
 /** @type {import("rollup").RollupOptions} */
 const config = {

--- a/packages/json/index.d.ts
+++ b/packages/json/index.d.ts
@@ -1,6 +1,6 @@
 import { Plugin } from 'rollup';
 
-interface RollupJsonOptions {
+export interface RollupJsonOptions {
 	/**
 	 * All JSON files will be parsed by default,
 	 * but you can also specifically include files

--- a/packages/json/test/types.ts
+++ b/packages/json/test/types.ts
@@ -1,5 +1,5 @@
 // @ts-check
-import json from '..';
+import json, { RollupJsonOptions } from '..';
 
 /** @type {import("rollup").RollupOptions} */
 const config = {

--- a/packages/replace/index.d.ts
+++ b/packages/replace/index.d.ts
@@ -2,7 +2,7 @@ import { Plugin } from 'rollup';
 
 type Replacement = string | ((id: string) => string);
 
-interface RollupReplaceOptions {
+export interface RollupReplaceOptions {
 	/**
 	 * A minimatch pattern, or array of patterns, of files that should be
 	 * processed by this plugin (if omitted, all files are included by default)

--- a/packages/replace/test/types.ts
+++ b/packages/replace/test/types.ts
@@ -1,7 +1,7 @@
 // @ts-check
 import { dirname } from 'path';
 
-import replace from '..';
+import replace, { RollupReplaceOptions } from '..';
 
 /** @type {import("rollup").RollupOptions} */
 const config = {


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->
## Rollup Plugin Name: `buble`, `inject`, `json`, and `replace`

This PR contains:
- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

Sometimes we need to have access to `Rollup*Options` interfaces, for example when building a tool in Typescript which wrap Rollup and have a big options object. 

It's something that I've already done for some plugins on DefinitelyTyped repo:
- `rollup-plugin-buble` https://github.com/DefinitelyTyped/DefinitelyTyped/pull/32804
- `rollup-plugin-node-globals` https://github.com/DefinitelyTyped/DefinitelyTyped/pull/32524
- `rollup-plugin-node-resolve` https://github.com/DefinitelyTyped/DefinitelyTyped/pull/32525

The plugin `rollup-plugin-vue` also do the same: https://github.com/vuejs/rollup-plugin-vue/blob/master/src/index.ts#L47

Thanks!