### PR TITLE
fix(pluginutils): bring back named exports

### DIFF
--- a/packages/pluginutils/src/index.ts
+++ b/packages/pluginutils/src/index.ts
@@ -5,6 +5,16 @@ import dataToEsm from './dataToEsm';
 import extractAssignedNames from './extractAssignedNames';
 import makeLegalIdentifier from './makeLegalIdentifier';
 
+export {
+  addExtension,
+  attachScopes,
+  createFilter,
+  dataToEsm,
+  extractAssignedNames,
+  makeLegalIdentifier
+};
+
+// TODO: remove this in next major
 export default {
   addExtension,
   attachScopes,


### PR DESCRIPTION
## Rollup Plugin Name: `@rollup/pluginutils`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
fixes #171

### Description

For some reason, those exports were moved to an exported as default object - but all (most?) existing consumers expect named exports for those (and I also believe that named exports are just better suited here).