### PR TITLE
chore: remove placeholder security script from each plugin

### DIFF
--- a/packages/alias/package.json
+++ b/packages/alias/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "rollup -c",
     "ci:coverage": "nyc pnpm run test && nyc report --reporter=text-lcov > coverage.lcov",
-    "ci:lint": "pnpm run build && pnpm run lint && pnpm run security",
+    "ci:lint": "pnpm run build && pnpm run lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm run test -- --verbose",
     "lint": "pnpm run lint:js && pnpm run lint:docs && pnpm run lint:package",

--- a/packages/alias/package.json
+++ b/packages/alias/package.json
@@ -25,7 +25,6 @@
     "prepare": "pnpm run build",
     "prepublishOnly": "pnpm run lint && pnpm run test",
     "pretest": "pnpm run build",
-    "security": "echo 'pnpm needs `npm audit` support'",
     "test": "ava"
   },
   "files": [

--- a/packages/auto-install/package.json
+++ b/packages/auto-install/package.json
@@ -13,7 +13,7 @@
   "main": "lib/index.js",
   "scripts": {
     "ci:coverage": "nyc pnpm run test && nyc report --reporter=text-lcov > coverage.lcov",
-    "ci:lint": "pnpm run lint && pnpm run security",
+    "ci:lint": "pnpm run lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm run test -- --verbose",
     "lint": "pnpm run lint:js && pnpm run lint:docs && pnpm run lint:package",

--- a/packages/auto-install/package.json
+++ b/packages/auto-install/package.json
@@ -20,7 +20,6 @@
     "lint:docs": "prettier --single-quote --write README.md",
     "lint:js": "eslint --fix --cache lib test",
     "lint:package": "prettier --write package.json --plugin=prettier-plugin-package",
-    "security": "echo 'pnpm needs `npm audit` support'",
     "test": "ava"
   },
   "files": [

--- a/packages/beep/package.json
+++ b/packages/beep/package.json
@@ -23,7 +23,6 @@
     "lint:docs": "prettier --single-quote --write README.md",
     "lint:js": "eslint --fix --cache lib test",
     "lint:package": "prettier --write package.json --plugin=prettier-plugin-package",
-    "security": "echo 'pnpm needs `npm audit` support'",
     "test": "ava"
   },
   "files": [

--- a/packages/beep/package.json
+++ b/packages/beep/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "ci:coverage": "nyc pnpm run test && nyc report --reporter=text-lcov > coverage.lcov",
-    "ci:lint": "pnpm run lint && pnpm run security",
+    "ci:lint": "pnpm run lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "ava --verbose",
     "lint": "pnpm run lint:js && pnpm run lint:docs && pnpm run lint:package",

--- a/packages/buble/package.json
+++ b/packages/buble/package.json
@@ -25,7 +25,6 @@
     "prepare": "pnpm run build",
     "prepublishOnly": "pnpm run lint && pnpm run test && pnpm run test:ts",
     "pretest": "pnpm run build",
-    "security": "echo 'pnpm needs `npm audit` support'",
     "test": "ava",
     "test:ts": "tsc index.d.ts test/types.ts --noEmit"
   },

--- a/packages/buble/package.json
+++ b/packages/buble/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "rollup -c",
     "ci:coverage": "nyc pnpm run test && nyc report --reporter=text-lcov > coverage.lcov",
-    "ci:lint": "pnpm run build && pnpm run lint && pnpm run security",
+    "ci:lint": "pnpm run build && pnpm run lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm run test -- --verbose && pnpm run test:ts",
     "lint": "pnpm run lint:js && pnpm run lint:docs && pnpm run lint:package",

--- a/packages/dsv/package.json
+++ b/packages/dsv/package.json
@@ -25,7 +25,6 @@
     "prepare": "pnpm run build",
     "prepublishOnly": "pnpm run lint",
     "pretest": "pnpm run build",
-    "security": "echo 'pnpm needs `npm audit` support'",
     "test": "ava"
   },
   "files": [

--- a/packages/dsv/package.json
+++ b/packages/dsv/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "rollup -c",
     "ci:coverage": "nyc pnpm run test && nyc report --reporter=text-lcov > coverage.lcov",
-    "ci:lint": "pnpm run build && pnpm run lint && pnpm run security",
+    "ci:lint": "pnpm run build && pnpm run lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm run test -- --verbose",
     "lint": "pnpm run lint:js && pnpm run lint:docs && pnpm run lint:package",

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "ci:coverage": "nyc pnpm run test && nyc report --reporter=text-lcov > coverage.lcov",
-    "ci:lint": "pnpm run lint && pnpm run security",
+    "ci:lint": "pnpm run lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm run test -- --verbose",
     "lint": "pnpm run lint:js && pnpm run lint:docs && pnpm run lint:package",

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -24,7 +24,6 @@
     "lint:js": "eslint --fix --cache lib test",
     "lint:package": "prettier --write package.json --plugin=prettier-plugin-package",
     "prepublishOnly": "pnpm run lint",
-    "security": "echo 'pnpm needs `npm audit` support'",
     "test": "ava"
   },
   "files": [

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "rollup -c",
     "ci:coverage": "nyc pnpm run test && nyc report --reporter=text-lcov > coverage.lcov",
-    "ci:lint": "pnpm run build && pnpm run lint && pnpm run security",
+    "ci:lint": "pnpm run build && pnpm run lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm run test -- --verbose",
     "lint": "pnpm run lint:js && pnpm run lint:docs && pnpm run lint:package",

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -28,7 +28,6 @@
     "prepare": "pnpm run build",
     "prepublishOnly": "pnpm run lint",
     "pretest": "pnpm run build",
-    "security": "echo 'pnpm needs `npm audit` support'",
     "test": "ava"
   },
   "files": [

--- a/packages/inject/package.json
+++ b/packages/inject/package.json
@@ -25,7 +25,6 @@
     "prepare": "pnpm run build",
     "prepublishOnly": "pnpm run lint && pnpm run test",
     "pretest": "pnpm run build",
-    "security": "echo 'pnpm needs `npm audit` support'",
     "test": "ava",
     "test:ts": "tsc index.d.ts test/types.ts --noEmit"
   },

