### PR TITLE
chore(repo): assert changelogs

### DIFF
--- a/packages/alias/CHANGELOG.md
+++ b/packages/alias/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @rollup/plugin-alias Changelog
+# @rollup/plugin-alias ChangeLog
 
 ## 3.0.0
 

--- a/packages/auto-install/CHANGELOG.md
+++ b/packages/auto-install/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @rollup/plugin-auto-install Change Log
+# @rollup/plugin-auto-install ChangeLog
 
 ## 2.0.0
 
@@ -8,12 +8,12 @@
 
 ## 1.0.2
 
-* Ignore virtual modules
+- Ignore virtual modules
 
 ## 1.0.1
 
-* Prevent duplicate installs
+- Prevent duplicate installs
 
 ## 1.0.0
 
-* First release
+- First release

--- a/packages/beep/CHANGELOG.md
+++ b/packages/beep/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @rollup/plugin-beep ChangeLog
+
+## 0.1.0
+
+- First Release

--- a/packages/buble/CHANGELOG.md
+++ b/packages/buble/CHANGELOG.md
@@ -1,4 +1,4 @@
-# rollup-plugin-buble changelog
+# @rollup/plugin-buble ChangeLog
 
 ## 0.21.0
 

--- a/packages/commonjs/CHANGELOG.md
+++ b/packages/commonjs/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @rollup/plugin-commonjs changelog
+# @rollup/plugin-commonjs ChangeLog
 
 ## 11.0.0
 

--- a/packages/dsv/CHANGELOG.md
+++ b/packages/dsv/CHANGELOG.md
@@ -1,25 +1,25 @@
-# rollup-plugin-dsv changelog
+# @rollup/plugin-dsv ChangeLog
 
 ## 1.2.0
 
-* Pass `id` to `processRow`
+- Pass `id` to `processRow`
 
 ## 1.1.2
 
-* Return a `name`
+- Return a `name`
 
 ## 1.1.1
 
-* Add missing dependencies
+- Add missing dependencies
 
 ## 1.1.0
 
-* Support `options.processRow`
+- Support `options.processRow`
 
 ## 1.0.1
 
-* Include correct files in package
+- Include correct files in package
 
 ## 1.0.0
 
-* First release
+- First release

--- a/packages/html/CHANGELOG.md
+++ b/packages/html/CHANGELOG.md
@@ -1,7 +1,7 @@
-# @rollup/plugin-html Change Log
+# @rollup/plugin-html ChangeLog
 
 ## 0.1.0
 
 _2019-11-29_
 
-- First version
+- First Release

--- a/packages/image/CHANGELOG.md
+++ b/packages/image/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @rollup/plugin-image Change Log
+# @rollup/plugin-image ChangeLog
 
 ## 2.0.0
 
@@ -20,4 +20,4 @@
 
 ## 1.0.0
 
-- First release
+- First Release

--- a/packages/inject/CHANGELOG.md
+++ b/packages/inject/CHANGELOG.md
@@ -1,54 +1,54 @@
-# @rollup/plugin-inject Changelog
+# @rollup/plugin-inject ChangeLog
 
 ## 3.0.2
 
-* Fix bug with sourcemap usage
+- Fix bug with sourcemap usage
 
 ## 3.0.1
 
-* Generate sourcemap when sourcemap enabled
+- Generate sourcemap when sourcemap enabled
 
 ## 3.0.0
 
-* Remove node v6 from support
-* Use modern js
+- Remove node v6 from support
+- Use modern js
 
 ## 2.1.0
 
