### PR TITLE
fix(url): windows compatible, tests

### DIFF
--- a/packages/url/src/index.js
+++ b/packages/url/src/index.js
@@ -9,7 +9,7 @@ import { createFilter } from 'rollup-pluginutils';
 
 const fsStatPromise = util.promisify(fs.stat);
 const fsReadFilePromise = util.promisify(fs.readFile);
-const { sep } = path;
+const { posix, sep } = path;
 const defaultInclude = ['**/*.svg', '**/*.png', '**/*.jpg', '**/*.gif'];
 
 export default function url(options = {}) {
@@ -59,7 +59,7 @@ export default function url(options = {}) {
             .replace(/\[dirname\]/g, `${relativeDir}${sep}`)
             .replace(/\[name\]/g, name);
           // Windows fix - exports must be in unix format
-          data = `${publicPath}${outputFileName.split(sep).join('/')}`;
+          data = `${publicPath}${outputFileName.split(sep).join(posix.sep)}`;
           copies[id] = outputFileName;
         } else {
           const mimetype = mime.getType(id);

--- a/packages/url/src/index.js
+++ b/packages/url/src/index.js
@@ -9,7 +9,7 @@ import { createFilter } from 'rollup-pluginutils';
 
 const fsStatPromise = util.promisify(fs.stat);
 const fsReadFilePromise = util.promisify(fs.readFile);
-
+const { sep } = path;
 const defaultInclude = ['**/*.svg', '**/*.png', '**/*.jpg', '**/*.gif'];
 
 export default function url(options = {}) {
@@ -47,7 +47,7 @@ export default function url(options = {}) {
             ? path.relative(options.sourceDir, path.dirname(id))
             : path
                 .dirname(id)
-                .split(path.sep)
+                .split(sep)
                 .pop();
 
           // Generate the output file name based on some string
@@ -55,9 +55,11 @@ export default function url(options = {}) {
           const outputFileName = fileName
             .replace(/\[hash\]/g, hash)
             .replace(/\[extname\]/g, ext)
-            .replace(/\[dirname\]/g, `${relativeDir}/`)
+            // use `sep` for windows environments
+            .replace(/\[dirname\]/g, `${relativeDir}${sep}`)
             .replace(/\[name\]/g, name);
-          data = `${publicPath}${outputFileName}`;
+          // Windows fix - exports must be in unix format
+          data = `${publicPath}${outputFileName.split(sep).join('/')}`;
           copies[id] = outputFileName;
         } else {
           const mimetype = mime.getType(id);

--- a/packages/url/test/test.js
+++ b/packages/url/test/test.js
@@ -1,5 +1,5 @@
 const { readFileSync } = require('fs');
-const { join, sep } = require('path');
+const { join, posix, sep } = require('path');
 
 const test = require('ava');
 const del = require('del');
@@ -27,7 +27,7 @@ const run = async (t, type, opts) => {
   // Windows fix, glob paths must be in unix format
   const glob = join(outputDir, `**/*.${type}`)
     .split(sep)
-    .join('/');
+    .join(posix.sep);
 
   t.snapshot(code);
   t.snapshot(await globby(glob));

--- a/packages/url/test/test.js
+++ b/packages/url/test/test.js
@@ -1,5 +1,5 @@
 const { readFileSync } = require('fs');
-const { join } = require('path');
+const { join, sep } = require('path');
 
 const test = require('ava');
 const del = require('del');
@@ -24,7 +24,10 @@ const run = async (t, type, opts) => {
   });
   await bundle.write({ format: 'es', file: outputFile });
   const code = readFileSync(outputFile, 'utf-8');
-  const glob = join(outputDir, `**/*.${type}`);
+  // Windows fix, glob paths must be in unix format
+  const glob = join(outputDir, `**/*.${type}`)
+    .split(sep)
+    .join('/');
 
   t.snapshot(code);
   t.snapshot(await globby(glob));
@@ -83,7 +86,7 @@ test.serial(
       limit: 10,
       emitFiles: true,
       fileName: '[dirname][hash][extname]',
-      sourceDir: join(__dirname, '../')
+      sourceDir: join(__dirname, '..')
     });
   }
 );


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `url`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

### Description

As with a few other plugin tests, the recent change in Github Actions' Windows image/pipeline was causing `@rollup/plugin-url` to fail tests on Windows. After looking into it, the plugin would have been fairly unusable on Windows. Previously, the tests were passing the Windows Github Actions - somehow. This change addresses Windows file paths and normalizes paths that need to be.

Because this is a critical flaw, this will be merged with or without review after 12 hours. 