### PR TITLE
Add typings to `run`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This repository houses plugins that Rollup considers critical to every day use o
 | [multi-entry](packages/multi-entry)   | Use multiple entry points for a bundle                                                    |
 | [node-resolve](packages/node-resolve) | Locate and bundle third-party dependencies in node_modules                                |
 | [replace](packages/replace)           | Replace strings in files while bundling                                                   |
+| [run](packages/run)                   | Run your bundles in Node once they're built                                               |
 | [strip](packages/strip)               | Remove debugger statements and functions like assert.equal and console.log from your code |
 | [sucrase](packages/sucrase)           | Compile TypeScript, Flow, JSX, etc with Sucrase                                           |
 | [typescript](packages/typescript)     | Integration between Rollup and Typescript                                                 |

--- a/packages/run/index.d.ts
+++ b/packages/run/index.d.ts
@@ -1,13 +1,8 @@
+import { ForkOptions } from 'child_process'
 import { Plugin } from 'rollup'
-
-interface RollupRunOptions {
-  /**
-   * Pass options through to `child_process.fork(...)`
-   */
-  execArgv?: string[]
-}
 
 /**
  * Run your bundles in Node once they're built
+ * @param options These are passed through to `child_process.fork(..)`
  */
-export default function run(options?: RollupRunOptions): Plugin
+export default function run(options?: ForkOptions): Plugin

--- a/packages/run/index.d.ts
+++ b/packages/run/index.d.ts
@@ -1,0 +1,13 @@
+import { Plugin } from 'rollup'
+
+interface RollupRunOptions {
+  /**
+   * Pass options through to `child_process.fork(...)`
+   */
+  execArgv?: string[]
+}
+
+/**
+ * Run your bundles in Node once they're built
+ */
+export default function run(options?: RollupRunOptions): Plugin

--- a/packages/run/package.json
+++ b/packages/run/package.json
@@ -24,6 +24,7 @@
     "test": "ava"
   },
   "files": [
+    "index.d.ts",
     "lib"
   ],
   "keywords": [

--- a/packages/run/package.json
+++ b/packages/run/package.json
@@ -36,6 +36,7 @@
     "rollup": "^1.20.0"
   },
   "devDependencies": {
+    "@types/node": "^12.12.22",
     "del": "^5.1.0",
     "rollup": "^1.20.0",
     "sinon": "^7.5.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -323,10 +323,12 @@ importers:
       typescript: ^3.4.3
   packages/run:
     devDependencies:
+      '@types/node': 12.12.22
       del: 5.1.0
       rollup: 1.27.8
       sinon: 7.5.0
     specifiers:
+      '@types/node': ^12.12.22
       del: ^5.1.0
       rollup: ^1.20.0
       sinon: ^7.5.0
@@ -2004,6 +2006,10 @@ packages:
   /@types/node/12.12.21:
     resolution:
       integrity: sha512-8sRGhbpU+ck1n0PGAUgVrWrWdjSW2aqNeyC15W88GRsMpSwzv6RJGlLhE7s2RhVSOdyDmxbqlWSeThq4/7xqlA==
+  /@types/node/12.12.22:
+    dev: true
+    resolution:
+      integrity: sha512-r5i93jqbPWGXYXxianGATOxTelkp6ih/U0WVnvaqAvTqM+0U6J3kw6Xk6uq/dWNRkEVw/0SLcO5ORXbVNz4FMQ==
   /@types/normalize-package-data/2.4.0:
     dev: true
     resolution:


### PR DESCRIPTION
## Rollup Plugin Name: `run`

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

### Description
Adds TypeScript types for the `@rollup/plugin-run` plugin, as well as links to it from the README.