### PR TITLE
fix: Argument order in testBundle

### DIFF
--- a/util/test.js
+++ b/util/test.js
@@ -1,3 +1,7 @@
+/**
+ * Gets the code from a rollup bundle.
+ * @param {import('rollup').RollupBuild} bundle
+ */
 const getCode = async (bundle) => {
   const { output } = await bundle.generate({ format: 'cjs' });
   const [{ code }] = output;
@@ -5,6 +9,15 @@ const getCode = async (bundle) => {
   return code;
 };
 
+/**
+ * Runs a bundle for testing.
+ * A `result` variable is also inject that lets the script return some result.
+ * @param {import('ava').Assertions} t Ava assertions object.
+ * `t` is injected into the script so that test assertions can be used.
+ * @param {import('rollup').RollupBuild} bundle The rollup bundle to run.
+ * @param {object} args Additional arguments for the script.
+ * Each key is an argument name, and the value is the value passed to the function.
+ */
 const testBundle = async (t, bundle, args = {}) => {
   const { output } = await bundle.generate({ format: 'cjs' });
   const [{ code }] = output;
@@ -12,7 +25,7 @@ const testBundle = async (t, bundle, args = {}) => {
   // eslint-disable-next-line no-new-func
   const func = new Function(...params);
 
-  return { code, result: func(...[t, ...Object.values(args)]) };
+  return { code, result: func(...Object.values(args), t) };
 };
 
 module.exports = {


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

Fixes the order of the arguments passed into `func` inside `testBundle`. 

`t` is the last argument in `params`, so it should also be the last value passed into `func`.

Also added some JSDoc comments to add intellisense.