--- a/packages/inject/package.json
+++ b/packages/inject/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "rollup -c",
     "ci:coverage": "nyc pnpm run test && nyc report --reporter=text-lcov > coverage.lcov",
-    "ci:lint": "pnpm run build && pnpm run lint && pnpm run security",
+    "ci:lint": "pnpm run build && pnpm run lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm run test -- --verbose && pnpm run test:ts",
     "lint": "pnpm run lint:js && pnpm run lint:docs && pnpm run lint:package",

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -22,7 +22,6 @@
     "prepare": "pnpm run build",
     "prepublishOnly": "pnpm run lint && pnpm run test",
     "pretest": "pnpm run build",
-    "security": "echo 'pnpm needs `npm audit` support'",
     "test": "ava",
     "test:ts": "tsc index.d.ts test/types.ts --noEmit"
   },

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "rollup -c",
     "ci:coverage": "nyc pnpm run test && nyc report --reporter=text-lcov > coverage.lcov",
-    "ci:lint": "pnpm run build && pnpm run lint && pnpm run security",
+    "ci:lint": "pnpm run build && pnpm run lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm run test -- --verbose && pnpm run test:ts",
     "lint": "pnpm run lint:js && pnpm run lint:docs && pnpm run lint:package",

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -25,7 +25,6 @@
     "prepare": "pnpm run build",
     "prepublishOnly": "pnpm run lint",
     "pretest": "pnpm run build",
-    "security": "echo 'pnpm needs `npm audit` support'",
     "test": "ava"
   },
   "files": [

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "rollup -c",
     "ci:coverage": "nyc pnpm run test && nyc report --reporter=text-lcov > coverage.lcov",
-    "ci:lint": "pnpm run build && pnpm run lint && pnpm run security",
+    "ci:lint": "pnpm run build && pnpm run lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm run test -- --verbose",
     "lint": "pnpm run lint:js && pnpm run lint:docs && pnpm run lint:package",

--- a/packages/node-resolve/package.json
+++ b/packages/node-resolve/package.json
@@ -28,7 +28,6 @@
     "prepare": "pnpm run build",
     "prepublishOnly": "pnpm run lint && pnpm run test && pnpm run test:ts",
     "pretest": "pnpm run build",
-    "security": "echo 'pnpm needs `npm audit` support'",
     "test": "ava",
     "test:ts": "tsc types/index.d.ts test/types.ts --noEmit"
   },

--- a/packages/node-resolve/package.json
+++ b/packages/node-resolve/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "rollup -c",
     "ci:coverage": "nyc pnpm run test && nyc report --reporter=text-lcov > coverage.lcov",
-    "ci:lint": "pnpm run build && pnpm run lint && pnpm run security",
+    "ci:lint": "pnpm run build && pnpm run lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm run test -- --verbose && pnpm run test:ts",
     "lint": "pnpm run lint:js && pnpm run lint:docs && pnpm run lint:package",

--- a/packages/pluginutils/package.json
+++ b/packages/pluginutils/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "rollup -c",
     "ci:coverage": "nyc pnpm run test && nyc report --reporter=text-lcov > coverage.lcov",
