### PR TITLE
Fix default include option regex

### DIFF
--- a/packages/strip/src/index.js
+++ b/packages/strip/src/index.js
@@ -32,8 +32,7 @@ function flatten(node) {
 }
 
 export default function strip(options = {}) {
-  const include = options.include || '**/*.js';
-  const { exclude } = options;
+  const { include, exclude } = options;
   const filter = createFilter(include, exclude);
   const sourceMap = options.sourceMap !== false;
 


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: strip

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
#128

### Description
Default include did not match relative module ids. Module ids are not always resolved when invoking the transformation step (e.g. when using the alias plugin). Leaving the default include undefined leads to a consistent behavior.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
