### PR TITLE
chore: migrate rollup-plugin-multi-entry

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,6 @@ trim_trailing_whitespace = true
 [*.md]
 insert_final_newline = true
 trim_trailing_whitespace = false
-max_line_length = 500
 
 [*.yml]
 max_line_length = 500

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ This repository houses plugins that Rollup considers critical to every day use o
 | [image](packages/image)               | Import JPG, PNG, GIF, SVG, and WebP files                                                 |
 | [inject](packages/inject)             | Scan modules for global variables and injects `import` statements where necessary         |
 | [json](packages/json)                 | Convert .json files to ES6 modules                                                        |
-| [legacy](packages/legacy)             | Add `export` declarations to legacy non-module scripts.                                   |
+| [legacy](packages/legacy)             | Add `export` declarations to legacy non-module scripts                                    |
+| [multi-entry](packages/multi-entry)   | Use multiple entry points for a bundle                                                    |
 | [node-resolve](packages/node-resolve) | Locate and bundle third-party dependencies in node_modules                                |
 | [replace](packages/replace)           | Replace strings in files while bundling                                                   |
 | [strip](packages/strip)               | Remove debugger statements and functions like assert.equal and console.log from your code |

--- a/packages/multi-entry/README.md
+++ b/packages/multi-entry/README.md
@@ -1,0 +1,125 @@
+[npm]: https://img.shields.io/npm/v/@rollup/plugin-multi-entry
+[npm-url]: https://www.npmjs.com/package/@rollup/plugin-multi-entry
+[size]: https://packagephobia.now.sh/badge?p=@rollup/plugin-multi-entry
+[size-url]: https://packagephobia.now.sh/result?p=@rollup/plugin-multi-entry
+
+[![npm][npm]][npm-url]
+[![size][size]][size-url]
+[![libera manifesto](https://img.shields.io/badge/libera-manifesto-lightgrey.svg)](https://liberamanifesto.com)
+
+# @rollup/plugin-multi-entry
+
+🍣 A Rollup plugin which allows use of multiple entry points for a bundle.
+
+As an added bonus, the _named exports_ from all entry points will be combined. This is particularly useful for tests, but can also be used to package a library.
+
+_Note: `default` exports cannot be combined and exported by this plugin. Only named exports will be exported._
+
+## Requirements
+
+This plugin requires an [LTS](https://github.com/nodejs/Release) Node version (v8.0.0+) and Rollup v1.20.0+.
+
+## Install
+
+Using npm:
+
+```console
+npm install @rollup/plugin-multi-entry --save-dev
+```
+
+## Usage
+
+Suppose that we have three separate source files, each with their own export(s):
+
+```js
+// batman.js
+export const belt = 'utility';
+```
+
+```js
+// robin.js
+export const tights = 'tight';
+```
+
+```js
+// joker.js
+export const color = 'purple';
+```
+
+Then, create a `rollup.config.js` [configuration file](https://www.rollupjs.org/guide/en/#configuration-files) and import the plugin:
+
+```js
+import multi from '@rollup/plugin-multi-entry';
+
+export default {
+  input: ['batman.js', 'robin.js', 'joker.js'],
+  output: {
+    dir: 'output'
+  },
+  plugins: [multi()]
+};
+```
+
+Then call `rollup` either via the [CLI](https://www.rollupjs.org/guide/en/#command-line-reference) or the [API](https://www.rollupjs.org/guide/en/#javascript-api).
+
+Using all three files above as entry points will yield a bundle with exports for `belt`, `tights`, and `color`.
+
+## Options
+
+### `exports`
+
+Type: `Boolean`<br>
+Default: `true`
+
+If `true`, instructs the plugin to export named exports to the bundle from all entries. If `false`, the plugin will not export any entry exports to the bundle. This can be useful when wanting to combine code from multiple entry files, but not necessarily to export each entry file's exports.
+
+## Supported Input Types
+
+This plugin extends Rollup's `input` option to support multiple new value types, in addition to a `String` specifying a path to a file.
+
+### Glob
+
+When using `plugin-multi-entry`, input values passed as a normal `String` are [glob aware](<https://en.wikipedia.org/wiki/Glob_(programming)>). Meaning you can utilize glob wildcards and other glob patterns to specify files as being input files.
+
+```js
+export default {
+  input: 'batcave/friends/**/*.js',
+  plugins: [multiEntry()]
+  // ...
+};
+```
+
+### Array
+
+An `Array` of `String` can be passed as the input. Values are glob-aware and can specify paths or globbed paths.
+
+```js
+export default {
+  input: ['party/supplies.js', 'batcave/friends/**/*.js'],
+  plugins: [multiEntry()]
+  // ...
+};
+```
+
+### `include` and `exclude`
+
+For fine-grain control, an `Object` may be passed containing `include` and `exclude` properties. These properties specify and `Array` of `String` representing paths (which are also glob-aware) which should be included as entry files, as well as files that should be excluded from any entries that may have been found with `include`, respectively.
+
+```js
+export default {
+  input: {
+    // invite everyone!
+    include: ['food.js', 'drinks.js', 'batcave/friends/**/*.js'],
+    // except for the joker
+    exclude: ['**/joker.js']
+  },
+  plugins: [multiEntry()]
+  // ...
+};
+```
+
+## Meta
+
+[CONTRIBUTING](/.github/CONTRIBUTING.md)
+
+[LICENSE (MIT)](/LICENSE)

--- a/packages/multi-entry/README.md
+++ b/packages/multi-entry/README.md
@@ -84,7 +84,7 @@ When using `plugin-multi-entry`, input values passed as a normal `String` are [g
 ```js
 export default {
   input: 'batcave/friends/**/*.js',
-  plugins: [multiEntry()]
+  plugins: [multi()]
   // ...
 };
 ```
@@ -96,7 +96,7 @@ An `Array` of `String` can be passed as the input. Values are glob-aware and can
 ```js
 export default {
   input: ['party/supplies.js', 'batcave/friends/**/*.js'],
-  plugins: [multiEntry()]
+  plugins: [multi()]
   // ...
 };
 ```
@@ -113,7 +113,7 @@ export default {
     // except for the joker
     exclude: ['**/joker.js']
   },
-  plugins: [multiEntry()]
+  plugins: [multi()]
   // ...
 };
 ```

--- a/packages/multi-entry/package.json
+++ b/packages/multi-entry/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@rollup/plugin-multi-entry",
+  "version": "3.0.0",
+  "publishConfig": {
+    "access": "public"
+  },
+  "description": "Use multiple entry points for a bundle",
+  "license": "MIT",
+  "repository": "rollup/plugins",
+  "author": "rollup",
+  "homepage": "https://github.com/rollup/plugins/packages/multi-entry/#readme",
+  "bugs": "https://github.com/rollup/plugins/issues",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "rollup -c",
+    "ci:coverage": "nyc pnpm run test && nyc report --reporter=text-lcov > coverage.lcov",
+    "ci:lint": "pnpm run build && pnpm run lint",
+    "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
+    "ci:test": "pnpm run test -- --verbose",
+    "lint": "pnpm run lint:js && pnpm run lint:docs && pnpm run lint:package",
+    "lint:docs": "prettier --single-quote --write README.md",
+    "lint:js": "eslint --fix --cache src test",
+    "lint:package": "prettier --write package.json --plugin=prettier-plugin-package",
+    "prebuild": "del-cli dist",
+    "prepare": "pnpm run build",
+    "prepublishOnly": "pnpm run lint",
+    "pretest": "pnpm run build",
+    "test": "ava"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "keywords": [
+    "rollup",
+    "plugin",
+    "multi",
+    "multiple",
+    "entry",
+    "entries"
+  ],
+  "peerDependencies": {
+    "rollup": "^1.20.0"
+  },
+  "dependencies": {
+    "matched": "^1.0.2"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.2.0",
+    "@babel/preset-env": "^7.2.0",
+    "rollup": "^1.20.1",
+    "rollup-plugin-babel": "^4.0.3"
+  },
+  "ava": {
+    "files": [
+      "!**/fixtures/**",
+      "!**/helpers/**",
+      "!**/recipes/**",
+      "!**/types.ts"
+    ]
+  },
+  "module": "dist/index.es.js"
+}

--- a/packages/multi-entry/rollup.config.js
+++ b/packages/multi-entry/rollup.config.js
@@ -1,0 +1,18 @@
+import babel from 'rollup-plugin-babel';
+
+const pkg = require('./package.json');
+
+export default {
+  input: 'src/index.js',
+  plugins: [
+    babel({
+      presets: [['@babel/env', { targets: { node: '8' }, modules: false }]],
+      babelrc: false
+    })
+  ],
+  external: Object.keys(pkg.dependencies),
+  output: [
+    { format: 'cjs', file: pkg.main },
+    { format: 'es', file: pkg.module }
+  ]
+};

--- a/packages/multi-entry/src/index.js
+++ b/packages/multi-entry/src/index.js
@@ -1,0 +1,56 @@
+/* eslint-disable consistent-return, no-param-reassign */
+
+import { promise as matched } from 'matched';
+
+const entry = '\0rollup:plugin-multi-entry:entry-point';
+
+export default function multiEntry(conf) {
+  let include = [];
+  let exclude = [];
+  let exporter = (path) => `export * from ${JSON.stringify(path)};`;
+
+  function configure(config) {
+    if (typeof config === 'string') {
+      include = [config];
+    } else if (Array.isArray(config)) {
+      include = config;
+    } else {
+      include = config.include || [];
+      exclude = config.exclude || [];
+      if (config.exports === false) {
+        exporter = (path) => `import ${JSON.stringify(path)};`;
+      }
+    }
+  }
+
+  if (conf) {
+    configure(conf);
+  }
+
+  return {
+    options(options) {
+      if (options.input && options.input !== entry) {
+        configure(options.input);
+      }
+      options.input = entry;
+    },
+
+    resolveId(id) {
+      if (id === entry) {
+        return entry;
+      }
+    },
+
+    load(id) {
+      if (id === entry) {
+        if (!include.length) {
+          return Promise.resolve('');
+        }
+        const patterns = include.concat(exclude.map((pattern) => `!${pattern}`));
+        return matched(patterns, { realpath: true }).then((paths) =>
+          paths.map(exporter).join('\n')
+        );
+      }
+    }
+  };
+}

--- a/packages/multi-entry/test/fixtures/.eslintrc
+++ b/packages/multi-entry/test/fixtures/.eslintrc
@@ -1,0 +1,6 @@
+{
+  "rules": {
+    "import/prefer-default-export": "off",
+    "no-console": "off"
+  }
+}

--- a/packages/multi-entry/test/fixtures/0.js
+++ b/packages/multi-entry/test/fixtures/0.js
@@ -1,0 +1,1 @@
+export const zero = 0;

--- a/packages/multi-entry/test/fixtures/1.js
+++ b/packages/multi-entry/test/fixtures/1.js
@@ -1,0 +1,1 @@
+export const one = 1;

--- a/packages/multi-entry/test/fixtures/2.js
+++ b/packages/multi-entry/test/fixtures/2.js
@@ -1,0 +1,1 @@
+console.log('Hello, 2');

--- a/packages/multi-entry/test/test.js
+++ b/packages/multi-entry/test/test.js
@@ -1,0 +1,74 @@
+/* eslint-disable no-bitwise */
+
+import test from 'ava';
+import { rollup } from 'rollup';
+
+import { getCode } from '../../../util/test';
+
+import multiEntry from '../';
+
+test('takes a single file as input', async (t) => {
+  const bundle = await rollup({ input: 'test/fixtures/0.js', plugins: [multiEntry()] });
+  const code = await getCode(bundle);
+  t.truthy(~code.indexOf('exports.zero = zero;'));
+});
+
+test('takes an array of files as input', async (t) => {
+  const bundle = await rollup({
+    input: ['test/fixtures/0.js', 'test/fixtures/1.js'],
+    plugins: [multiEntry()]
+  });
+  const code = await getCode(bundle);
+  t.truthy(~code.indexOf('exports.zero = zero;'));
+  t.truthy(~code.indexOf('exports.one = one;'));
+});
+
+test('allows an empty array as input', async (t) => {
+  const bundle = await rollup({ input: [], plugins: [multiEntry()] });
+  const code = await getCode(bundle);
+  t.falsy(~code.indexOf('exports'));
+});
+
+test('takes a glob as input', async (t) => {
+  const bundle = await rollup({ input: 'test/fixtures/{0,1}.js', plugins: [multiEntry()] });
+  const code = await getCode(bundle);
+  t.truthy(~code.indexOf('exports.zero = zero;'));
+  t.truthy(~code.indexOf('exports.one = one;'));
+});
+
+test('takes an array of globs as input', async (t) => {
+  const bundle = await rollup({
+    input: ['test/fixtures/{0,}.js', 'test/fixtures/{1,}.js'],
+    plugins: [multiEntry()]
+  });
+  const code = await getCode(bundle);
+  t.truthy(~code.indexOf('exports.zero = zero;'));
+  t.truthy(~code.indexOf('exports.one = one;'));
+});
+
+test('takes an {include,exclude} object as input', async (t) => {
+  const bundle = await rollup({
+    input: {
+      include: ['test/fixtures/*.js'],
+      exclude: ['test/fixtures/1.js']
+    },
+    plugins: [multiEntry()]
+  });
+  const code = await getCode(bundle);
+  t.truthy(~code.indexOf('exports.zero = zero;'));
+  t.falsy(~code.indexOf('exports.one = one;'));
+});
+
+test('allows to prevent exporting', async (t) => {
+  const bundle = await rollup({
+    input: {
+      include: ['test/fixtures/*.js'],
+      exports: false
+    },
+    plugins: [multiEntry()]
+  });
+  const code = await getCode(bundle);
+  t.truthy(~code.indexOf(`console.log('Hello, 2');`));
+  t.falsy(~code.indexOf('zero'));
+  t.falsy(~code.indexOf('one'));
+});

--- a/packages/multi-entry/test/test.js
+++ b/packages/multi-entry/test/test.js
@@ -10,7 +10,7 @@ import multiEntry from '../';
 test('takes a single file as input', async (t) => {
   const bundle = await rollup({ input: 'test/fixtures/0.js', plugins: [multiEntry()] });
   const code = await getCode(bundle);
-  t.truthy(~code.indexOf('exports.zero = zero;'));
+  t.truthy(code.includes('exports.zero = zero;'));
 });
 
 test('takes an array of files as input', async (t) => {
@@ -19,21 +19,21 @@ test('takes an array of files as input', async (t) => {
     plugins: [multiEntry()]
   });
   const code = await getCode(bundle);
-  t.truthy(~code.indexOf('exports.zero = zero;'));
-  t.truthy(~code.indexOf('exports.one = one;'));
+  t.truthy(code.includes('exports.zero = zero;'));
+  t.truthy(code.includes('exports.one = one;'));
 });
 
 test('allows an empty array as input', async (t) => {
   const bundle = await rollup({ input: [], plugins: [multiEntry()] });
   const code = await getCode(bundle);
-  t.falsy(~code.indexOf('exports'));
+  t.falsy(code.includes('exports'));
 });
 
 test('takes a glob as input', async (t) => {
   const bundle = await rollup({ input: 'test/fixtures/{0,1}.js', plugins: [multiEntry()] });
   const code = await getCode(bundle);
-  t.truthy(~code.indexOf('exports.zero = zero;'));
-  t.truthy(~code.indexOf('exports.one = one;'));
+  t.truthy(code.includes('exports.zero = zero;'));
+  t.truthy(code.includes('exports.one = one;'));
 });
 
 test('takes an array of globs as input', async (t) => {
@@ -42,8 +42,8 @@ test('takes an array of globs as input', async (t) => {
     plugins: [multiEntry()]
   });
   const code = await getCode(bundle);
-  t.truthy(~code.indexOf('exports.zero = zero;'));
-  t.truthy(~code.indexOf('exports.one = one;'));
+  t.truthy(code.includes('exports.zero = zero;'));
+  t.truthy(code.includes('exports.one = one;'));
 });
 
 test('takes an {include,exclude} object as input', async (t) => {
@@ -55,8 +55,8 @@ test('takes an {include,exclude} object as input', async (t) => {
     plugins: [multiEntry()]
   });
   const code = await getCode(bundle);
-  t.truthy(~code.indexOf('exports.zero = zero;'));
-  t.falsy(~code.indexOf('exports.one = one;'));
+  t.truthy(code.includes('exports.zero = zero;'));
+  t.falsy(code.includes('exports.one = one;'));
 });
 
 test('allows to prevent exporting', async (t) => {
@@ -68,7 +68,7 @@ test('allows to prevent exporting', async (t) => {
     plugins: [multiEntry()]
   });
   const code = await getCode(bundle);
-  t.truthy(~code.indexOf(`console.log('Hello, 2');`));
-  t.falsy(~code.indexOf('zero'));
-  t.falsy(~code.indexOf('one'));
+  t.truthy(code.includes(`console.log('Hello, 2');`));
+  t.falsy(code.includes('zero'));
+  t.falsy(code.includes('one'));
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,8 +1,8 @@
 importers:
   .:
     devDependencies:
-      '@typescript-eslint/eslint-plugin': 2.10.0_5e4c5b4b3611e7f57e1c4733830e94f0
-      '@typescript-eslint/parser': 2.10.0_typescript@3.7.2
+      '@typescript-eslint/eslint-plugin': 2.11.0_cb180cc210aa77d673b05caf1fc681e5
+      '@typescript-eslint/parser': 2.11.0_typescript@3.7.3
       ava: 2.4.0
       chalk: 2.4.2
       codecov-lite: 0.3.1
@@ -16,11 +16,11 @@ importers:
       pnpm: 4.3.3
       prettier: 1.19.1
       prettier-plugin-package: 0.3.1_prettier@1.19.1
-      rollup: 1.27.8
-      ts-node: 8.5.4_typescript@3.7.2
+      rollup: 1.27.9
+      ts-node: 8.5.4_typescript@3.7.3
       tsconfig-paths: 3.9.0
       tslib: 1.10.0
-      typescript: 3.7.2
+      typescript: 3.7.3
       yaml: 1.7.2
     specifiers:
       '@typescript-eslint/eslint-plugin': ^2.8.0
@@ -173,6 +173,20 @@ importers:
       '@rollup/plugin-buble': ^0.20.0
       del-cli: ^3.0.0
       rollup: ^1.27.2
+  packages/multi-entry:
+    dependencies:
+      matched: 1.0.2
+    devDependencies:
+      '@babel/core': 7.7.5
+      '@babel/preset-env': 7.7.6_@babel+core@7.7.5
+      rollup: 1.27.9
+      rollup-plugin-babel: 4.3.3_@babel+core@7.7.5+rollup@1.27.9
+    specifiers:
+      '@babel/core': ^7.2.0
+      '@babel/preset-env': ^7.2.0
+      matched: ^1.0.2
+      rollup: ^1.20.1
+      rollup-plugin-babel: ^4.0.3
   packages/node-resolve:
     dependencies:
       '@rollup/pluginutils': 3.0.0_rollup@1.27.8
@@ -366,13 +380,13 @@ packages:
       node: '>=8.9.4 <9 || >=10.0.0 <11 || >=12.0.0'
     resolution:
       integrity: sha512-3diBLIVBPPh3j4+hb5lo0I1D+S/O/VDJPI4Y502apBxmwEqjyXG4gTSPFUlm41sSZeZzMarT/Gzovw9kV7An0w==
-  /@ava/babel-preset-stage-4/4.0.0_@babel+core@7.7.4:
+  /@ava/babel-preset-stage-4/4.0.0_@babel+core@7.7.5:
     dependencies:
-      '@babel/plugin-proposal-async-generator-functions': 7.7.4_@babel+core@7.7.4
-      '@babel/plugin-proposal-dynamic-import': 7.7.4_@babel+core@7.7.4
-      '@babel/plugin-proposal-optional-catch-binding': 7.7.4_@babel+core@7.7.4
-      '@babel/plugin-transform-dotall-regex': 7.7.4_@babel+core@7.7.4
-      '@babel/plugin-transform-modules-commonjs': 7.7.4_@babel+core@7.7.4
+      '@babel/plugin-proposal-async-generator-functions': 7.7.4_@babel+core@7.7.5
+      '@babel/plugin-proposal-dynamic-import': 7.7.4_@babel+core@7.7.5
+      '@babel/plugin-proposal-optional-catch-binding': 7.7.4_@babel+core@7.7.5
+      '@babel/plugin-transform-dotall-regex': 7.7.4_@babel+core@7.7.5
+      '@babel/plugin-transform-modules-commonjs': 7.7.5_@babel+core@7.7.5
     dev: true
     engines:
       node: '>=8.9.4 <9 || >=10.0.0 <11 || >=12.0.0'
@@ -416,6 +430,27 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-+bYbx56j4nYBmpsWtnPUsKW3NdnYxbqyfrP2w9wILBuHzdfIKz9prieZK0DFPyIzkjYVUe4QkusGL07r5pXznQ==
+  /@babel/core/7.7.5:
+    dependencies:
+      '@babel/code-frame': 7.5.5
+      '@babel/generator': 7.7.4
+      '@babel/helpers': 7.7.4
+      '@babel/parser': 7.7.5
+      '@babel/template': 7.7.4
+      '@babel/traverse': 7.7.4
+      '@babel/types': 7.7.4
+      convert-source-map: 1.7.0
+      debug: 4.1.1
+      json5: 2.1.1
+      lodash: 4.17.15
+      resolve: 1.13.1
+      semver: 5.7.1
+      source-map: 0.5.7
+    dev: true
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-M42+ScN4+1S9iB6f+TL7QBpoQETxbclx+KNoKJABghnKYE+fMzSGqst0BZJc8CpI625bwPwYgUyRvxZ+0mZzpw==
   /@babel/generator/7.7.4:
     dependencies:
       '@babel/types': 7.7.4
@@ -449,6 +484,16 @@ packages:
   /@babel/helper-create-regexp-features-plugin/7.7.4_@babel+core@7.7.4:
     dependencies:
       '@babel/core': 7.7.4
+      '@babel/helper-regex': 7.5.5
+      regexpu-core: 4.6.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    resolution:
+      integrity: sha512-Mt+jBKaxL0zfOIWrfQpnfYCN7/rS6GKx6CCCfuoqVVd+17R8zNDlzVYmIi9qyb2wOk002NsmSTDymkIygDUH7A==
+  /@babel/helper-create-regexp-features-plugin/7.7.4_@babel+core@7.7.5:
+    dependencies:
+      '@babel/core': 7.7.5
       '@babel/helper-regex': 7.5.5
       regexpu-core: 4.6.0
     dev: true
@@ -514,6 +559,17 @@ packages:
     dev: true
     resolution:
       integrity: sha512-ehGBu4mXrhs0FxAqN8tWkzF8GSIGAiEumu4ONZ/hD9M88uHcD+Yu2ttKfOCgwzoesJOJrtQh7trI5YPbRtMmnA==
+  /@babel/helper-module-transforms/7.7.5:
+    dependencies:
+      '@babel/helper-module-imports': 7.7.4
+      '@babel/helper-simple-access': 7.7.4
+      '@babel/helper-split-export-declaration': 7.7.4
+      '@babel/template': 7.7.4
+      '@babel/types': 7.7.4
+      lodash: 4.17.15
+    dev: true
+    resolution:
+      integrity: sha512-A7pSxyJf1gN5qXVcidwLWydjftUN878VkalhXX5iQDuGyiGK3sOrrKKHF4/A4fwHtnsotv/NipwAeLzY4KQPvw==
   /@babel/helper-optimise-call-expression/7.7.4:
     dependencies:
       '@babel/types': 7.7.4
@@ -594,12 +650,30 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-jIwvLO0zCL+O/LmEJQjWA75MQTWwx3c3u2JOTDK5D3/9egrWRRA0/0hk9XXywYnXZVVpzrBYeIQTmhwUaePI9g==
+  /@babel/parser/7.7.5:
+    dev: true
+    engines:
+      node: '>=6.0.0'
+    hasBin: true
+    resolution:
+      integrity: sha512-KNlOe9+/nk4i29g0VXgl8PEXIRms5xKLJeuZ6UptN0fHv+jDiriG+y94X6qAgWTR0h3KaoM1wK5G5h7MHFRSig==
   /@babel/plugin-proposal-async-generator-functions/7.7.4_@babel+core@7.7.4:
     dependencies:
       '@babel/core': 7.7.4
       '@babel/helper-plugin-utils': 7.0.0
       '@babel/helper-remap-async-to-generator': 7.7.4
       '@babel/plugin-syntax-async-generators': 7.7.4_@babel+core@7.7.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-1ypyZvGRXriY/QP668+s8sFr2mqinhkRDMPSQLNghCQE+GAkFtp+wkHVvg2+Hdki8gwP+NFzJBJ/N1BfzCCDEw==
+  /@babel/plugin-proposal-async-generator-functions/7.7.4_@babel+core@7.7.5:
+    dependencies:
+      '@babel/core': 7.7.5
+      '@babel/helper-plugin-utils': 7.0.0
+      '@babel/helper-remap-async-to-generator': 7.7.4
+      '@babel/plugin-syntax-async-generators': 7.7.4_@babel+core@7.7.5
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -615,11 +689,31 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-StH+nGAdO6qDB1l8sZ5UBV8AC3F2VW2I8Vfld73TMKyptMU9DY5YsJAS8U81+vEtxcH3Y/La0wG0btDrhpnhjQ==
+  /@babel/plugin-proposal-dynamic-import/7.7.4_@babel+core@7.7.5:
+    dependencies:
+      '@babel/core': 7.7.5
+      '@babel/helper-plugin-utils': 7.0.0
+      '@babel/plugin-syntax-dynamic-import': 7.7.4_@babel+core@7.7.5
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-StH+nGAdO6qDB1l8sZ5UBV8AC3F2VW2I8Vfld73TMKyptMU9DY5YsJAS8U81+vEtxcH3Y/La0wG0btDrhpnhjQ==
   /@babel/plugin-proposal-json-strings/7.7.4_@babel+core@7.7.4:
     dependencies:
       '@babel/core': 7.7.4
       '@babel/helper-plugin-utils': 7.0.0
       '@babel/plugin-syntax-json-strings': 7.7.4_@babel+core@7.7.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-wQvt3akcBTfLU/wYoqm/ws7YOAQKu8EVJEvHip/mzkNtjaclQoCCIqKXFP5/eyfnfbQCDV3OLRIK3mIVyXuZlw==
+  /@babel/plugin-proposal-json-strings/7.7.4_@babel+core@7.7.5:
+    dependencies:
+      '@babel/core': 7.7.5
+      '@babel/helper-plugin-utils': 7.0.0
+      '@babel/plugin-syntax-json-strings': 7.7.4_@babel+core@7.7.5
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -635,11 +729,31 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-rnpnZR3/iWKmiQyJ3LKJpSwLDcX/nSXhdLk4Aq/tXOApIvyu7qoabrige0ylsAJffaUC51WiBu209Q0U+86OWQ==
+  /@babel/plugin-proposal-object-rest-spread/7.7.4_@babel+core@7.7.5:
+    dependencies:
+      '@babel/core': 7.7.5
+      '@babel/helper-plugin-utils': 7.0.0
+      '@babel/plugin-syntax-object-rest-spread': 7.7.4_@babel+core@7.7.5
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-rnpnZR3/iWKmiQyJ3LKJpSwLDcX/nSXhdLk4Aq/tXOApIvyu7qoabrige0ylsAJffaUC51WiBu209Q0U+86OWQ==
   /@babel/plugin-proposal-optional-catch-binding/7.7.4_@babel+core@7.7.4:
     dependencies:
       '@babel/core': 7.7.4
       '@babel/helper-plugin-utils': 7.0.0
       '@babel/plugin-syntax-optional-catch-binding': 7.7.4_@babel+core@7.7.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-DyM7U2bnsQerCQ+sejcTNZh8KQEUuC3ufzdnVnSiUv/qoGJp2Z3hanKL18KDhsBT5Wj6a7CMT5mdyCNJsEaA9w==
+  /@babel/plugin-proposal-optional-catch-binding/7.7.4_@babel+core@7.7.5:
+    dependencies:
+      '@babel/core': 7.7.5
+      '@babel/helper-plugin-utils': 7.0.0
+      '@babel/plugin-syntax-optional-catch-binding': 7.7.4_@babel+core@7.7.5
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -657,9 +771,30 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-cHgqHgYvffluZk85dJ02vloErm3Y6xtH+2noOBOJ2kXOJH3aVCDnj5eR/lVNlTnYu4hndAPJD3rTFjW3qee0PA==
+  /@babel/plugin-proposal-unicode-property-regex/7.7.4_@babel+core@7.7.5:
+    dependencies:
+      '@babel/core': 7.7.5
+      '@babel/helper-create-regexp-features-plugin': 7.7.4_@babel+core@7.7.5
+      '@babel/helper-plugin-utils': 7.0.0
+    dev: true
+    engines:
+      node: '>=4'
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-cHgqHgYvffluZk85dJ02vloErm3Y6xtH+2noOBOJ2kXOJH3aVCDnj5eR/lVNlTnYu4hndAPJD3rTFjW3qee0PA==
   /@babel/plugin-syntax-async-generators/7.7.4_@babel+core@7.7.4:
     dependencies:
       '@babel/core': 7.7.4
+      '@babel/helper-plugin-utils': 7.0.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-Li4+EjSpBgxcsmeEF8IFcfV/+yJGxHXDirDkEoyFjumuwbmfCVHUt0HuowD/iGM7OhIRyXJH9YXxqiH6N815+g==
+  /@babel/plugin-syntax-async-generators/7.7.4_@babel+core@7.7.5:
+    dependencies:
+      '@babel/core': 7.7.5
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
     peerDependencies:
@@ -675,9 +810,27 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-jHQW0vbRGvwQNgyVxwDh4yuXu4bH1f5/EICJLAhl1SblLs2CDhrsmCk+v5XLdE9wxtAFRyxx+P//Iw+a5L/tTg==
+  /@babel/plugin-syntax-dynamic-import/7.7.4_@babel+core@7.7.5:
+    dependencies:
+      '@babel/core': 7.7.5
+      '@babel/helper-plugin-utils': 7.0.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-jHQW0vbRGvwQNgyVxwDh4yuXu4bH1f5/EICJLAhl1SblLs2CDhrsmCk+v5XLdE9wxtAFRyxx+P//Iw+a5L/tTg==
   /@babel/plugin-syntax-json-strings/7.7.4_@babel+core@7.7.4:
     dependencies:
       '@babel/core': 7.7.4
+      '@babel/helper-plugin-utils': 7.0.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-QpGupahTQW1mHRXddMG5srgpHWqRLwJnJZKXTigB9RPFCCGbDGCgBeM/iC82ICXp414WeYx/tD54w7M2qRqTMg==
+  /@babel/plugin-syntax-json-strings/7.7.4_@babel+core@7.7.5:
+    dependencies:
+      '@babel/core': 7.7.5
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
     peerDependencies:
@@ -693,9 +846,27 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-mObR+r+KZq0XhRVS2BrBKBpr5jqrqzlPvS9C9vuOf5ilSwzloAl7RPWLrgKdWS6IreaVrjHxTjtyqFiOisaCwg==
+  /@babel/plugin-syntax-object-rest-spread/7.7.4_@babel+core@7.7.5:
+    dependencies:
+      '@babel/core': 7.7.5
+      '@babel/helper-plugin-utils': 7.0.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-mObR+r+KZq0XhRVS2BrBKBpr5jqrqzlPvS9C9vuOf5ilSwzloAl7RPWLrgKdWS6IreaVrjHxTjtyqFiOisaCwg==
   /@babel/plugin-syntax-optional-catch-binding/7.7.4_@babel+core@7.7.4:
     dependencies:
       '@babel/core': 7.7.4
+      '@babel/helper-plugin-utils': 7.0.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-4ZSuzWgFxqHRE31Glu+fEr/MirNZOMYmD/0BhBWyLyOOQz/gTAl7QmWm2hX1QxEIXsr2vkdlwxIzTyiYRC4xcQ==
+  /@babel/plugin-syntax-optional-catch-binding/7.7.4_@babel+core@7.7.5:
+    dependencies:
+      '@babel/core': 7.7.5
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
     peerDependencies:
@@ -711,9 +882,27 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-wdsOw0MvkL1UIgiQ/IFr3ETcfv1xb8RMM0H9wbiDyLaJFyiDg5oZvDLCXosIXmFeIlweML5iOBXAkqddkYNizg==
+  /@babel/plugin-syntax-top-level-await/7.7.4_@babel+core@7.7.5:
+    dependencies:
+      '@babel/core': 7.7.5
+      '@babel/helper-plugin-utils': 7.0.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-wdsOw0MvkL1UIgiQ/IFr3ETcfv1xb8RMM0H9wbiDyLaJFyiDg5oZvDLCXosIXmFeIlweML5iOBXAkqddkYNizg==
   /@babel/plugin-transform-arrow-functions/7.7.4_@babel+core@7.7.4:
     dependencies:
       '@babel/core': 7.7.4
+      '@babel/helper-plugin-utils': 7.0.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-zUXy3e8jBNPiffmqkHRNDdZM2r8DWhCB7HhcoyZjiK1TxYEluLHAvQuYnTT+ARqRpabWqy/NHkO6e3MsYB5YfA==
+  /@babel/plugin-transform-arrow-functions/7.7.4_@babel+core@7.7.5:
+    dependencies:
+      '@babel/core': 7.7.5
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
     peerDependencies:
@@ -731,6 +920,17 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-zpUTZphp5nHokuy8yLlyafxCJ0rSlFoSHypTUWgpdwoDXWQcseaect7cJ8Ppk6nunOM6+5rPMkod4OYKPR5MUg==
+  /@babel/plugin-transform-async-to-generator/7.7.4_@babel+core@7.7.5:
+    dependencies:
+      '@babel/core': 7.7.5
+      '@babel/helper-module-imports': 7.7.4
+      '@babel/helper-plugin-utils': 7.0.0
+      '@babel/helper-remap-async-to-generator': 7.7.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-zpUTZphp5nHokuy8yLlyafxCJ0rSlFoSHypTUWgpdwoDXWQcseaect7cJ8Ppk6nunOM6+5rPMkod4OYKPR5MUg==
   /@babel/plugin-transform-block-scoped-functions/7.7.4_@babel+core@7.7.4:
     dependencies:
       '@babel/core': 7.7.4
@@ -740,9 +940,28 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-kqtQzwtKcpPclHYjLK//3lH8OFsCDuDJBaFhVwf8kqdnF6MN4l618UDlcA7TfRs3FayrHj+svYnSX8MC9zmUyQ==
+  /@babel/plugin-transform-block-scoped-functions/7.7.4_@babel+core@7.7.5:
+    dependencies:
+      '@babel/core': 7.7.5
+      '@babel/helper-plugin-utils': 7.0.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-kqtQzwtKcpPclHYjLK//3lH8OFsCDuDJBaFhVwf8kqdnF6MN4l618UDlcA7TfRs3FayrHj+svYnSX8MC9zmUyQ==
   /@babel/plugin-transform-block-scoping/7.7.4_@babel+core@7.7.4:
     dependencies:
       '@babel/core': 7.7.4
+      '@babel/helper-plugin-utils': 7.0.0
+      lodash: 4.17.15
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-2VBe9u0G+fDt9B5OV5DQH4KBf5DoiNkwFKOz0TCvBWvdAN2rOykCTkrL+jTLxfCAm76l9Qo5OqL7HBOx2dWggg==
+  /@babel/plugin-transform-block-scoping/7.7.4_@babel+core@7.7.5:
+    dependencies:
+      '@babel/core': 7.7.5
       '@babel/helper-plugin-utils': 7.0.0
       lodash: 4.17.15
     dev: true
@@ -766,6 +985,22 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-sK1mjWat7K+buWRuImEzjNf68qrKcrddtpQo3swi9j7dUcG6y6R6+Di039QN2bD1dykeswlagupEmpOatFHHUg==
+  /@babel/plugin-transform-classes/7.7.4_@babel+core@7.7.5:
+    dependencies:
+      '@babel/core': 7.7.5
+      '@babel/helper-annotate-as-pure': 7.7.4
+      '@babel/helper-define-map': 7.7.4
+      '@babel/helper-function-name': 7.7.4
+      '@babel/helper-optimise-call-expression': 7.7.4
+      '@babel/helper-plugin-utils': 7.0.0
+      '@babel/helper-replace-supers': 7.7.4
+      '@babel/helper-split-export-declaration': 7.7.4
+      globals: 11.12.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-sK1mjWat7K+buWRuImEzjNf68qrKcrddtpQo3swi9j7dUcG6y6R6+Di039QN2bD1dykeswlagupEmpOatFHHUg==
   /@babel/plugin-transform-computed-properties/7.7.4_@babel+core@7.7.4:
     dependencies:
       '@babel/core': 7.7.4
@@ -775,9 +1010,27 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-bSNsOsZnlpLLyQew35rl4Fma3yKWqK3ImWMSC/Nc+6nGjC9s5NFWAer1YQ899/6s9HxO2zQC1WoFNfkOqRkqRQ==
+  /@babel/plugin-transform-computed-properties/7.7.4_@babel+core@7.7.5:
+    dependencies:
+      '@babel/core': 7.7.5
+      '@babel/helper-plugin-utils': 7.0.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-bSNsOsZnlpLLyQew35rl4Fma3yKWqK3ImWMSC/Nc+6nGjC9s5NFWAer1YQ899/6s9HxO2zQC1WoFNfkOqRkqRQ==
   /@babel/plugin-transform-destructuring/7.7.4_@babel+core@7.7.4:
     dependencies:
       '@babel/core': 7.7.4
+      '@babel/helper-plugin-utils': 7.0.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-4jFMXI1Cu2aXbcXXl8Lr6YubCn6Oc7k9lLsu8v61TZh+1jny2BWmdtvY9zSUlLdGUvcy9DMAWyZEOqjsbeg/wA==
+  /@babel/plugin-transform-destructuring/7.7.4_@babel+core@7.7.5:
+    dependencies:
+      '@babel/core': 7.7.5
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
     peerDependencies:
@@ -794,9 +1047,28 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-mk0cH1zyMa/XHeb6LOTXTbG7uIJ8Rrjlzu91pUx/KS3JpcgaTDwMS8kM+ar8SLOvlL2Lofi4CGBAjCo3a2x+lw==
+  /@babel/plugin-transform-dotall-regex/7.7.4_@babel+core@7.7.5:
+    dependencies:
+      '@babel/core': 7.7.5
+      '@babel/helper-create-regexp-features-plugin': 7.7.4_@babel+core@7.7.5
+      '@babel/helper-plugin-utils': 7.0.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-mk0cH1zyMa/XHeb6LOTXTbG7uIJ8Rrjlzu91pUx/KS3JpcgaTDwMS8kM+ar8SLOvlL2Lofi4CGBAjCo3a2x+lw==
   /@babel/plugin-transform-duplicate-keys/7.7.4_@babel+core@7.7.4:
     dependencies:
       '@babel/core': 7.7.4
+      '@babel/helper-plugin-utils': 7.0.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-g1y4/G6xGWMD85Tlft5XedGaZBCIVN+/P0bs6eabmcPP9egFleMAo65OOjlhcz1njpwagyY3t0nsQC9oTFegJA==
+  /@babel/plugin-transform-duplicate-keys/7.7.4_@babel+core@7.7.5:
+    dependencies:
+      '@babel/core': 7.7.5
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
     peerDependencies:
@@ -813,9 +1085,28 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-MCqiLfCKm6KEA1dglf6Uqq1ElDIZwFuzz1WH5mTf8k2uQSxEJMbOIEh7IZv7uichr7PMfi5YVSrr1vz+ipp7AQ==
+  /@babel/plugin-transform-exponentiation-operator/7.7.4_@babel+core@7.7.5:
+    dependencies:
+      '@babel/core': 7.7.5
+      '@babel/helper-builder-binary-assignment-operator-visitor': 7.7.4
+      '@babel/helper-plugin-utils': 7.0.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-MCqiLfCKm6KEA1dglf6Uqq1ElDIZwFuzz1WH5mTf8k2uQSxEJMbOIEh7IZv7uichr7PMfi5YVSrr1vz+ipp7AQ==
   /@babel/plugin-transform-for-of/7.7.4_@babel+core@7.7.4:
     dependencies:
       '@babel/core': 7.7.4
+      '@babel/helper-plugin-utils': 7.0.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-zZ1fD1B8keYtEcKF+M1TROfeHTKnijcVQm0yO/Yu1f7qoDoxEIc/+GX6Go430Bg84eM/xwPFp0+h4EbZg7epAA==
+  /@babel/plugin-transform-for-of/7.7.4_@babel+core@7.7.5:
+    dependencies:
+      '@babel/core': 7.7.5
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
     peerDependencies:
@@ -832,6 +1123,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-E/x09TvjHNhsULs2IusN+aJNRV5zKwxu1cpirZyRPw+FyyIKEHPXTsadj48bVpc1R5Qq1B5ZkzumuFLytnbT6g==
+  /@babel/plugin-transform-function-name/7.7.4_@babel+core@7.7.5:
+    dependencies:
+      '@babel/core': 7.7.5
+      '@babel/helper-function-name': 7.7.4
+      '@babel/helper-plugin-utils': 7.0.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-E/x09TvjHNhsULs2IusN+aJNRV5zKwxu1cpirZyRPw+FyyIKEHPXTsadj48bVpc1R5Qq1B5ZkzumuFLytnbT6g==
   /@babel/plugin-transform-literals/7.7.4_@babel+core@7.7.4:
     dependencies:
       '@babel/core': 7.7.4
@@ -841,9 +1142,27 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-X2MSV7LfJFm4aZfxd0yLVFrEXAgPqYoDG53Br/tCKiKYfX0MjVjQeWPIhPHHsCqzwQANq+FLN786fF5rgLS+gw==
+  /@babel/plugin-transform-literals/7.7.4_@babel+core@7.7.5:
+    dependencies:
+      '@babel/core': 7.7.5
+      '@babel/helper-plugin-utils': 7.0.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-X2MSV7LfJFm4aZfxd0yLVFrEXAgPqYoDG53Br/tCKiKYfX0MjVjQeWPIhPHHsCqzwQANq+FLN786fF5rgLS+gw==
   /@babel/plugin-transform-member-expression-literals/7.7.4_@babel+core@7.7.4:
     dependencies:
       '@babel/core': 7.7.4
+      '@babel/helper-plugin-utils': 7.0.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-9VMwMO7i69LHTesL0RdGy93JU6a+qOPuvB4F4d0kR0zyVjJRVJRaoaGjhtki6SzQUu8yen/vxPKN6CWnCUw6bA==
+  /@babel/plugin-transform-member-expression-literals/7.7.4_@babel+core@7.7.5:
+    dependencies:
+      '@babel/core': 7.7.5
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
     peerDependencies:
@@ -861,6 +1180,17 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-/542/5LNA18YDtg1F+QHvvUSlxdvjZoD/aldQwkq+E3WCkbEjNSN9zdrOXaSlfg3IfGi22ijzecklF/A7kVZFQ==
+  /@babel/plugin-transform-modules-amd/7.7.5_@babel+core@7.7.5:
+    dependencies:
+      '@babel/core': 7.7.5
+      '@babel/helper-module-transforms': 7.7.5
+      '@babel/helper-plugin-utils': 7.0.0
+      babel-plugin-dynamic-import-node: 2.3.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-CT57FG4A2ZUNU1v+HdvDSDrjNWBrtCmSH6YbbgN3Lrf0Di/q/lWRxZrE72p3+HCCz9UjfZOEBdphgC0nzOS6DQ==
   /@babel/plugin-transform-modules-commonjs/7.7.4_@babel+core@7.7.4:
     dependencies:
       '@babel/core': 7.7.4
@@ -873,9 +1203,32 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-k8iVS7Jhc367IcNF53KCwIXtKAH7czev866ThsTgy8CwlXjnKZna2VHwChglzLleYrcHz1eQEIJlGRQxB53nqA==
+  /@babel/plugin-transform-modules-commonjs/7.7.5_@babel+core@7.7.5:
+    dependencies:
+      '@babel/core': 7.7.5
+      '@babel/helper-module-transforms': 7.7.5
+      '@babel/helper-plugin-utils': 7.0.0
+      '@babel/helper-simple-access': 7.7.4
+      babel-plugin-dynamic-import-node: 2.3.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-9Cq4zTFExwFhQI6MT1aFxgqhIsMWQWDVwOgLzl7PTWJHsNaqFvklAU+Oz6AQLAS0dJKTwZSOCo20INwktxpi3Q==
   /@babel/plugin-transform-modules-systemjs/7.7.4_@babel+core@7.7.4:
     dependencies:
       '@babel/core': 7.7.4
+      '@babel/helper-hoist-variables': 7.7.4
+      '@babel/helper-plugin-utils': 7.0.0
+      babel-plugin-dynamic-import-node: 2.3.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-y2c96hmcsUi6LrMqvmNDPBBiGCiQu0aYqpHatVVu6kD4mFEXKjyNxd/drc18XXAf9dv7UXjrZwBVmTTGaGP8iw==
+  /@babel/plugin-transform-modules-systemjs/7.7.4_@babel+core@7.7.5:
+    dependencies:
+      '@babel/core': 7.7.5
       '@babel/helper-hoist-variables': 7.7.4
       '@babel/helper-plugin-utils': 7.0.0
       babel-plugin-dynamic-import-node: 2.3.0
@@ -894,10 +1247,29 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-u2B8TIi0qZI4j8q4C51ktfO7E3cQ0qnaXFI1/OXITordD40tt17g/sXqgNNCcMTcBFKrUPcGDx+TBJuZxLx7tw==
+  /@babel/plugin-transform-modules-umd/7.7.4_@babel+core@7.7.5:
+    dependencies:
+      '@babel/core': 7.7.5
+      '@babel/helper-module-transforms': 7.7.4
+      '@babel/helper-plugin-utils': 7.0.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-u2B8TIi0qZI4j8q4C51ktfO7E3cQ0qnaXFI1/OXITordD40tt17g/sXqgNNCcMTcBFKrUPcGDx+TBJuZxLx7tw==
   /@babel/plugin-transform-named-capturing-groups-regex/7.7.4_@babel+core@7.7.4:
     dependencies:
       '@babel/core': 7.7.4
       '@babel/helper-create-regexp-features-plugin': 7.7.4_@babel+core@7.7.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    resolution:
+      integrity: sha512-jBUkiqLKvUWpv9GLSuHUFYdmHg0ujC1JEYoZUfeOOfNydZXp1sXObgyPatpcwjWgsdBGsagWW0cdJpX/DO2jMw==
+  /@babel/plugin-transform-named-capturing-groups-regex/7.7.4_@babel+core@7.7.5:
+    dependencies:
+      '@babel/core': 7.7.5
+      '@babel/helper-create-regexp-features-plugin': 7.7.4_@babel+core@7.7.5
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -912,9 +1284,28 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-CnPRiNtOG1vRodnsyGX37bHQleHE14B9dnnlgSeEs3ek3fHN1A1SScglTCg1sfbe7sRQ2BUcpgpTpWSfMKz3gg==
+  /@babel/plugin-transform-new-target/7.7.4_@babel+core@7.7.5:
+    dependencies:
+      '@babel/core': 7.7.5
+      '@babel/helper-plugin-utils': 7.0.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-CnPRiNtOG1vRodnsyGX37bHQleHE14B9dnnlgSeEs3ek3fHN1A1SScglTCg1sfbe7sRQ2BUcpgpTpWSfMKz3gg==
   /@babel/plugin-transform-object-super/7.7.4_@babel+core@7.7.4:
     dependencies:
       '@babel/core': 7.7.4
+      '@babel/helper-plugin-utils': 7.0.0
+      '@babel/helper-replace-supers': 7.7.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-ho+dAEhC2aRnff2JCA0SAK7V2R62zJd/7dmtoe7MHcso4C2mS+vZjn1Pb1pCVZvJs1mgsvv5+7sT+m3Bysb6eg==
+  /@babel/plugin-transform-object-super/7.7.4_@babel+core@7.7.5:
+    dependencies:
+      '@babel/core': 7.7.5
       '@babel/helper-plugin-utils': 7.0.0
       '@babel/helper-replace-supers': 7.7.4
     dev: true
@@ -933,9 +1324,29 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-VJwhVePWPa0DqE9vcfptaJSzNDKrWU/4FbYCjZERtmqEs05g3UMXnYMZoXja7JAJ7Y7sPZipwm/pGApZt7wHlw==
+  /@babel/plugin-transform-parameters/7.7.4_@babel+core@7.7.5:
+    dependencies:
+      '@babel/core': 7.7.5
+      '@babel/helper-call-delegate': 7.7.4
+      '@babel/helper-get-function-arity': 7.7.4
+      '@babel/helper-plugin-utils': 7.0.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-VJwhVePWPa0DqE9vcfptaJSzNDKrWU/4FbYCjZERtmqEs05g3UMXnYMZoXja7JAJ7Y7sPZipwm/pGApZt7wHlw==
   /@babel/plugin-transform-property-literals/7.7.4_@babel+core@7.7.4:
     dependencies:
       '@babel/core': 7.7.4
+      '@babel/helper-plugin-utils': 7.0.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-MatJhlC4iHsIskWYyawl53KuHrt+kALSADLQQ/HkhTjX954fkxIEh4q5slL4oRAnsm/eDoZ4q0CIZpcqBuxhJQ==
+  /@babel/plugin-transform-property-literals/7.7.4_@babel+core@7.7.5:
+    dependencies:
+      '@babel/core': 7.7.5
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
     peerDependencies:
@@ -951,9 +1362,27 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-e7MWl5UJvmPEwFJTwkBlPmqixCtr9yAASBqff4ggXTNicZiwbF8Eefzm6NVgfiBp7JdAGItecnctKTgH44q2Jw==
+  /@babel/plugin-transform-regenerator/7.7.5_@babel+core@7.7.5:
+    dependencies:
+      '@babel/core': 7.7.5
+      regenerator-transform: 0.14.1
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-/8I8tPvX2FkuEyWbjRCt4qTAgZK0DVy8QRguhA524UH48RfGJy94On2ri+dCuwOpcerPRl9O4ebQkRcVzIaGBw==
   /@babel/plugin-transform-reserved-words/7.7.4_@babel+core@7.7.4:
     dependencies:
       '@babel/core': 7.7.4
+      '@babel/helper-plugin-utils': 7.0.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-OrPiUB5s5XvkCO1lS7D8ZtHcswIC57j62acAnJZKqGGnHP+TIc/ljQSrgdX/QyOTdEK5COAhuc820Hi1q2UgLQ==
+  /@babel/plugin-transform-reserved-words/7.7.4_@babel+core@7.7.5:
+    dependencies:
+      '@babel/core': 7.7.5
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
     peerDependencies:
@@ -969,6 +1398,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-q+suddWRfIcnyG5YiDP58sT65AJDZSUhXQDZE3r04AuqD6d/XLaQPPXSBzP2zGerkgBivqtQm9XKGLuHqBID6Q==
+  /@babel/plugin-transform-shorthand-properties/7.7.4_@babel+core@7.7.5:
+    dependencies:
+      '@babel/core': 7.7.5
+      '@babel/helper-plugin-utils': 7.0.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-q+suddWRfIcnyG5YiDP58sT65AJDZSUhXQDZE3r04AuqD6d/XLaQPPXSBzP2zGerkgBivqtQm9XKGLuHqBID6Q==
   /@babel/plugin-transform-spread/7.7.4_@babel+core@7.7.4:
     dependencies:
       '@babel/core': 7.7.4
@@ -978,9 +1416,28 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-8OSs0FLe5/80cndziPlg4R0K6HcWSM0zyNhHhLsmw/Nc5MaA49cAsnoJ/t/YZf8qkG7fD+UjTRaApVDB526d7Q==
+  /@babel/plugin-transform-spread/7.7.4_@babel+core@7.7.5:
+    dependencies:
+      '@babel/core': 7.7.5
+      '@babel/helper-plugin-utils': 7.0.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-8OSs0FLe5/80cndziPlg4R0K6HcWSM0zyNhHhLsmw/Nc5MaA49cAsnoJ/t/YZf8qkG7fD+UjTRaApVDB526d7Q==
   /@babel/plugin-transform-sticky-regex/7.7.4_@babel+core@7.7.4:
     dependencies:
       '@babel/core': 7.7.4
+      '@babel/helper-plugin-utils': 7.0.0
+      '@babel/helper-regex': 7.5.5
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-Ls2NASyL6qtVe1H1hXts9yuEeONV2TJZmplLONkMPUG158CtmnrzW5Q5teibM5UVOFjG0D3IC5mzXR6pPpUY7A==
+  /@babel/plugin-transform-sticky-regex/7.7.4_@babel+core@7.7.5:
+    dependencies:
+      '@babel/core': 7.7.5
       '@babel/helper-plugin-utils': 7.0.0
       '@babel/helper-regex': 7.5.5
     dev: true
@@ -998,9 +1455,28 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-sA+KxLwF3QwGj5abMHkHgshp9+rRz+oY9uoRil4CyLtgEuE/88dpkeWgNk5qKVsJE9iSfly3nvHapdRiIS2wnQ==
+  /@babel/plugin-transform-template-literals/7.7.4_@babel+core@7.7.5:
+    dependencies:
+      '@babel/core': 7.7.5
+      '@babel/helper-annotate-as-pure': 7.7.4
+      '@babel/helper-plugin-utils': 7.0.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-sA+KxLwF3QwGj5abMHkHgshp9+rRz+oY9uoRil4CyLtgEuE/88dpkeWgNk5qKVsJE9iSfly3nvHapdRiIS2wnQ==
   /@babel/plugin-transform-typeof-symbol/7.7.4_@babel+core@7.7.4:
     dependencies:
       '@babel/core': 7.7.4
+      '@babel/helper-plugin-utils': 7.0.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-KQPUQ/7mqe2m0B8VecdyaW5XcQYaePyl9R7IsKd+irzj6jvbhoGnRE+M0aNkyAzI07VfUQ9266L5xMARitV3wg==
+  /@babel/plugin-transform-typeof-symbol/7.7.4_@babel+core@7.7.5:
+    dependencies:
+      '@babel/core': 7.7.5
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
     peerDependencies:
@@ -1011,6 +1487,16 @@ packages:
     dependencies:
       '@babel/core': 7.7.4
       '@babel/helper-create-regexp-features-plugin': 7.7.4_@babel+core@7.7.4
+      '@babel/helper-plugin-utils': 7.0.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-N77UUIV+WCvE+5yHw+oks3m18/umd7y392Zv7mYTpFqHtkpcc+QUz+gLJNTWVlWROIWeLqY0f3OjZxV5TcXnRw==
+  /@babel/plugin-transform-unicode-regex/7.7.4_@babel+core@7.7.5:
+    dependencies:
+      '@babel/core': 7.7.5
+      '@babel/helper-create-regexp-features-plugin': 7.7.4_@babel+core@7.7.5
       '@babel/helper-plugin-utils': 7.0.0
     dev: true
     peerDependencies:
@@ -1076,6 +1562,65 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-Dg+ciGJjwvC1NIe/DGblMbcGq1HOtKbw8RLl4nIjlfcILKEOkWT/vRqPpumswABEBVudii6dnVwrBtzD7ibm4g==
+  /@babel/preset-env/7.7.6_@babel+core@7.7.5:
+    dependencies:
+      '@babel/core': 7.7.5
+      '@babel/helper-module-imports': 7.7.4
+      '@babel/helper-plugin-utils': 7.0.0
+      '@babel/plugin-proposal-async-generator-functions': 7.7.4_@babel+core@7.7.5
+      '@babel/plugin-proposal-dynamic-import': 7.7.4_@babel+core@7.7.5
+      '@babel/plugin-proposal-json-strings': 7.7.4_@babel+core@7.7.5
+      '@babel/plugin-proposal-object-rest-spread': 7.7.4_@babel+core@7.7.5
+      '@babel/plugin-proposal-optional-catch-binding': 7.7.4_@babel+core@7.7.5
+      '@babel/plugin-proposal-unicode-property-regex': 7.7.4_@babel+core@7.7.5
+      '@babel/plugin-syntax-async-generators': 7.7.4_@babel+core@7.7.5
+      '@babel/plugin-syntax-dynamic-import': 7.7.4_@babel+core@7.7.5
+      '@babel/plugin-syntax-json-strings': 7.7.4_@babel+core@7.7.5
+      '@babel/plugin-syntax-object-rest-spread': 7.7.4_@babel+core@7.7.5
+      '@babel/plugin-syntax-optional-catch-binding': 7.7.4_@babel+core@7.7.5
+      '@babel/plugin-syntax-top-level-await': 7.7.4_@babel+core@7.7.5
+      '@babel/plugin-transform-arrow-functions': 7.7.4_@babel+core@7.7.5
+      '@babel/plugin-transform-async-to-generator': 7.7.4_@babel+core@7.7.5
+      '@babel/plugin-transform-block-scoped-functions': 7.7.4_@babel+core@7.7.5
+      '@babel/plugin-transform-block-scoping': 7.7.4_@babel+core@7.7.5
+      '@babel/plugin-transform-classes': 7.7.4_@babel+core@7.7.5
+      '@babel/plugin-transform-computed-properties': 7.7.4_@babel+core@7.7.5
+      '@babel/plugin-transform-destructuring': 7.7.4_@babel+core@7.7.5
+      '@babel/plugin-transform-dotall-regex': 7.7.4_@babel+core@7.7.5
+      '@babel/plugin-transform-duplicate-keys': 7.7.4_@babel+core@7.7.5
+      '@babel/plugin-transform-exponentiation-operator': 7.7.4_@babel+core@7.7.5
+      '@babel/plugin-transform-for-of': 7.7.4_@babel+core@7.7.5
+      '@babel/plugin-transform-function-name': 7.7.4_@babel+core@7.7.5
+      '@babel/plugin-transform-literals': 7.7.4_@babel+core@7.7.5
+      '@babel/plugin-transform-member-expression-literals': 7.7.4_@babel+core@7.7.5
+      '@babel/plugin-transform-modules-amd': 7.7.5_@babel+core@7.7.5
+      '@babel/plugin-transform-modules-commonjs': 7.7.5_@babel+core@7.7.5
+      '@babel/plugin-transform-modules-systemjs': 7.7.4_@babel+core@7.7.5
+      '@babel/plugin-transform-modules-umd': 7.7.4_@babel+core@7.7.5
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.7.4_@babel+core@7.7.5
+      '@babel/plugin-transform-new-target': 7.7.4_@babel+core@7.7.5
+      '@babel/plugin-transform-object-super': 7.7.4_@babel+core@7.7.5
+      '@babel/plugin-transform-parameters': 7.7.4_@babel+core@7.7.5
+      '@babel/plugin-transform-property-literals': 7.7.4_@babel+core@7.7.5
+      '@babel/plugin-transform-regenerator': 7.7.5_@babel+core@7.7.5
+      '@babel/plugin-transform-reserved-words': 7.7.4_@babel+core@7.7.5
+      '@babel/plugin-transform-shorthand-properties': 7.7.4_@babel+core@7.7.5
+      '@babel/plugin-transform-spread': 7.7.4_@babel+core@7.7.5
+      '@babel/plugin-transform-sticky-regex': 7.7.4_@babel+core@7.7.5
+      '@babel/plugin-transform-template-literals': 7.7.4_@babel+core@7.7.5
+      '@babel/plugin-transform-typeof-symbol': 7.7.4_@babel+core@7.7.5
+      '@babel/plugin-transform-unicode-regex': 7.7.4_@babel+core@7.7.5
+      '@babel/types': 7.7.4
+      browserslist: 4.8.2
+      core-js-compat: 3.4.8
+      invariant: 2.2.4
+      js-levenshtein: 1.1.6
+      semver: 5.7.1
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-k5hO17iF/Q7tR9Jv8PdNBZWYW6RofxhnxKjBMc0nG4JTaWvOTiPoO/RLFwAKcA4FpmuBFm6jkoqaRJLGi0zdaQ==
   /@babel/register/7.7.4_@babel+core@7.7.4:
     dependencies:
       '@babel/core': 7.7.4
@@ -1089,16 +1634,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-/fmONZqL6ZMl9KJUYajetCrID6m0xmL4odX7v+Xvoxcv0DdbP/oO0TWIeLUCHqczQ6L6njDMqmqHFy2cp3FFsA==
-  /@babel/runtime/7.7.4:
+  /@babel/runtime/7.7.6:
     dependencies:
       regenerator-runtime: 0.13.3
     dev: true
     resolution:
-      integrity: sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==
+      integrity: sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==
   /@babel/template/7.7.4:
     dependencies:
       '@babel/code-frame': 7.5.5
-      '@babel/parser': 7.7.4
+      '@babel/parser': 7.7.5
       '@babel/types': 7.7.4
     dev: true
     resolution:
@@ -1109,7 +1654,7 @@ packages:
       '@babel/generator': 7.7.4
       '@babel/helper-function-name': 7.7.4
       '@babel/helper-split-export-declaration': 7.7.4
-      '@babel/parser': 7.7.4
+      '@babel/parser': 7.7.5
       '@babel/types': 7.7.4
       debug: 4.1.1
       globals: 11.12.0
@@ -1239,7 +1784,7 @@ packages:
       integrity: sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
   /@szmarczak/http-timer/1.1.2:
     dependencies:
-      defer-to-connect: 1.1.0
+      defer-to-connect: 1.1.1
     dev: true
     engines:
       node: '>=6'
@@ -1278,7 +1823,7 @@ packages:
     dependencies:
       '@types/events': 3.0.0
       '@types/minimatch': 3.0.3
-      '@types/node': 12.12.14
+      '@types/node': 12.12.16
     dev: true
     resolution:
       integrity: sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==
@@ -1326,6 +1871,10 @@ packages:
   /@types/node/12.12.14:
     resolution:
       integrity: sha512-u/SJDyXwuihpwjXy7hOOghagLEV1KdAST6syfnOk6QZAMzZuWZqXy5aYYZbh8Jdpd4escVFP0MvftHNDb9pruA==
+  /@types/node/12.12.16:
+    dev: true
+    resolution:
+      integrity: sha512-vRuMyoOr5yfNf8QWxXegOjeyjpWJxFePzHzmBOIzDIzo+rSqF94RW0PkS6y4T2+VjAWLXHWrfbIJY3E3aS7lUw==
   /@types/normalize-package-data/2.4.0:
     dev: true
     resolution:
@@ -1349,15 +1898,15 @@ packages:
     dev: true
     resolution:
       integrity: sha512-K8/LfZq2duW33XW/tFwEAfnZlqIfVsoyRB3kfXdPXYhl0nfM8mmh7GS0jg7WrX2Dgq/0Ha/pR1PaR+BvmWwjiQ==
-  /@typescript-eslint/eslint-plugin/2.10.0_5e4c5b4b3611e7f57e1c4733830e94f0:
+  /@typescript-eslint/eslint-plugin/2.11.0_cb180cc210aa77d673b05caf1fc681e5:
     dependencies:
-      '@typescript-eslint/experimental-utils': 2.10.0_typescript@3.7.2
-      '@typescript-eslint/parser': 2.10.0_typescript@3.7.2
+      '@typescript-eslint/experimental-utils': 2.11.0_typescript@3.7.3
+      '@typescript-eslint/parser': 2.11.0_typescript@3.7.3
       eslint-utils: 1.4.3
       functional-red-black-tree: 1.0.1
       regexpp: 3.0.0
-      tsutils: 3.17.1_typescript@3.7.2
-      typescript: 3.7.2
+      tsutils: 3.17.1_typescript@3.7.3
+      typescript: 3.7.3
     dev: true
     engines:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
@@ -1369,11 +1918,11 @@ packages:
       typescript:
         optional: true
     resolution:
-      integrity: sha512-rT51fNLW0u3fnDGnAHVC5nu+Das+y2CpW10yqvf6/j5xbuUV3FxA3mBaIbM24CXODXjbgUznNb4Kg9XZOUxKAw==
-  /@typescript-eslint/experimental-utils/2.10.0_typescript@3.7.2:
+      integrity: sha512-G2HHA1vpMN0EEbUuWubiCCfd0R3a30BB+UdvnFkxwZIxYEGOrWEXDv8tBFO9f44CWc47Xv9lLM3VSn4ORLI2bA==
+  /@typescript-eslint/experimental-utils/2.11.0_typescript@3.7.3:
     dependencies:
       '@types/json-schema': 7.0.3
-      '@typescript-eslint/typescript-estree': 2.10.0_typescript@3.7.2
+      '@typescript-eslint/typescript-estree': 2.11.0_typescript@3.7.3
       eslint-scope: 5.0.0
     dev: true
     engines:
@@ -1382,12 +1931,12 @@ packages:
       eslint: '*'
       typescript: '*'
     resolution:
-      integrity: sha512-FZhWq6hWWZBP76aZ7bkrfzTMP31CCefVIImrwP3giPLcoXocmLTmr92NLZxuIcTL4GTEOE33jQMWy9PwelL+yQ==
-  /@typescript-eslint/parser/2.10.0_typescript@3.7.2:
+      integrity: sha512-YxcA/y0ZJaCc/fB/MClhcDxHI0nOBB7v2/WxBju2cOTanX7jO9ttQq6Fy4yW9UaY5bPd9xL3cun3lDVqk67sPQ==
+  /@typescript-eslint/parser/2.11.0_typescript@3.7.3:
     dependencies:
       '@types/eslint-visitor-keys': 1.0.0
-      '@typescript-eslint/experimental-utils': 2.10.0_typescript@3.7.2
-      '@typescript-eslint/typescript-estree': 2.10.0_typescript@3.7.2
+      '@typescript-eslint/experimental-utils': 2.11.0_typescript@3.7.3
+      '@typescript-eslint/typescript-estree': 2.11.0_typescript@3.7.3
       eslint-visitor-keys: 1.1.0
     dev: true
     engines:
@@ -1396,8 +1945,8 @@ packages:
       eslint: ^5.0.0 || ^6.0.0
       typescript: '*'
     resolution:
-      integrity: sha512-wQNiBokcP5ZsTuB+i4BlmVWq6o+oAhd8en2eSm/EE9m7BgZUIfEeYFd6z3S+T7bgNuloeiHA1/cevvbBDLr98g==
-  /@typescript-eslint/typescript-estree/2.10.0_typescript@3.7.2:
+      integrity: sha512-DyGXeqhb3moMioEFZIHIp7oXBBh7dEfPTzGrlyP0Mi9ScCra4SWEGs3kPd18mG7Sy9Wy8z88zmrw5tSGL6r/6A==
+  /@typescript-eslint/typescript-estree/2.11.0_typescript@3.7.3:
     dependencies:
       debug: 4.1.1
       eslint-visitor-keys: 1.1.0
@@ -1405,8 +1954,8 @@ packages:
       is-glob: 4.0.1
       lodash.unescape: 4.0.1
       semver: 6.3.0
-      tsutils: 3.17.1_typescript@3.7.2
-      typescript: 3.7.2
+      tsutils: 3.17.1_typescript@3.7.3
+      typescript: 3.7.3
     dev: true
     engines:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
@@ -1416,7 +1965,7 @@ packages:
       typescript:
         optional: true
     resolution:
-      integrity: sha512-oOYnplddQNm/LGVkqbkAwx4TIBuuZ36cAQq9v3nFIU9FmhemHuVzAesMSXNQDdAzCa5bFgCrfD3JWhYVKlRN2g==
+      integrity: sha512-HGY4+d4MagO6cKMcKfIKaTMxcAv7dEVnji2Zi+vi5VV8uWAM631KjAB5GxFcexMYrwKT0EekRiiGK1/Sd7VFGA==
   /acorn-dynamic-import/4.0.0_acorn@6.4.0:
     dependencies:
       acorn: 6.4.0
@@ -1600,6 +2149,12 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==
+  /arr-union/3.1.0:
+    dev: false
+    engines:
+      node: '>=0.10.0'
+    resolution:
+      integrity: sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
   /array-find-index/1.0.2:
     dev: true
     engines:
@@ -1613,7 +2168,7 @@ packages:
   /array-includes/3.0.3:
     dependencies:
       define-properties: 1.1.3
-      es-abstract: 1.16.2
+      es-abstract: 1.16.3
     dev: true
     engines:
       node: '>= 0.4'
@@ -1645,6 +2200,16 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-bdHxtev7FN6+MXI1YFW0Q8mQ8dTJc2S8AMfju+ZR77pbg2yAdVyDlwkaUI7Har0LyOMRFPHrJ9lYdyjZZswdlQ==
+  /array.prototype.flat/1.2.2:
+    dependencies:
+      define-properties: 1.1.3
+      es-abstract: 1.16.3
+      function-bind: 1.1.1
+    dev: true
+    engines:
+      node: '>= 0.4'
+    resolution:
+      integrity: sha512-VXjh7lAL4KXKF2hY4FnEW9eRW6IhdvFW1sN/JwLbmECbCgACCnBHNyP3lFiYuttr0jxRN9Bsc5+G27dMseSWqQ==
   /arrify/1.0.1:
     dev: true
     engines:
@@ -1663,11 +2228,23 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
+  /astral-regex/2.0.0:
+    dev: true
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
+  /async-array-reduce/0.2.1:
+    dev: false
+    engines:
+      node: '>=0.10.0'
+    resolution:
+      integrity: sha1-yL4BCitc0A3qlsgRFgNGk9/dgtE=
   /ava/2.4.0:
     dependencies:
-      '@ava/babel-preset-stage-4': 4.0.0_@babel+core@7.7.4
+      '@ava/babel-preset-stage-4': 4.0.0_@babel+core@7.7.5
       '@ava/babel-preset-transform-test-files': 6.0.0
-      '@babel/core': 7.7.4
+      '@babel/core': 7.7.5
       '@babel/generator': 7.7.4
       '@concordance/react': 2.0.0
       ansi-escapes: 4.3.0
@@ -1684,7 +2261,7 @@ packages:
       clean-stack: 2.2.0
       clean-yaml-object: 0.1.0
       cli-cursor: 3.1.0
-      cli-truncate: 2.0.0
+      cli-truncate: 2.1.0
       code-excerpt: 2.1.1
       common-path-prefix: 1.0.0
       concordance: 4.0.0
@@ -1753,9 +2330,9 @@ packages:
   /babel-plugin-espower/3.0.1:
     dependencies:
       '@babel/generator': 7.7.4
-      '@babel/parser': 7.7.4
+      '@babel/parser': 7.7.5
       call-matcher: 1.1.0
-      core-js: 2.6.10
+      core-js: 2.6.11
       espower-location-detector: 1.0.0
       espurify: 1.8.1
       estraverse: 4.3.0
@@ -1763,7 +2340,6 @@ packages:
     resolution:
       integrity: sha512-Ms49U7VIAtQ/TtcqRbD6UBmJBUCSxiC3+zPc+eGqxKUIFO1lTshyEDRUjhoAbd2rWfwYf3cZ62oXozrd8W6J0A==
   /balanced-match/1.0.0:
-    dev: true
     resolution:
       integrity: sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
   /big.js/3.2.0:
@@ -1807,7 +2383,6 @@ packages:
     dependencies:
       balanced-match: 1.0.0
       concat-map: 0.0.1
-    dev: true
     resolution:
       integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
   /braces/3.0.2:
@@ -1827,6 +2402,15 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-HYnxc/oLRWvJ3TsGegR0SRL/UDnknGq2s/a8dYYEO+kOQ9m9apKoS5oiathLKZdh/e9uE+/J3j92qPlGD/vTqA==
+  /browserslist/4.8.2:
+    dependencies:
+      caniuse-lite: 1.0.30001015
+      electron-to-chromium: 1.3.322
+      node-releases: 1.1.42
+    dev: true
+    hasBin: true
+    resolution:
+      integrity: sha512-+M4oeaTplPm/f1pXDw84YohEv7B1i/2Aisei8s4s6k3QsoSHa7i5sz8u/cGQkkatCPxMASKxPualR4wwYgVboA==
   /buble/0.10.7:
     dependencies:
       acorn: 3.3.0
@@ -1888,7 +2472,7 @@ packages:
       integrity: sha512-Mtgcv3lh3U0zRii/6qVgQODdPA4G3zhG+jtbCWj39RXuUFTMzH0vcdMtaJS1jPowd+It2Pqr6y3NJMQqOqCE2w==
   /call-matcher/1.1.0:
     dependencies:
-      core-js: 2.6.10
+      core-js: 2.6.11
       deep-equal: 1.1.1
       espurify: 1.8.1
       estraverse: 4.3.0
@@ -1964,6 +2548,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-hOAXaWKuq/UVFgYawxIOdPdyMQdYcwOCDOjnZcKn7wCgFUrhP7smuNZjGLuJlPSgE6aRA4cRJ+bGSrhtEt7ZAg==
+  /caniuse-lite/1.0.30001015:
+    dev: true
+    resolution:
+      integrity: sha512-/xL2AbW/XWHNu1gnIrO8UitBGoFthcsDgU9VLK1/dpsoxbaD5LscHozKze05R6WLsBvLhqv78dAPozMFQBYLbQ==
   /chalk/1.1.3:
     dependencies:
       ansi-styles: 2.2.1
@@ -2066,15 +2654,15 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=
-  /cli-truncate/2.0.0:
+  /cli-truncate/2.1.0:
     dependencies:
-      slice-ansi: 2.1.0
+      slice-ansi: 3.0.0
       string-width: 4.2.0
     dev: true
     engines:
       node: '>=8'
     resolution:
-      integrity: sha512-C4hp+8GCIFVsUUiXcw+ce+7wexVWImw8rQrgMBFsqerx9LvvcGlwm6sMjQYAEmV/Xb87xc1b5Ttx505MSpZVqg==
+      integrity: sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==
   /cli-width/2.2.0:
     dev: true
     resolution:
@@ -2125,7 +2713,7 @@ packages:
       integrity: sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
   /codecov-lite/0.3.1:
     dependencies:
-      '@babel/runtime': 7.7.4
+      '@babel/runtime': 7.7.6
       got: 9.6.0
     dev: true
     engines:
@@ -2179,7 +2767,6 @@ packages:
     resolution:
       integrity: sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
   /concat-map/0.0.1:
-    dev: true
     resolution:
       integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
   /concat-with-sourcemaps/1.1.0:
@@ -2244,12 +2831,19 @@ packages:
     dev: true
     resolution:
       integrity: sha512-57+mgz/P/xsGdjwQYkwtBZR3LuISaxD1dEwVDtbk8xJMqAmwqaxLOvnNT7kdJ7jYE/NjNptyzXi+IQFMi/2fCw==
-  /core-js/2.6.10:
-    deprecated: 'core-js@<3.0 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.'
+  /core-js-compat/3.4.8:
+    dependencies:
+      browserslist: 4.8.2
+      semver: 6.3.0
+    dev: true
+    resolution:
+      integrity: sha512-l3WTmnXHV2Sfu5VuD7EHE2w7y+K68+kULKt5RJg8ZJk3YhHF1qLD4O8v8AmNq+8vbOwnPFFDvds25/AoEvMqlQ==
+  /core-js/2.6.11:
+    deprecated: 'core-js@<3 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.'
     dev: true
     requiresBuild: true
     resolution:
-      integrity: sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==
+      integrity: sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
   /cosmiconfig/5.2.1:
     dependencies:
       import-fresh: 2.0.0
@@ -2580,10 +3174,10 @@ packages:
     dev: true
     resolution:
       integrity: sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=
-  /defer-to-connect/1.1.0:
+  /defer-to-connect/1.1.1:
     dev: true
     resolution:
-      integrity: sha512-WE2sZoctWm/v4smfCAdjYbrfS55JiMRdlY9ZubFhsYbteCK9+BvAx4YV7nPjYM6ZnX5BcoVKwfmyx9sIFTgQMQ==
+      integrity: sha512-J7thop4u3mRTkYRQ+Vpfwy2G5Ehoy82I14+14W4YMDLKdWloI9gSzRbV30s/NckQGVJtPkWNcW4oMAUigTdqiQ==
   /define-properties/1.1.3:
     dependencies:
       object-keys: 1.1.1
@@ -2749,7 +3343,7 @@ packages:
   /empower-core/1.2.0:
     dependencies:
       call-signature: 0.0.2
-      core-js: 2.6.10
+      core-js: 2.6.11
     dev: true
     resolution:
       integrity: sha512-g6+K6Geyc1o6FdXs9HwrXleCFan7d66G5xSCfSF7x1mJDCes6t0om9lFQG3zOrzh3Bkb/45N0cZ5Gqsf7YrzGQ==
@@ -2792,6 +3386,23 @@ packages:
       node: '>= 0.4'
     resolution:
       integrity: sha512-jYo/J8XU2emLXl3OLwfwtuFfuF2w6DYPs+xy9ZfVyPkDcrauu6LYrw/q2TyCtrbc/KUdCiC5e9UajRhgNkVopA==
+  /es-abstract/1.16.3:
+    dependencies:
+      es-to-primitive: 1.2.1
+      function-bind: 1.1.1
+      has: 1.0.3
+      has-symbols: 1.0.1
+      is-callable: 1.1.4
+      is-regex: 1.0.4
+      object-inspect: 1.7.0
+      object-keys: 1.1.1
+      string.prototype.trimleft: 2.1.0
+      string.prototype.trimright: 2.1.0
+    dev: true
+    engines:
+      node: '>= 0.4'
+    resolution:
+      integrity: sha512-WtY7Fx5LiOnSYgF5eg/1T+GONaGmpvpPdCpSnYij+U2gDTL0UPfWrhDw7b2IYb+9NQJsYpCA0wOQvZfsd6YwRw==
   /es-to-primitive/1.2.1:
     dependencies:
       is-callable: 1.1.4
@@ -2843,7 +3454,7 @@ packages:
   /eslint-config-rollup/0.1.0:
     dependencies:
       eslint: 6.7.2
-      eslint-plugin-import: 2.18.2_eslint@6.7.2
+      eslint-plugin-import: 2.19.1_eslint@6.7.2
       eslint-plugin-prettier: 3.1.1_eslint@6.7.2+prettier@1.19.1
       prettier: 1.19.1
     dev: true
@@ -2858,7 +3469,7 @@ packages:
     dev: true
     resolution:
       integrity: sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==
-  /eslint-module-utils/2.4.1:
+  /eslint-module-utils/2.5.0:
     dependencies:
       debug: 2.6.9
       pkg-dir: 2.0.0
@@ -2866,16 +3477,17 @@ packages:
     engines:
       node: '>=4'
     resolution:
-      integrity: sha512-H6DOj+ejw7Tesdgbfs4jeS4YMFrT8uI8xwd1gtQqXssaR0EQ26L+2O/w6wkYFy2MymON0fTwHmXBvvfLNZVZEw==
-  /eslint-plugin-import/2.18.2_eslint@6.7.2:
+      integrity: sha512-kCo8pZaNz2dsAW7nCUjuVoI11EBXXpIzfNxmaoLhXoRDOnqXLC4iSGVRdZPhOitfbdEfMEfKOiENaK6wDPZEGw==
+  /eslint-plugin-import/2.19.1_eslint@6.7.2:
     dependencies:
       array-includes: 3.0.3
+      array.prototype.flat: 1.2.2
       contains-path: 0.1.0
       debug: 2.6.9
       doctrine: 1.5.0
       eslint: 6.7.2
       eslint-import-resolver-node: 0.3.2
-      eslint-module-utils: 2.4.1
+      eslint-module-utils: 2.5.0
       has: 1.0.3
       minimatch: 3.0.4
       object.values: 1.1.0
@@ -2887,7 +3499,7 @@ packages:
     peerDependencies:
       eslint: 2.x - 6.x
     resolution:
-      integrity: sha512-5ohpsHAiUBRNaBWAF08izwUGlbrJoJJ+W9/TBwsGoR1MnlgfwMIKrFeSjWbt6moabiXW9xNvtFz+97KHRfI4HQ==
+      integrity: sha512-x68131aKoCZlCae7rDXKSAQmbT5DQuManyXo2sK6fJJ0aK5CWAkv6A6HJZGgqC8IhjQxYPgo6/IY4Oz8AFsbBw==
   /eslint-plugin-prettier/3.1.1_eslint@6.7.2+prettier@1.19.1:
     dependencies:
       eslint: 6.7.2
@@ -3002,7 +3614,7 @@ packages:
       integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
   /espurify/1.8.1:
     dependencies:
-      core-js: 2.6.10
+      core-js: 2.6.11
     dev: true
     resolution:
       integrity: sha512-ZDko6eY/o+D/gHCWyHTU85mKDgYcS4FJj7S+YD6WIInm7GQ6AnOjmcL4+buFV/JOztVLELi/7MmuGU5NHta0Mg==
@@ -3089,6 +3701,14 @@ packages:
       node: ^8.12.0 || >=9.7.0
     resolution:
       integrity: sha512-Y/URAVapfbYy2Xp/gb6A0E7iR8xeqOCXsuuaoMn7A5PzrXUK84E1gyiEfq0wQd/GHA6GsoHWwhNq8anb0mleIw==
+  /expand-tilde/2.0.2:
+    dependencies:
+      homedir-polyfill: 1.0.3
+    dev: false
+    engines:
+      node: '>=0.10.0'
+    resolution:
+      integrity: sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=
   /ext/1.4.0:
     dependencies:
       type: 2.0.0
@@ -3241,7 +3861,6 @@ packages:
     resolution:
       integrity: sha1-T9ca0t/elnibmApcCilZN8svXOk=
   /fs.realpath/1.0.0:
-    dev: true
     resolution:
       integrity: sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
   /fsevents/2.1.2:
@@ -3271,10 +3890,10 @@ packages:
       node: 6.* || 8.* || >= 10.*
     resolution:
       integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
-  /get-own-enumerable-property-symbols/3.0.1:
+  /get-own-enumerable-property-symbols/3.0.2:
     dev: true
     resolution:
-      integrity: sha512-09/VS4iek66Dh2bctjRkowueRJbY1JDGR1L/zRxO1Qk8Uxs6PnqaNSqalpizPT+CDjre3hnEsuzvhgomz9qYrA==
+      integrity: sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==
   /get-port/5.0.0:
     dependencies:
       type-fest: 0.3.1
@@ -3327,7 +3946,6 @@ packages:
       minimatch: 3.0.4
       once: 1.4.0
       path-is-absolute: 1.0.1
-    dev: true
     resolution:
       integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
   /global-dirs/0.1.1:
@@ -3338,6 +3956,28 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=
+  /global-modules/1.0.0:
+    dependencies:
+      global-prefix: 1.0.2
+      is-windows: 1.0.2
+      resolve-dir: 1.0.1
+    dev: false
+    engines:
+      node: '>=0.10.0'
+    resolution:
+      integrity: sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==
+  /global-prefix/1.0.2:
+    dependencies:
+      expand-tilde: 2.0.2
+      homedir-polyfill: 1.0.3
+      ini: 1.3.5
+      is-windows: 1.0.2
+      which: 1.3.1
+    dev: false
+    engines:
+      node: '>=0.10.0'
+    resolution:
+      integrity: sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=
   /globals/11.12.0:
     dev: true
     engines:
@@ -3411,7 +4051,7 @@ packages:
       node: '>=0.4.7'
     hasBin: true
     optionalDependencies:
-      uglify-js: 3.7.1
+      uglify-js: 3.7.2
     resolution:
       integrity: sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==
   /has-ansi/2.0.0:
@@ -3439,6 +4079,14 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+  /has-glob/1.0.0:
+    dependencies:
+      is-glob: 3.1.0
+    dev: false
+    engines:
+      node: '>=0.10.0'
+    resolution:
+      integrity: sha1-mqqe7b/7G6OZCnsAEPtnjuAIEgc=
   /has-symbols/1.0.1:
     dev: true
     engines:
@@ -3480,6 +4128,14 @@ packages:
     dev: true
     resolution:
       integrity: sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
+  /homedir-polyfill/1.0.3:
+    dependencies:
+      parse-passwd: 1.0.0
+    dev: false
+    engines:
+      node: '>=0.10.0'
+    resolution:
+      integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==
   /hosted-git-info/2.8.5:
     dev: true
     resolution:
@@ -3624,15 +4280,12 @@ packages:
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
-    dev: true
     resolution:
       integrity: sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=
   /inherits/2.0.4:
-    dev: true
     resolution:
       integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
   /ini/1.3.5:
-    dev: true
     resolution:
       integrity: sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
   /inquirer/7.0.0:
@@ -3736,7 +4389,6 @@ packages:
     resolution:
       integrity: sha512-IOQqts/aHWbiisY5DuPJQ0gcbvaLFCa7fBa9xoLfxBZvQ+ZI/Zh9xoI7Gk+G64N0FdK4AbibytHht2tWgpJWLg==
   /is-extglob/2.1.1:
-    dev: true
     engines:
       node: '>=0.10.0'
     resolution:
@@ -3761,6 +4413,14 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
+  /is-glob/3.1.0:
+    dependencies:
+      is-extglob: 2.1.1
+    dev: false
+    engines:
+      node: '>=0.10.0'
+    resolution:
+      integrity: sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=
   /is-glob/4.0.1:
     dependencies:
       is-extglob: 2.1.1
@@ -3937,6 +4597,18 @@ packages:
     dev: true
     resolution:
       integrity: sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
+  /is-valid-glob/1.0.0:
+    dev: false
+    engines:
+      node: '>=0.10.0'
+    resolution:
+      integrity: sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao=
+  /is-windows/1.0.2:
+    dev: false
+    engines:
+      node: '>=0.10.0'
+    resolution:
+      integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
   /is-yarn-global/0.3.0:
     dev: true
     resolution:
@@ -3950,7 +4622,6 @@ packages:
     resolution:
       integrity: sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
   /isexe/2.0.0:
-    dev: true
     resolution:
       integrity: sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
   /isobject/4.0.0:
@@ -3976,7 +4647,7 @@ packages:
   /istanbul-lib-instrument/3.3.0:
     dependencies:
       '@babel/generator': 7.7.4
-      '@babel/parser': 7.7.4
+      '@babel/parser': 7.7.5
       '@babel/template': 7.7.4
       '@babel/traverse': 7.7.4
       '@babel/types': 7.7.4
@@ -4451,6 +5122,19 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-plzSkIepJZi4eRJXpSPgISIqwfk=
+  /matched/1.0.2:
+    dependencies:
+      arr-union: 3.1.0
+      async-array-reduce: 0.2.1
+      glob: 7.1.6
+      has-glob: 1.0.0
+      is-valid-glob: 1.0.0
+      resolve-dir: 1.0.1
+    dev: false
+    engines:
+      node: '>= 0.12.0'
+    resolution:
+      integrity: sha512-7ivM1jFZVTOOS77QsR+TtYHH0ecdLclMkqbf5qiJdX2RorqfhsL65QHySPZgDE0ZjHoh+mQUNHTanNXIlzXd0Q==
   /matcher/2.1.0:
     dependencies:
       escape-string-regexp: 2.0.0
@@ -4552,7 +5236,6 @@ packages:
   /minimatch/3.0.4:
     dependencies:
       brace-expansion: 1.1.11
-    dev: true
     resolution:
       integrity: sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
   /minimist-options/3.0.2:
@@ -4640,6 +5323,12 @@ packages:
     dev: true
     resolution:
       integrity: sha512-+IctMa7wIs8Cfsa8iYzeaLTFwv5Y4r5jZud+4AnfymzeEXKBCavFX0KBgzVaPVqf0ywa6PrO8/b+bPqdwjGBSg==
+  /node-releases/1.1.42:
+    dependencies:
+      semver: 6.3.0
+    dev: true
+    resolution:
+      integrity: sha512-OQ/ESmUqGawI2PRX+XIRao44qWYBBfN54ImQYdWVTQqUckuejOg76ysSqDBK8NG3zwySRVnX36JwDQ6x+9GxzA==
   /normalize-package-data/2.5.0:
     dependencies:
       hosted-git-info: 2.8.5
@@ -4773,7 +5462,7 @@ packages:
   /object.values/1.1.0:
     dependencies:
       define-properties: 1.1.3
-      es-abstract: 1.16.2
+      es-abstract: 1.16.3
       function-bind: 1.1.1
       has: 1.0.3
     dev: true
@@ -4793,7 +5482,6 @@ packages:
   /once/1.4.0:
     dependencies:
       wrappy: 1.0.2
-    dev: true
     resolution:
       integrity: sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
   /onetime/2.0.1:
@@ -5033,6 +5721,12 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==
+  /parse-passwd/1.0.0:
+    dev: false
+    engines:
+      node: '>=0.10.0'
+    resolution:
+      integrity: sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=
   /path-exists/3.0.0:
     dev: true
     engines:
@@ -5046,7 +5740,6 @@ packages:
     resolution:
       integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
   /path-is-absolute/1.0.1:
-    dev: true
     engines:
       node: '>=0.10.0'
     resolution:
@@ -5887,6 +6580,15 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==
+  /resolve-dir/1.0.1:
+    dependencies:
+      expand-tilde: 2.0.2
+      global-modules: 1.0.0
+    dev: false
+    engines:
+      node: '>=0.10.0'
+    resolution:
+      integrity: sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=
   /resolve-from/3.0.0:
     dev: true
     engines:
@@ -5975,6 +6677,18 @@ packages:
       '@babel/core': 7.7.4
       '@babel/helper-module-imports': 7.7.4
       rollup: 1.27.8
+      rollup-pluginutils: 2.8.2
+    dev: true
+    peerDependencies:
+      '@babel/core': 7 || ^7.0.0-rc.2
+      rollup: '>=0.60.0 <2'
+    resolution:
+      integrity: sha512-tKzWOCmIJD/6aKNz0H1GMM+lW1q9KyFubbWzGiOG540zxPPifnEAHTZwjo0g991Y+DyOZcLqBgqOdqazYE5fkw==
+  /rollup-plugin-babel/4.3.3_@babel+core@7.7.5+rollup@1.27.9:
+    dependencies:
+      '@babel/core': 7.7.5
+      '@babel/helper-module-imports': 7.7.4
+      rollup: 1.27.9
       rollup-pluginutils: 2.8.2
     dev: true
     peerDependencies:
@@ -6110,6 +6824,15 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-EVoEV5rAWl+5clnGznt1KY8PeVkzVQh/R0d2s3gHEkN7gfoyC4JmvIVuCtPbYE8NM5Ep/g+nAmvKXBjzaqTsHA==
+  /rollup/1.27.9:
+    dependencies:
+      '@types/estree': 0.0.40
+      '@types/node': 12.12.16
+      acorn: 7.1.0
+    dev: true
+    hasBin: true
+    resolution:
+      integrity: sha512-8AfW4cJTPZfG6EXWwT/ujL4owUsDI1Xl8J1t+hvK4wDX81F5I4IbwP9gvGbHzxnV19fnU4rRABZQwZSX9J402Q==
   /run-async/2.3.0:
     dependencies:
       is-promise: 2.1.0
@@ -6255,6 +6978,16 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==
+  /slice-ansi/3.0.0:
+    dependencies:
+      ansi-styles: 4.2.0
+      astral-regex: 2.0.0
+      is-fullwidth-code-point: 3.0.0
+    dev: true
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==
   /source-map-support/0.5.16:
     dependencies:
       buffer-from: 1.1.1
@@ -6402,7 +7135,7 @@ packages:
       integrity: sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==
   /stringify-object/3.3.0:
     dependencies:
-      get-own-enumerable-property-symbols: 3.0.1
+      get-own-enumerable-property-symbols: 3.0.2
       is-obj: 1.0.1
       is-regexp: 1.0.0
     dev: true
@@ -6676,13 +7409,13 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
-  /ts-node/8.5.4_typescript@3.7.2:
+  /ts-node/8.5.4_typescript@3.7.3:
     dependencies:
       arg: 4.1.2
       diff: 4.0.1
       make-error: 1.3.5
       source-map-support: 0.5.16
-      typescript: 3.7.2
+      typescript: 3.7.3
       yn: 3.1.1
     dev: true
     engines:
@@ -6705,10 +7438,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
-  /tsutils/3.17.1_typescript@3.7.2:
+  /tsutils/3.17.1_typescript@3.7.3:
     dependencies:
       tslib: 1.10.0
-      typescript: 3.7.2
+      typescript: 3.7.3
     dev: true
     engines:
       node: '>= 6'
@@ -6769,7 +7502,14 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==
-  /uglify-js/3.7.1:
+  /typescript/3.7.3:
+    dev: true
+    engines:
+      node: '>=4.2.0'
+    hasBin: true
+    resolution:
+      integrity: sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
+  /uglify-js/3.7.2:
     dependencies:
       commander: 2.20.3
       source-map: 0.6.1
@@ -6779,7 +7519,7 @@ packages:
     hasBin: true
     optional: true
     resolution:
-      integrity: sha512-pnOF7jY82wdIhATVn87uUY/FHU+MDUdPLkmGFvGoclQmeu229eTkbG5gjGGBi3R7UuYYSEeYXY/TTY5j2aym2g==
+      integrity: sha512-uhRwZcANNWVLrxLfNFEdltoPNhECUR3lc+UdJoG9CBpMcSnKyWA94tc3eAujB1GcMY5Uwq8ZMp4qWpxWYDQmaA==
   /uid2/0.0.3:
     dev: true
     resolution:
@@ -6920,7 +7660,6 @@ packages:
   /which/1.3.1:
     dependencies:
       isexe: 2.0.0
-    dev: true
     hasBin: true
     resolution:
       integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
@@ -6973,7 +7712,6 @@ packages:
     resolution:
       integrity: sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==
   /wrappy/1.0.2:
-    dev: true
     resolution:
       integrity: sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
   /write-file-atomic/2.4.3:
@@ -7023,7 +7761,7 @@ packages:
       integrity: sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
   /yaml/1.7.2:
     dependencies:
-      '@babel/runtime': 7.7.4
+      '@babel/runtime': 7.7.6
     dev: true
     engines:
       node: '>= 6'


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `multi-entry`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [x] yes (_breaking changes will not be merged unless absolutely necessary_)
- [ ] no

List any relevant issue numbers:

### Description

Migrates `rollup-plugin-multi-entry`.

#### Breaking Changes

- Minimum Rollup version ^1.20.0
- Changes entry tag