### PR TITLE
feat(buble): use types from @types/buble

### DIFF
--- a/packages/buble/index.d.ts
+++ b/packages/buble/index.d.ts
@@ -1,30 +1,7 @@
 import { Plugin } from 'rollup';
+import { TransformOptions } from 'buble';
 
-interface TransformOptions {
-  arrow?: boolean;
-  classes?: boolean;
-  collections?: boolean;
-  computedProperty?: boolean;
-  conciseMethodProperty?: boolean;
-  constLoop?: boolean;
-  dangerousForOf?: boolean;
-  dangerousTaggedTemplateString?: boolean;
-  defaultParameter?: boolean;
-  destructuring?: boolean;
-  forOf?: boolean;
-  generator?: boolean;
-  letConst?: boolean;
-  modules?: boolean;
-  numericLiteral?: boolean;
-  parameterDestructuring?: boolean;
-  reservedProperties?: boolean;
-  spreadRest?: boolean;
-  stickyRegExp?: boolean;
-  templateString?: boolean;
-  unicodeRegExp?: boolean;
-}
-
-export interface RollupBubleOptions {
+export interface RollupBubleOptions extends TransformOptions {
   /**
    * A minimatch pattern, or array of patterns, of files that should be
    * processed by this plugin (if omitted, all files are included by default)
@@ -34,10 +11,6 @@ export interface RollupBubleOptions {
    * Files that should be excluded, if `include` is otherwise too permissive.
    */
   exclude?: string | RegExp | ReadonlyArray<string | RegExp> | null;
-  /**
-   * Buble TransformOptions
-   */
-  transforms?: TransformOptions;
 }
 
 /**

--- a/packages/buble/package.json
+++ b/packages/buble/package.json
@@ -47,11 +47,11 @@
     "rollup": "^1.20.0"
   },
   "dependencies": {
+    "@types/buble": "^0.19.2",
     "buble": "^0.19.8",
     "rollup-pluginutils": "^2.8.2"
   },
   "devDependencies": {
-    "@types/buble": "^0.19.2",
     "del-cli": "^3.0.0",
     "rollup": "^1.27.0",
     "source-map": "^0.7.3",

--- a/packages/buble/package.json
+++ b/packages/buble/package.json
@@ -48,13 +48,14 @@
   },
   "dependencies": {
     "buble": "^0.19.8",
-    "rollup-pluginutils": "^2.6.0"
+    "rollup-pluginutils": "^2.8.2"
   },
   "devDependencies": {
+    "@types/buble": "^0.19.2",
     "del-cli": "^3.0.0",
-    "rollup": "^1.20.0",
+    "rollup": "^1.27.0",
     "source-map": "^0.7.3",
-    "typescript": "^3.4.3"
+    "typescript": "^3.7.2"
   },
   "ava": {
     "files": [

--- a/packages/buble/test/types.ts
+++ b/packages/buble/test/types.ts
@@ -12,7 +12,8 @@ const config = {
     buble({
       exclude: 'node_modules/**',
       include: 'config.js',
-      transforms: { modules: true }
+      transforms: { modules: true },
+      objectAssign: true,
     })
   ]
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,17 +74,19 @@ importers:
       buble: 0.19.8
       rollup-pluginutils: 2.8.2
     devDependencies:
+      '@types/buble': 0.19.2
       del-cli: 3.0.0
       rollup: 1.27.0
       source-map: 0.7.3
       typescript: 3.7.2
     specifiers:
+      '@types/buble': ^0.19.2
       buble: ^0.19.8
       del-cli: ^3.0.0
-      rollup: ^1.20.0
-      rollup-pluginutils: ^2.6.0
+      rollup: ^1.27.0
+      rollup-pluginutils: ^2.8.2
       source-map: ^0.7.3
-      typescript: ^3.4.3
+      typescript: ^3.7.2
   packages/dsv:
     dependencies:
       d3-dsv: 0.1.14
@@ -1061,6 +1063,12 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==
+  /@types/buble/0.19.2:
+    dependencies:
+      magic-string: 0.25.4
+    dev: true
+    resolution:
+      integrity: sha512-uUD8zIfXMKThmFkahTXDGI3CthFH1kMg2dOm3KLi4GlC5cbARA64bEcUMbbWdWdE73eoc/iBB9PiTMqH0dNS2Q==
   /@types/color-name/1.1.1:
     dev: true
     resolution:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,10 +71,10 @@ importers:
       strip-ansi: ^5.2.0
   packages/buble:
     dependencies:
+      '@types/buble': 0.19.2
       buble: 0.19.8
       rollup-pluginutils: 2.8.2
     devDependencies:
-      '@types/buble': 0.19.2
       del-cli: 3.0.0
       rollup: 1.27.0
       source-map: 0.7.3
@@ -1066,7 +1066,7 @@ packages:
   /@types/buble/0.19.2:
     dependencies:
       magic-string: 0.25.4
-    dev: true
+    dev: false
     resolution:
       integrity: sha512-uUD8zIfXMKThmFkahTXDGI3CthFH1kMg2dOm3KLi4GlC5cbARA64bEcUMbbWdWdE73eoc/iBB9PiTMqH0dNS2Q==
   /@types/color-name/1.1.1:


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->
## Rollup Plugin Name: `buble`

This PR contains:
- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

Instead of manually defining types, we use the one from [buble](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/buble/index.d.ts).

Knowing that [the whole options are passed to buble](https://github.com/rollup/plugins/blob/master/packages/buble/src/index.js#L6), I've made `RollupBubleOptions` extends `TransformOptions` (maybe there is a best way to do this?). 
So now we can pass [`jsx`, `Object.assign`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/buble/index.d.ts#L25-L29) and [`namedFunctionExpressions`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/buble/index.d.ts#L57) options too. 

Note that the _old_ and _new_ `TransformOptions` are different. The new one include a `transforms` option which is the old `TransformOptions`.

By the way, I've ran `pnpm add @types/buble -D --filter ./packages/buble` but every dependencies ranges from buble package have been updated. Is this wanted? How can I prevent this without manually editing `package.json` and `pnpm-lock.yaml` files?

Thanks!