### PR TITLE
docs(typescript): include jsx `preserve` instructions

### DIFF
--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -132,6 +132,32 @@ export default {
 
 Note that this will often result in less optimal output.
 
+### Preserving JSX output
+
+Whenever choosing to preserve JSX output to be further consumed by another transform step via `tsconfig` `compilerOptions` by setting `jsx: 'preserve'` or [overriding options](#options), please bear in mind that, by itself, this plugin won't be able to preserve JSX output, usually failing with:
+
+```sh
+[!] Error: Unexpected token (Note that you need plugins to import files that are not JavaScript)
+file.tsx (1:15)
+1: export default <span>Foobar</span>
+                  ^
+```
+
+To prevent that, make sure to use the acorn plugin, namely `acorn-jsx`, which will make Rollup's parser acorn handle JSX tokens. (See https://rollupjs.org/guide/en/#acorninjectplugins)
+
+After adding `acorn-jsx` plugin, your Rollup config would look like the following, correctly preserving your JSX output.
+
+```js
+import jsx from 'acorn-jsx';
+import typescript from 'rollup-plugin-typescript';
+
+export default {
+    // … other options …
+    acornInjectPlugins: [ jsx() ],
+    plugins: [ typescript({jsx: 'preserve'}) ]
+};
+```
+
 ## Issues
 
 This plugin will currently **not warn for any type violations**. This plugin relies on TypeScript's [transpileModule](https://github.com/Microsoft/TypeScript/wiki/Using-the-Compiler-API#a-simple-transform-function) function which basically transpiles TypeScript to JavaScript by stripping any type information on a per-file basis. While this is faster than using the language service, no cross-file type checks are possible with this approach.


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `typescript`

This PR contains:

- [x] documentation

Are tests included?

- [x] no

Breaking Changes?

- [x] no

List any relevant issue numbers: #72 

### Description
Adds instructions for preserving the `jsx: 'preserve'` option which will fail by default if the pluging `acorn-jsx` is not also used.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
