### PR TITLE
feat(typescript): Add back transpileModule API

### DIFF
--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -86,6 +86,13 @@ Default: `true`
 
 When set to false, ignores any options specified in the config file. If set to a string that corresponds to a file path, the specified file will be used as config file.
 
+### `transpileOnly`
+
+Type: `Boolean`<br>
+Default: `false`
+
+Set to true to avoid type checking the code.
+
 ### `typescript`
 
 Type: `import('typescript')`<br>
@@ -122,6 +129,14 @@ Type: `Boolean`<br>
 Default: `true`
 
 If a type error is detected, the Rollup build is aborted when this option is set to true.
+
+#### `isolatedModules`
+
+Type: `Boolean`<br>
+Default: `false`
+
+Typescript will perform additional checks to allow faster separate compilation (such as with @babel/plugin-transform-typescript).
+If `isolatedModules` and `transpileOnly` are both set to true, a faster compilation method will be used.
 
 #### `files`, `include`, `exclude`
 

--- a/packages/typescript/src/options.ts
+++ b/packages/typescript/src/options.ts
@@ -62,7 +62,15 @@ const FORCED_COMPILER_OPTIONS: Partial<CompilerOptions> = {
  * - `tslib`: ESM code from the tslib helper library (possibly)
  */
 export function getPluginOptions(options: RollupTypescriptOptions) {
-  const { include, exclude, tsconfig, typescript, tslib, ...compilerOptions } = options;
+  const {
+    include,
+    exclude,
+    tsconfig,
+    typescript,
+    tslib,
+    transpileOnly,
+    ...compilerOptions
+  } = options;
 
   const filter = createFilter(
     include || ['*.ts+(|x)', '**/*.ts+(|x)'],

--- a/packages/typescript/types/index.d.ts
+++ b/packages/typescript/types/index.d.ts
@@ -37,6 +37,10 @@ interface RollupTypescriptOptions {
    * Overrides the injected TypeScript helpers with a custom version.
    */
   tslib?: Promise<string> | string;
+  /**
+   * Set to true to avoid type checking the code.
+   */
+  transpileOnly?: boolean;
 }
 
 /**


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `typescript`

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
This PR adds a new `transpileOnly` option to the Typescript plugin. Turning this on will turn off explicit typechecking (although some syntax errors are still reported).

Typescript also has an `isolatedModules` compiler option. Normally Typescript works on entire projects at once, rather than one file at a time. `isolatedModules` switches to a one file at a time system that matches what Babel and Rollup do. If this flag is on along with `transpileOnly`, the `transpileModule` API will be used.