### PR TITLE
chore: remove `jsnext:main` in favor of `module`

### DIFF
--- a/packages/alias/package.json
+++ b/packages/alias/package.json
@@ -57,6 +57,5 @@
       "!**/types.ts"
     ]
   },
-  "jsnext:main": "dist/index.es2015.js",
   "module": "dist/index.es2015.js"
 }

--- a/packages/dsv/package.json
+++ b/packages/dsv/package.json
@@ -49,6 +49,5 @@
       "!**/types.ts"
     ]
   },
-  "jsnext:main": "dist/index.es.js",
   "module": "dist/index.es.js"
 }

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -59,6 +59,5 @@
       "!**/types.ts"
     ]
   },
-  "jsnext:main": "dist/index.es.js",
   "module": "dist/index.es.js"
 }

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -58,6 +58,5 @@
       "!**/types.ts"
     ]
   },
-  "jsnext:main": "dist/rollup-plugin-json.es.js",
   "module": "dist/index.es.js"
 }

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -52,6 +52,5 @@
       "!**/types.ts"
     ]
   },
-  "jsnext:main": "dist/index.es.js",
   "module": "dist/index.es.js"
 }

--- a/packages/node-resolve/package.json
+++ b/packages/node-resolve/package.json
@@ -73,7 +73,6 @@
       "!**/types.ts"
     ]
   },
-  "jsnext:main": "dist/index.es.js",
   "module": "dist/index.es.js",
   "types": "types/index.d.ts"
 }

--- a/packages/pluginutils/package.json
+++ b/packages/pluginutils/package.json
@@ -75,7 +75,6 @@
       "!**/types.ts"
     ]
   },
-  "jsnext:main": "dist/index.es.js",
   "module": "dist/index.es.js",
   "nyc": {
     "extension": [

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -68,6 +68,5 @@
       "!**/types.ts"
     ]
   },
-  "jsnext:main": "dist/index.es.js",
   "module": "dist/index.es.js"
 }

--- a/packages/url/package.json
+++ b/packages/url/package.json
@@ -66,6 +66,5 @@
       "!**/types.ts"
     ]
   },
-  "jsnext:main": "src/index.js",
   "module": "dist/index.es.js"
 }

--- a/packages/virtual/package.json
+++ b/packages/virtual/package.json
@@ -55,6 +55,5 @@
       "!**/types.ts"
     ]
   },
-  "jsnext:main": "dist/index.es.js",
   "module": "dist/index.es.js"
 }

--- a/packages/yaml/package.json
+++ b/packages/yaml/package.json
@@ -62,6 +62,5 @@
       "!**/types.ts"
     ]
   },
-  "jsnext:main": "dist/index.es.js",
   "module": "dist/index.es.js"
 }


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `alias`, `dsv`, `image`, `json`, `legacy`, `node-resolve`, `pluginutils`, `typescript`, `url`, `virtual`, `yaml`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [x] yes (_breaking changes will not be merged unless absolutely necessary_)
- [ ] no

List any relevant issue numbers:

this closes https://github.com/rollup/plugins/pull/81

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

This PR has two targets:
1. fixes `@rollup/plugin-json` as it's current `jsnext:main` field is pointing to a wrong path, which makes rollup failed to import the plugin
2. remove all `jsnext:main` in favor of `module` as mentioned in https://github.com/rollup/plugins/pull/81#issuecomment-562956077