### PR TITLE
chore(commonjs): remove jsnext:main

### DIFF
--- a/packages/commonjs/package.json
+++ b/packages/commonjs/package.json
@@ -85,7 +85,6 @@
       "!**/types.ts"
     ]
   },
-  "jsnext:main": "dist/index.es.js",
   "module": "dist/index.es.js",
   "types": "types/index.d.ts"
 }


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `commonjs`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers: Fixes #83

### Description

This is the last of the `jsnext:main` package.json entries that needs to be cleaned up. It's not technically breaking since the `module` field has existed beside it for several versions. 