### PR TITLE
Add labels to `firstpass` regex (@rollup/plugin-strip)

### DIFF
--- a/packages/strip/src/index.js
+++ b/packages/strip/src/index.js
@@ -52,7 +52,7 @@ export default function strip(options = {}) {
 
     transform(code, id) {
       if (!filter(id)) return null;
-      if (functions.length > 0 && !firstpass.test(code)) return null;
+      if (!firstpass.test(code)) return null;
 
       let ast;
 

--- a/packages/strip/src/index.js
+++ b/packages/strip/src/index.js
@@ -44,7 +44,7 @@ export default function strip(options = {}) {
 
   const labels = options.labels || [];
 
-  const firstpass = new RegExp(`\\b(?:${functions.join('|')}|debugger)\\b`);
+  const firstpass = new RegExp(`\\b(?:${[...functions, ...labels].join('|')}|debugger)\\b`);
   const pattern = new RegExp(`^(?:${functions.join('|')})$`);
 
   return {


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `strip`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [ ] no
- [x] https://xkcd.com/1172/

List any relevant issue numbers: #167

### Description

This adds the labels to the `firstpass` regex. I also removed the `functions.length > 0` check which felt a little odd when the regex also looks for `debugger` and labels.

I'm marking this PR as a draft as it doesn't include tests. I tried this fix in my local repo and it has the right behavior with my config and code. Someone more familiar with the testing setup in the `rollup/plugins` repo will probably get the tests right faster.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
