### PR TITLE
Update type definitions

### DIFF
--- a/packages/json/index.d.ts
+++ b/packages/json/index.d.ts
@@ -21,17 +21,17 @@ export interface RollupJsonOptions {
 	 * Specify indentation for the generated default export
 	 * @default '\t'
 	 */
-	indent: string;
+	indent?: string;
 	/**
 	 * Ignores indent and generates the smallest code
 	 * @default false
 	 */
-	compact: boolean;
+	compact?: boolean;
 	/**
 	 * Generate a named export for every property of the JSON object
 	 * @default true
 	 */
-	namedExports: true;
+	namedExports?: boolean;
 }
 
 /**


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `json`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [X] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [X] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [X] no

List any relevant issue numbers:

### Description

The type definitions don't match the docs, or the plugin behavior. When used with TypeScript, you can't call the plugin without explicitly including these options which are meant to be optional. And `namedExports: false` was literally not allowed.