### PR TITLE
Fix link for plugin-node-resolve

### DIFF
--- a/packages/commonjs/README.md
+++ b/packages/commonjs/README.md
@@ -129,7 +129,7 @@ Sometimes you have to leave require statements unconverted. Pass an array contai
 
 ## Using with @rollup/plugin-node-resolve
 
-Since most CommonJS packages you are importing are probably depdenencies in `node_modules`, you may need to use [@rollup/plugin-node-resolve](https://github.com/rollup/plugins/packages/node-resolve):
+Since most CommonJS packages you are importing are probably depdenencies in `node_modules`, you may need to use [@rollup/plugin-node-resolve](https://github.com/rollup/plugins/tree/master/packages/node-resolve):
 
 ```js
 // rollup.config.js


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `plugin-node-resolve`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [X] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [X] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [X] no

List any relevant issue numbers:

### Description

The link to `plugin-node-resolve` was broken (https://github.com/rollup/plugins/packages/node-resolve). This PR updates the link URL to resolve to the correct place (https://github.com/rollup/plugins/tree/master/packages/node-resolve).