### PR TITLE
fix typo in virtual plugin

### DIFF
--- a/packages/virtual/README.md
+++ b/packages/virtual/README.md
@@ -40,7 +40,7 @@ console.log(batman, robin);
 Create a `rollup.config.js` [configuration file](https://www.rollupjs.org/guide/en/#configuration-files) and import the plugin:
 
 ```js
-import virtual from 'rollup-plugin-virtual';
+import virtual from '@rollup/plugin-virtual';
 
 export default {
   entry: 'src/entry.js',


### PR DESCRIPTION
## Rollup Plugin Name: `virtual`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

### Description

The import path of the virtual plugin in the readme is still the one before it moved to this monorepo. I fixed it.