-    "ci:lint": "pnpm run build && pnpm run lint && pnpm run security",
+    "ci:lint": "pnpm run build && pnpm run lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm run test -- --verbose",
     "lint": "pnpm run lint:js && pnpm run lint:docs && pnpm run lint:package",

--- a/packages/pluginutils/package.json
+++ b/packages/pluginutils/package.json
@@ -30,7 +30,6 @@
     "prepare": "pnpm run build",
     "prepublishOnly": "pnpm run lint && pnpm run build",
     "pretest": "pnpm run build -- --sourcemap",
-    "security": "echo 'pnpm needs `npm audit` support'",
     "test": "ava test/*.ts"
   },
   "files": [

--- a/packages/replace/package.json
+++ b/packages/replace/package.json
@@ -25,7 +25,6 @@
     "prepare": "pnpm run build",
     "prepublishOnly": "pnpm run lint && pnpm run test",
     "pretest": "pnpm run build",
-    "security": "echo 'pnpm needs `npm audit` support'",
     "test": "ava",
     "test:ts": "tsc index.d.ts test/types.ts --noEmit"
   },

--- a/packages/replace/package.json
+++ b/packages/replace/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "rollup -c",
     "ci:coverage": "nyc pnpm run test && nyc report --reporter=text-lcov > coverage.lcov",
-    "ci:lint": "pnpm run build && pnpm run lint && pnpm run security",
+    "ci:lint": "pnpm run build && pnpm run lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm run test -- --verbose && pnpm run test:ts",
     "lint": "pnpm run lint:js && pnpm run lint:docs && pnpm run lint:package",