-* Update all dependencies ([#15](https://github.com/rollup/rollup-plugin-inject/pull/15))
+- Update all dependencies ([#15](https://github.com/rollup/rollup-plugin-inject/pull/15))
 
 ## 2.0.0
 
-* Work with all file extensions, not just `.js` (unless otherwise specified via `options.include` and `options.exclude`) ([#6](https://github.com/rollup/rollup-plugin-inject/pull/6))
-* Allow `*` imports ([#9](https://github.com/rollup/rollup-plugin-inject/pull/9))
-* Ignore replacements that are superseded (e.g. if `Buffer.isBuffer` is replaced, ignore `Buffer` replacement) ([#10](https://github.com/rollup/rollup-plugin-inject/pull/10))
+- Work with all file extensions, not just `.js` (unless otherwise specified via `options.include` and `options.exclude`) ([#6](https://github.com/rollup/rollup-plugin-inject/pull/6))
+- Allow `*` imports ([#9](https://github.com/rollup/rollup-plugin-inject/pull/9))
+- Ignore replacements that are superseded (e.g. if `Buffer.isBuffer` is replaced, ignore `Buffer` replacement) ([#10](https://github.com/rollup/rollup-plugin-inject/pull/10))
 
 ## 1.4.1
 
-* Return a `name`
+- Return a `name`
 
 ## 1.4.0
 
-* Use `string.search` instead of `regex.test` to avoid state-related mishaps ([#5](https://github.com/rollup/rollup-plugin-inject/issues/5))
-* Prevent self-importing module bug
+- Use `string.search` instead of `regex.test` to avoid state-related mishaps ([#5](https://github.com/rollup/rollup-plugin-inject/issues/5))
+- Prevent self-importing module bug
 
 ## 1.3.0
 
-* Windows support ([#2](https://github.com/rollup/rollup-plugin-inject/issues/2))
-* Node 0.12 support
+- Windows support ([#2](https://github.com/rollup/rollup-plugin-inject/issues/2))
+- Node 0.12 support
 
 ## 1.2.0
 
-* Generate sourcemaps by default
+- Generate sourcemaps by default
 
 ## 1.1.1
 
-* Use `modules` option
+- Use `modules` option
 
 ## 1.1.0
 
-* Handle shorthand properties
+- Handle shorthand properties
 
 ## 1.0.0
 
-* First release
+- First release

--- a/packages/json/CHANGELOG.md
+++ b/packages/json/CHANGELOG.md
@@ -1,4 +1,4 @@
-# rollup-plugin-json changelog
+# @rollup/plugin-json ChangeLog
 
 ## 4.0.1
 

--- a/packages/legacy/CHANGELOG.md
+++ b/packages/legacy/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @rollup/plugin-legacy changelog
+# @rollup/plugin-legacy ChangeLog
 
 ## 2.0.0
 
@@ -12,4 +12,4 @@ _2019-11-24_
 
 _2016-12-28_
 
-- First release
+- First Release

--- a/packages/multi-entry/CHANGELOG.md
+++ b/packages/multi-entry/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @rollup/plugin-multi-entry Change Log
+# @rollup/plugin-multi-entry ChangeLog
 
 ## 3.0.0
 

--- a/packages/node-resolve/CHANGELOG.md
+++ b/packages/node-resolve/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @rollup/plugin-node-resolve Change Log
+# @rollup/plugin-node-resolve ChangeLog
 
 ## 6.0.0
 

--- a/packages/pluginutils/CHANGELOG.md
+++ b/packages/pluginutils/CHANGELOG.md
@@ -1,8 +1,8 @@
-# @rollup/pluginutils changelog
+# @rollup/pluginutils ChangeLog
 
 ## 3.0.1
 
-- fix(pluginutils): Escape glob characters in folder (#84)
+- fix: Escape glob characters in folder (#84)
 
 ## 3.0.0
 

--- a/packages/replace/CHANGELOG.md
+++ b/packages/replace/CHANGELOG.md
@@ -1,4 +1,4 @@
-# rollup-plugin-replace changelog
+# @rollup/plugin-replace ChangeLog
 
 ## 2.3.0
 

--- a/packages/run/CHANGELOG.md
+++ b/packages/run/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @rollup/plugin-run Change Log
+# @rollup/plugin-run ChangeLog
 
 ## 1.1.0
 

--- a/packages/strip/CHANGELOG.md
+++ b/packages/strip/CHANGELOG.md
@@ -1,39 +1,39 @@
-# @rollup/plugin-strip changelog
+# @rollup/plugin-strip ChangeLog
 
 ## 1.2.2
 
-* Fix object destructuring assignments with default values ([#17](https://github.com/rollup/@rollup/plugin-strip/pull/17))
-* update `rollup-pluginutils` ([#22](https://github.com/rollup/@rollup/plugin-strip/pull/22))
+- Fix object destructuring assignments with default values ([#17](https://github.com/rollup/@rollup/plugin-strip/pull/17))
+- update `rollup-pluginutils` ([#22](https://github.com/rollup/@rollup/plugin-strip/pull/22))
 
 ## 1.2.1
 
-* Update dependencies
+- Update dependencies
 
 ## 1.2.0
 
-* Use `this.parse` instead of `acorn.parse`
-* Make code removal more conservative ([#9](https://github.com/rollup/@rollup/plugin-strip/pull/9))
+- Use `this.parse` instead of `acorn.parse`
+- Make code removal more conservative ([#9](https://github.com/rollup/@rollup/plugin-strip/pull/9))
 
 ## 1.1.1
 
-* Return a `name`
+- Return a `name`
 
 ## 1.1.0
 
-* Remove methods of `this` and `super` ([#3](https://github.com/rollup/@rollup/plugin-strip/issues/3))
+- Remove methods of `this` and `super` ([#3](https://github.com/rollup/@rollup/plugin-strip/issues/3))
 
 ## 1.0.3
 
-* Fix build
+- Fix build
 
 ## 1.0.2
 
-* Default to adding sourcemap locations
+- Default to adding sourcemap locations
 
 ## 1.0.1
 
-* Skip removed call expressions from further AST traversal
+- Skip removed call expressions from further AST traversal
 
 ## 1.0.0
 
-* Initial release
+- Initial release

--- a/packages/sucrase/CHANGELOG.md
+++ b/packages/sucrase/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @rollup/plugin-sucrase Change Log
+# @rollup/plugin-sucrase ChangeLog
 
 ## 3.0.0
 

--- a/packages/typescript/CHANGELOG.md
+++ b/packages/typescript/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @rollup/plugin-typescript changelog
+# @rollup/plugin-typescript ChangeLog
 
 ## 2.0.1
 

--- a/packages/url/CHANGELOG.md
+++ b/packages/url/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @rollup/plugin-url Change Log
+# @rollup/plugin-url ChangeLog
 
 ## 4.0.0
 

--- a/packages/virtual/CHANGELOG.md
+++ b/packages/virtual/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @rollup/plugin-virtual Change Log
+# @rollup/plugin-virtual ChangeLog
 
 ## 2.0.0
 

--- a/packages/wasm/CHANGELOG.md
+++ b/packages/wasm/CHANGELOG.md
@@ -1,0 +1,13 @@
+# @rollup/plugin-wasm ChangeLog
+
+## 3.0.0
+
+_2018-02-17_
+
+### Breaking Changes
+
+- A function is now imported instead of the module.
+
+### Features
+
+- feat: simplify wasm imports (ace7b2a)

--- a/packages/yaml/CHANGELOG.md
+++ b/packages/yaml/CHANGELOG.md
@@ -1,15 +1,16 @@
-# @rollup/plugin-yaml Change Log
+# @rollup/plugin-yaml ChangeLog
 
 ## 2.0.0
-*2019-10-18*
 
-* Add `transform` option [#6](https://github.com/rollup/rollup-plugin-yaml/pull/6) (by @CharlesHolbrow)
-* Update dependencies and build, require Node 6 [#7](https://github.com/rollup/rollup-plugin-yaml/pull/7) (by @lukastaegert)
+_2019-10-18_
+
+- Add `transform` option [#6](https://github.com/rollup/rollup-plugin-yaml/pull/6) (by @CharlesHolbrow)
+- Update dependencies and build, require Node 6 [#7](https://github.com/rollup/rollup-plugin-yaml/pull/7) (by @lukastaegert)
 
 ## 1.1.0
 
-* Switch to `js-yaml` for parsing [#2](https://github.com/rollup/rollup-plugin-yaml/pull/2)
+- Switch to `js-yaml` for parsing [#2](https://github.com/rollup/rollup-plugin-yaml/pull/2)
 
 ## 1.0.0
 
-* First release
+- First release


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: all

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

### Description

In conjunction with #133, this PR asserts that changelogs exist and use the same title format. These changes are key to the auto-changelog-generation process.