### PR TITLE
chore: fix minimum Rollup version in several changelogs

### DIFF
--- a/packages/commonjs/CHANGELOG.md
+++ b/packages/commonjs/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 _2019-12-13_
 
-- **Breaking:** Minimum compatible Rollup version is 1.2.0
+- **Breaking:** Minimum compatible Rollup version is 1.20.0
 - **Breaking:** Minimum supported Node version is 8.0.0
 - Published as @rollup/plugin-commonjs
 

--- a/packages/image/CHANGELOG.md
+++ b/packages/image/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.0.0
 
-- **Breaking:** Minimum compatible Rollup version is 1.2.0
+- **Breaking:** Minimum compatible Rollup version is 1.20.0
 - **Breaking:** Minimum supported Node version is 8.0.0
 - **Breaking:** Plugin will generate a `const` variable for exporting the image by default. To obtain the old default functionality, use the `dom: true` option.
 - Published under @rollup/plugins-image

--- a/packages/legacy/CHANGELOG.md
+++ b/packages/legacy/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 _2019-11-24_
 
-- **Breaking:** Minimum compatible Rollup version is 1.2.0
+- **Breaking:** Minimum compatible Rollup version is 1.20.0
 - **Breaking:** Minimum supported Node version is 8.0.0
 - Published under @rollup/plugins-legacy
 

--- a/packages/node-resolve/CHANGELOG.md
+++ b/packages/node-resolve/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 _2019-11-25_
 
-- **Breaking:** Minimum compatible Rollup version is 1.2.0
+- **Breaking:** Minimum compatible Rollup version is 1.20.0
 - **Breaking:** Minimum supported Node version is 8.0.0
 - Published as @rollup/plugin-node-resolve
 

--- a/packages/pluginutils/CHANGELOG.md
+++ b/packages/pluginutils/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 _2019-11-25_
 
-- **Breaking:** Minimum compatible Rollup version is 1.2.0
+- **Breaking:** Minimum compatible Rollup version is 1.20.0
 - **Breaking:** Minimum supported Node version is 8.0.0
 - Published as @rollup/plugins-image
 

--- a/packages/sucrase/CHANGELOG.md
+++ b/packages/sucrase/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 _2019-12-??_
 
-- **Breaking:** Minimum compatible Rollup version is 1.2.0
+- **Breaking:** Minimum compatible Rollup version is 1.20.0
 - **Breaking:** Minimum supported Node version is 8.0.0
 - Published as @rollup/plugin-sucrase
 - Fix: correctly pass `enableLegacyBabel5ModuleInterop` option to Sucrase

--- a/packages/typescript/CHANGELOG.md
+++ b/packages/typescript/CHANGELOG.md
@@ -10,7 +10,7 @@ _2019-12-04_
 
 _2019-11-25_
 
-- **Breaking:** Minimum compatible Rollup version is 1.2.0
+- **Breaking:** Minimum compatible Rollup version is 1.20.0
 - **Breaking:** Minimum supported Node version is 8.0.0
 - Published as @rollup/plugin-typescript
 

--- a/packages/url/CHANGELOG.md
+++ b/packages/url/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 _2019-11-25_
 
-- **Breaking:** Minimum compatible Rollup version is 1.2.0
+- **Breaking:** Minimum compatible Rollup version is 1.20.0
 - **Breaking:** Minimum supported Node version is 8.0.0
 - Published as @rollup/plugins-url
 

--- a/packages/virtual/CHANGELOG.md
+++ b/packages/virtual/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.0.0
 
-- **Breaking:** Minimum compatible Rollup version is 1.2.0
+- **Breaking:** Minimum compatible Rollup version is 1.20.0
 - **Breaking:** Minimum supported Node version is 8.0.0
 - Published under @rollup/plugins-virtual
 


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `commonjs`, `image`, `legacy`, `node-resolve`, `pluginutils`, `sucrase`, `typescript`, `url`, `virtual`.

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

A bunch of changelogs list '1.2.0' as the new minimum Rollup version, when they should say '1.20.0'.