--- a/packages/run/package.json
+++ b/packages/run/package.json
@@ -13,7 +13,7 @@
   "main": "lib/index.js",
   "scripts": {
     "ci:coverage": "nyc pnpm run test && nyc report --reporter=text-lcov > coverage.lcov",
-    "ci:lint": "pnpm run lint && pnpm run security",
+    "ci:lint": "pnpm run lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm run test -- --verbose",
     "lint": "pnpm run lint:js && pnpm run lint:docs && pnpm run lint:package",

--- a/packages/run/package.json
+++ b/packages/run/package.json
@@ -21,7 +21,6 @@
     "lint:js": "eslint --fix --cache lib test",
     "lint:package": "prettier --write package.json --plugin=prettier-plugin-package",
     "prepublishOnly": "pnpm run lint && pnpm run test",
-    "security": "echo 'pnpm needs `npm audit` support'",
     "test": "ava"
   },
   "files": [

--- a/packages/strip/package.json
+++ b/packages/strip/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "rollup -c",
     "ci:coverage": "nyc pnpm run test && nyc report --reporter=text-lcov > coverage.lcov",
-    "ci:lint": "pnpm run lint && pnpm run security",
+    "ci:lint": "pnpm run lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm run test -- --verbose",
     "lint": "pnpm run lint:js && pnpm run lint:docs && pnpm run lint:package",

--- a/packages/strip/package.json
+++ b/packages/strip/package.json
@@ -22,7 +22,6 @@
     "lint:js": "eslint --fix --cache src test/test.js",
     "lint:package": "prettier --write package.json --plugin=prettier-plugin-package",
     "pretest": "pnpm run build",
-    "security": "echo 'pnpm needs `npm audit` support'",
     "test": "ava"
   },
   "files": [

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -152,9 +152,9 @@ import jsx from 'acorn-jsx';
 import typescript from 'rollup-plugin-typescript';
 
 export default {
-    // … other options …
-    acornInjectPlugins: [ jsx() ],
-    plugins: [ typescript({jsx: 'preserve'}) ]
+  // … other options …
+  acornInjectPlugins: [jsx()],
+  plugins: [typescript({ jsx: 'preserve' })]
 };
 ```
 

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "rollup -c",
     "ci:coverage": "nyc pnpm run test && nyc report --reporter=text-lcov > coverage.lcov",
-    "ci:lint": "pnpm run build && pnpm run lint && pnpm run security",
+    "ci:lint": "pnpm run build && pnpm run lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm run test -- --verbose",
     "lint": "pnpm run lint:js && pnpm run lint:docs && pnpm run lint:package",

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -28,7 +28,6 @@
     "prepare": "pnpm run build",
     "prepublishOnly": "pnpm run lint",
     "pretest": "pnpm run build",
-    "security": "echo 'pnpm needs `npm audit` support'",
     "test": "ava"
   },
   "files": [

--- a/packages/typescript/src/index.js
+++ b/packages/typescript/src/index.js
@@ -32,9 +32,7 @@ export default function typescript(options = {}) {
 
   // Load options from `tsconfig.json` unless explicitly asked not to.
   const tsConfig =
-    opts.tsconfig === false
-      ? { compilerOptions: {} }
-      : readTsConfig(tsRuntime, opts.tsconfig);
+    opts.tsconfig === false ? { compilerOptions: {} } : readTsConfig(tsRuntime, opts.tsconfig);
 
   delete opts.tsconfig;
 
@@ -138,10 +136,7 @@ export default function typescript(options = {}) {
       let fatalError = false;
 
       diagnostics.forEach((diagnostic) => {
-        const message = tsRuntime.flattenDiagnosticMessageText(
-          diagnostic.messageText,
-          '\n'
-        );
+        const message = tsRuntime.flattenDiagnosticMessageText(diagnostic.messageText, '\n');
 
         if (diagnostic.file) {
           const { line, character } = diagnostic.file.getLineAndCharacterOfPosition(

--- a/packages/url/package.json
+++ b/packages/url/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "rollup -c",
     "ci:coverage": "nyc pnpm run test && nyc report --reporter=text-lcov > coverage.lcov",
-    "ci:lint": "pnpm run build && pnpm run lint && pnpm run security",
+    "ci:lint": "pnpm run build && pnpm run lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm run test -- --verbose",
     "lint": "pnpm run lint:js && pnpm run lint:docs && pnpm run lint:package",

--- a/packages/url/package.json
+++ b/packages/url/package.json
@@ -28,7 +28,6 @@
     "prepare": "pnpm run build",
     "prepublishOnly": "pnpm run lint",
     "pretest": "pnpm run build",
-    "security": "echo 'pnpm needs `npm audit` support'",
     "test": "ava"
   },
   "files": [

--- a/packages/virtual/package.json
+++ b/packages/virtual/package.json
@@ -25,7 +25,6 @@
     "prepare": "pnpm run build",
     "prepublishOnly": "pnpm run lint",
     "pretest": "pnpm run build",
-    "security": "echo 'pnpm needs `npm audit` support'",
     "test": "ava"
   },
   "files": [

--- a/packages/virtual/package.json
+++ b/packages/virtual/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "rollup -c",
     "ci:coverage": "nyc pnpm run test && nyc report --reporter=text-lcov > coverage.lcov",
-    "ci:lint": "pnpm run build && pnpm run lint && pnpm run security",
+    "ci:lint": "pnpm run build && pnpm run lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm run test -- --verbose",
     "lint": "pnpm run lint:js && pnpm run lint:docs && pnpm run lint:package",

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -25,7 +25,6 @@
     "prepare": "pnpm run build",
     "prepublishOnly": "pnpm run lint",
     "pretest": "pnpm run build",
-    "security": "echo 'pnpm needs `npm audit` support'",
     "test": "ava"
   },
   "files": [

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "rollup -c",
     "ci:coverage": "nyc pnpm run test && nyc report --reporter=text-lcov > coverage.lcov",
-    "ci:lint": "pnpm run build && pnpm run lint && pnpm run security",
+    "ci:lint": "pnpm run build && pnpm run lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm run test -- --verbose",
     "lint": "pnpm run lint:js && pnpm run lint:docs && pnpm run lint:package",

--- a/packages/yaml/package.json
+++ b/packages/yaml/package.json
@@ -25,7 +25,6 @@
     "prepare": "pnpm run build",
     "prepublishOnly": "pnpm run lint",
     "pretest": "pnpm run build",
-    "security": "echo 'pnpm needs `npm audit` support'",
     "test": "ava"
   },
   "files": [

--- a/packages/yaml/package.json
+++ b/packages/yaml/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "rollup -c",
     "ci:coverage": "nyc pnpm run test && nyc report --reporter=text-lcov > coverage.lcov",
-    "ci:lint": "pnpm run build && pnpm run lint && pnpm run security",
+    "ci:lint": "pnpm run build && pnpm run lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm run test -- --verbose",
     "lint": "pnpm run lint:js && pnpm run lint:docs && pnpm run lint:package",


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `all`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

Resolves #75 

### Description

- Removes the placeholder `security` script from each plugin's `package.json`
- I verified that `pnpm audit` only uses `pnpm-lock.yaml` to run the audit.
  - I installed `lodash@4.17.11` (contains a vulnerability) in the `run` package and `pnpm audit` reported the vulnerability when ran from the repo's root.
  - Only adding the vulnerable dependency to `packages/run/package.json` had no effect on `pnpm audit`
  - Only adding the vulnerable dependency to `pnpm-lock.yaml` caused the vulnerability to show up during `pnpm audit`
- _Unrelated change: the typescript package had two un-linted files, I've included them here_
