### PR TITLE
fix(pluginutils): Escape glob characters in folder

### DIFF
--- a/packages/pluginutils/src/createFilter.ts
+++ b/packages/pluginutils/src/createFilter.ts
@@ -1,4 +1,4 @@
-import { resolve, sep } from 'path';
+import { resolve, join, sep } from 'path';
 
 import mm from 'micromatch';
 
@@ -6,11 +6,17 @@ import { CreateFilter } from '../types';
 
 import ensureArray from './utils/ensureArray';
 
+const ESCAPE_IN_PATH = '()+@!'
+
 function getMatcherString(id: string, resolutionBase: string | false | null | undefined) {
   if (resolutionBase === false) {
     return id;
   }
-  return resolve(...(typeof resolutionBase === 'string' ? [resolutionBase, id] : [id]));
+  let basePath = typeof resolutionBase === 'string' ? resolve(resolutionBase) : process.cwd();
+  for (const char of ESCAPE_IN_PATH) {
+    basePath = basePath.replace(new RegExp(`\\${char}`, 'g'), `\\${char}`);
+  }
+  return join(basePath, id);
 }
 
 const createFilter: CreateFilter = function createFilter(include?, exclude?, options?) {

--- a/packages/pluginutils/test/createFilter.ts
+++ b/packages/pluginutils/test/createFilter.ts
@@ -4,6 +4,8 @@ import test from 'ava';
 
 import { createFilter } from '../';
 
+test.beforeEach(() => process.chdir(__dirname));
+
 test('includes by default', (t) => {
   const filter = createFilter();
   t.truthy(filter(resolve('x')));
@@ -106,4 +108,12 @@ test('includes names starting with a "."', (t) => {
   const filter = createFilter(['**/*a']);
   t.truthy(filter(resolve('.a')));
   t.truthy(filter(resolve('.x/a')));
+});
+
+test.serial('includes names containing parenthesis', (t) => {
+  process.chdir(resolve(__dirname, 'fixtures/folder-with (parens)'));
+  const filter = createFilter(['*.ts+(|x)', '**/*.ts+(|x)'], ['*.d.ts', '**/*.d.ts']);
+  t.truthy(filter(resolve('folder (test)/src/main.tsx')));
+  t.truthy(filter(resolve('.x/(test)a.ts')));
+  t.falsy(filter(resolve('.x/(test)a.d.ts')));
 });


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `pluginutils`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
Fixes #80

Escapes some special characters for globs that can appear in paths.