### PR TITLE
fix(typescript) extended config file path

### DIFF
--- a/packages/typescript/src/options.ts
+++ b/packages/typescript/src/options.ts
@@ -24,8 +24,8 @@ export function readTsConfig(ts: typeof import('typescript'), tsconfigPath: stri
   if (!tsconfig.config || !tsconfig.config.compilerOptions) return { compilerOptions: {} };
 
   const extendedTsConfig: string = tsconfig.config.extends;
-  if (extendedTsConfig) {
-    tsconfig.config.extends = join(process.cwd(),existingTsConfig, '..', extendedTsConfig );
+  if (tsconfigPath && extendedTsConfig) {
+    tsconfig.config.extends = join(process.cwd(),existingTsConfig, '..', extendedTsConfig);
   }
 
   return tsconfig.config;

--- a/packages/typescript/src/options.ts
+++ b/packages/typescript/src/options.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { join } from 'path';
+import { resolve } from 'path';
 
 export function getDefaultOptions() {
   return {
@@ -25,7 +25,7 @@ export function readTsConfig(ts: typeof import('typescript'), tsconfigPath: stri
 
   const extendedTsConfig: string = tsconfig.config.extends;
   if (tsconfigPath && extendedTsConfig) {
-    tsconfig.config.extends = join(process.cwd(),existingTsConfig, '..', extendedTsConfig);
+    tsconfig.config.extends = resolve(process.cwd(), existingTsConfig, '..', extendedTsConfig);
   }
 
   return tsconfig.config;

--- a/packages/typescript/src/options.ts
+++ b/packages/typescript/src/options.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'fs';
+import { join } from 'path';
 
 export function getDefaultOptions() {
   return {
@@ -17,9 +18,16 @@ export function readTsConfig(ts: typeof import('typescript'), tsconfigPath: stri
   if (!existingTsConfig) {
     return {};
   }
+
   const tsconfig = ts.readConfigFile(existingTsConfig, (path) => readFileSync(path, 'utf8'));
 
   if (!tsconfig.config || !tsconfig.config.compilerOptions) return { compilerOptions: {} };
+
+  const extendedTsConfig: string = tsconfig.config.extends;
+  if (extendedTsConfig) {
+    tsconfig.config.extends = join(process.cwd(),existingTsConfig, '..', extendedTsConfig );
+  }
+
   return tsconfig.config;
 }
 

--- a/packages/typescript/test/fixtures/tsconfig-extends/ts-config-extends-child/main.tsx
+++ b/packages/typescript/test/fixtures/tsconfig-extends/ts-config-extends-child/main.tsx
@@ -1,0 +1,1 @@
+export default <span {...props}>Yo!</span>

--- a/packages/typescript/test/fixtures/tsconfig-extends/ts-config-extends-child/tsconfig.json
+++ b/packages/typescript/test/fixtures/tsconfig-extends/ts-config-extends-child/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../tsconfig.base",
+  "compilerOptions": {
+    "allowJs": true
+  }
+}

--- a/packages/typescript/test/test.js
+++ b/packages/typescript/test/test.js
@@ -250,6 +250,21 @@ test.serial('should support extends property in tsconfig', async (t) => {
   t.not(usage, -1, 'should contain usage');
 });
 
+test.serial('should support extends property with given tsconfig', async (t) => {
+  process.chdir('fixtures/tsconfig-extends/ts-config-extends-child');
+
+  const bundle = await rollup({
+    input: 'main.tsx',
+    plugins: [typescript({
+      tsconfig: './tsconfig.json',
+    })]
+  });
+  const code = await getCode(bundle, outputOptions);
+
+  const usage = code.indexOf('React.createElement("span", __assign({}, props), "Yo!")');
+  t.not(usage, -1, 'should contain usage');
+});
+
 test('allows specifying a path for tsconfig.json', async (t) => {
   const bundle = await rollup({
     input: 'fixtures/tsconfig-jsx/main.tsx',


### PR DESCRIPTION
## Rollup Plugin Name: `typescript`
This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (bugfixes and features will not be merged without tests)
- [ ] no

Breaking Changes?
- [ ] yes (breaking changes will not be merged unless absolutely necessary)
- [x] no

List any relevant issue numbers:

### Description
This plugin has `extends` option support  but plugin does not give the right extended config file path.

For example: If your tsconfig contains `"extends": "../generic-tsconfig.json"` typescript plugin looks parent directory of project root folder because of the dots.
I added proper path resolver to fix this bug.

UPDATE: Bug happens when tsconfig option given.
