### PR TITLE
fix(typescript): Use this.warn for ts errors

### DIFF
--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -1,92 +1,68 @@
 import * as fs from 'fs';
 
-import { Plugin } from 'rollup';
-import * as ts from 'typescript';
 import { createFilter } from '@rollup/pluginutils';
 import resolveId from 'resolve';
+import { Plugin } from 'rollup';
+import * as defaultTs from 'typescript';
 
 import { RollupTypescriptOptions } from '../types';
 
-import { getDefaultOptions, readTsConfig, adjustCompilerOptions } from './options';
+import {
+  adjustCompilerOptions,
+  getDefaultOptions,
+  parseCompilerOptions,
+  readTsConfig,
+  validateModuleType
+} from './options';
 import resolveHost from './resolveHost';
 
 const TSLIB_ID = '\0tslib';
 
 export default function typescript(options: RollupTypescriptOptions = {}): Plugin {
-  let opts = Object.assign({}, options);
+  const opts = Object.assign({}, options);
 
   const filter = createFilter(
     opts.include || ['*.ts+(|x)', '**/*.ts+(|x)'],
     opts.exclude || ['*.d.ts', '**/*.d.ts']
   );
-
   delete opts.include;
   delete opts.exclude;
 
   // Allow users to override the TypeScript version used for transpilation and tslib version used for helpers.
-  const tsRuntime: typeof import('typescript') = opts.typescript || ts;
+  const ts: typeof import('typescript') = opts.typescript || defaultTs;
+  delete opts.typescript;
+
   const tslib =
     opts.tslib ||
     fs.readFileSync(resolveId.sync('tslib/tslib.es6.js', { basedir: __dirname }), 'utf-8');
-
-  delete opts.typescript;
   delete opts.tslib;
 
   // Load options from `tsconfig.json` unless explicitly asked not to.
   const tsConfig =
-    opts.tsconfig === false ? { compilerOptions: {} } : readTsConfig(tsRuntime, opts.tsconfig);
-
+    opts.tsconfig === false ? { compilerOptions: {} } : readTsConfig(ts, opts.tsconfig);
   delete opts.tsconfig;
 
   // Since the CompilerOptions aren't designed for the Rollup
   // use case, we'll adjust them for use with Rollup.
   tsConfig.compilerOptions = adjustCompilerOptions(tsConfig.compilerOptions);
-  opts = adjustCompilerOptions(opts);
 
-  opts = Object.assign(tsConfig.compilerOptions, getDefaultOptions(), opts);
+  Object.assign(tsConfig.compilerOptions, getDefaultOptions(), adjustCompilerOptions(opts));
 
   // Verify that we're targeting ES2015 modules.
-  const moduleType = (opts.module as string).toUpperCase();
-  if (
-    moduleType !== 'ES2015' &&
-    moduleType !== 'ES6' &&
-    moduleType !== 'ESNEXT' &&
-    moduleType !== 'COMMONJS'
-  ) {
-    throw new Error(
-      `@rollup/plugin-typescript: The module kind should be 'ES2015' or 'ESNext, found: '${opts.module}'`
-    );
-  }
+  validateModuleType(tsConfig.compilerOptions.module);
 
-  const parsed = tsRuntime.convertCompilerOptionsFromJson(opts, process.cwd());
-
-  if (parsed.errors.length) {
-    parsed.errors.forEach((error) =>
-      // eslint-disable-next-line
-      console.error(`@rollup/plugin-typescript: ${error.messageText}`)
-    );
-
-    throw new Error(`@rollup/plugin-typescript: Couldn't process compiler options`);
-  }
-
-  // let typescript load inheritance chain if there are base configs
-  const extendedConfig = tsConfig.extends
-    ? tsRuntime.parseJsonConfigFileContent(tsConfig, tsRuntime.sys, process.cwd(), parsed.options)
-    : null;
-
-  if (extendedConfig && extendedConfig.errors.length) {
-    extendedConfig.errors.forEach((error) =>
-      // eslint-disable-next-line
-      console.error(`@rollup/plugin-typescript: ${error.messageText}`)
-    );
-
-    throw new Error(`@rollup/plugin-typescript: Couldn't process compiler options`);
-  }
-
-  const compilerOptions = extendedConfig ? extendedConfig.options : parsed.options;
+  const { options: compilerOptions, errors } = parseCompilerOptions(ts, tsConfig);
 
   return {
     name: 'typescript',
+
+    buildStart() {
+      if (errors.length > 0) {
+        errors.forEach((error) => this.warn(`@rollup/plugin-typescript: ${error.messageText}`));
+
+        this.error(`@rollup/plugin-typescript: Couldn't process compiler options`);
+      }
+    },
 
     resolveId(importee, importer) {
       if (importee === 'tslib') {
@@ -96,7 +72,7 @@ export default function typescript(options: RollupTypescriptOptions = {}): Plugi
       if (!importer) return null;
       const containingFile = importer.split('\\').join('/');
 
-      const result = tsRuntime.nodeModuleNameResolver(
+      const result = ts.nodeModuleNameResolver(
         importee,
         containingFile,
         compilerOptions,
@@ -124,7 +100,7 @@ export default function typescript(options: RollupTypescriptOptions = {}): Plugi
     transform(code, id) {
       if (!filter(id)) return null;
 
-      const transformed = tsRuntime.transpileModule(code, {
+      const transformed = ts.transpileModule(code, {
         fileName: id,
         reportDiagnostics: true,
         compilerOptions
@@ -138,7 +114,7 @@ export default function typescript(options: RollupTypescriptOptions = {}): Plugi
       let fatalError = false;
 
       diagnostics.forEach((diagnostic) => {
-        const message = tsRuntime.flattenDiagnosticMessageText(diagnostic.messageText, '\n');
+        const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n');
 
         if (diagnostic.file) {
           const { line, character } = diagnostic.file.getLineAndCharacterOfPosition(

--- a/packages/typescript/src/options.ts
+++ b/packages/typescript/src/options.ts
@@ -33,10 +33,7 @@ function findFile(cwd: string, filename: string): string | null {
   return null;
 }
 
-export function readTsConfig(
-  typescript: typeof import('typescript'),
-  tsconfigPath: string | undefined
-) {
+export function readTsConfig(ts: typeof import('typescript'), tsconfigPath: string | undefined) {
   if (tsconfigPath && !existsSync(tsconfigPath)) {
     throw new Error(`Could not find specified tsconfig.json at ${tsconfigPath}`);
   }
@@ -44,15 +41,13 @@ export function readTsConfig(
   if (!existingTsConfig) {
     return {};
   }
-  const tsconfig = typescript.readConfigFile(existingTsConfig, (path) =>
-    readFileSync(path, 'utf8')
-  );
+  const tsconfig = ts.readConfigFile(existingTsConfig, (path) => readFileSync(path, 'utf8'));
 
   if (!tsconfig.config || !tsconfig.config.compilerOptions) return { compilerOptions: {} };
   return tsconfig.config;
 }
 
-export function adjustCompilerOptions(options) {
+export function adjustCompilerOptions(options: any) {
   const opts = Object.assign({}, options);
   // Set `sourceMap` to `inlineSourceMap` if it's a boolean
   // under the assumption that both are never specified simultaneously.
@@ -71,4 +66,32 @@ export function adjustCompilerOptions(options) {
   delete opts.incremental;
   delete opts.tsBuildInfoFile;
   return opts;
+}
+
+export function parseCompilerOptions(ts: typeof import('typescript'), tsConfig: any) {
+  const parsed = ts.convertCompilerOptionsFromJson(tsConfig.compilerOptions, process.cwd());
+
+  // let typescript load inheritance chain if there are base configs
+  const extendedConfig = tsConfig.extends
+    ? ts.parseJsonConfigFileContent(tsConfig, ts.sys, process.cwd(), parsed.options)
+    : null;
+
+  return {
+    options: extendedConfig?.options || parsed.options,
+    errors: parsed.errors.concat(extendedConfig?.errors || [])
+  };
+}
+
+/**
+ * Verify that we're targeting ES2015 modules.
+ * @param moduleType `tsConfig.compilerOptions.module`
+ */
+export function validateModuleType(moduleType: string) {
+  const esModuleTypes = new Set(['ES2015', 'ES6', 'ESNEXT', 'COMMONJS']);
+
+  if (!esModuleTypes.has(moduleType.toUpperCase())) {
+    throw new Error(
+      `@rollup/plugin-typescript: The module kind should be 'ES2015' or 'ESNext, found: '${moduleType}'`
+    );
+  }
 }

--- a/packages/typescript/test/test.js
+++ b/packages/typescript/test/test.js
@@ -273,15 +273,23 @@ test('throws if tsconfig cannot be found', async (t) => {
   );
 });
 
-test('should throw on bad options', (t) => {
-  t.throws(
+test('should throw on bad options', async (t) => {
+  const warnings = [];
+  await t.throwsAsync(
     () =>
       rollup({
         input: 'does-not-matter.ts',
-        plugins: [typescript({ foo: 'bar' })]
+        plugins: [typescript({ foo: 'bar' })],
+        onwarn(warning) {
+          warnings.push(warning);
+        }
       }),
     "@rollup/plugin-typescript: Couldn't process compiler options"
   );
+
+  t.is(warnings.length, 1);
+  t.is(warnings[0].plugin, 'typescript');
+  t.is(warnings[0].message, `@rollup/plugin-typescript: Unknown compiler option 'foo'.`);
 });
 
 test('prevents errors due to conflicting `sourceMap`/`inlineSourceMap` options', async (t) => {


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `typescript`

This PR contains:

- [x] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

Moving from `console.error` to `this.warn`. Additionally cleaned up the options slightly by isolating mutations and extracting some code to helper functions.