### PR TITLE
fix(pluginutils): resolve relative paths starting with "./"

### DIFF
--- a/packages/pluginutils/src/createFilter.ts
+++ b/packages/pluginutils/src/createFilter.ts
@@ -1,4 +1,4 @@
-import { resolve, sep } from 'path';
+import { resolve, sep, posix } from 'path';
 
 import mm from 'micromatch';
 
@@ -17,12 +17,11 @@ function getMatcherString(id: string, resolutionBase: string | false | null | un
     .join('/')
     // escape all possible (posix + win) path characters that might interfere with regex
     .replace(/[-^$*+?.()|[\]{}]/g, '\\$&');
-  // this juggling is to join two paths:
-  // 1. the basePath which has been normalized to use /
-  // 2. the incoming glob (id) matcher, which uses /
-  // we can't use join or resolve here because Node will force backslash (\) on windows
-  const result = [...basePath.split('/'), ...id.split('/')].join('/');
-  return result;
+  // Note that we use posix.join because:
+  // 1. the basePath has been normalized to use /
+  // 2. the incoming glob (id) matcher, also uses /
+  // otherwise Node will force backslash (\) on windows
+  return posix.join(basePath, id);
 }
 
 const createFilter: CreateFilter = function createFilter(include?, exclude?, options?) {

--- a/packages/pluginutils/test/createFilter.ts
+++ b/packages/pluginutils/test/createFilter.ts
@@ -117,3 +117,10 @@ test.serial('includes names containing parenthesis', (t) => {
   t.truthy(filter(resolve('.x/(test)a.ts')));
   t.falsy(filter(resolve('.x/(test)a.d.ts')));
 });
+
+test('handles relative paths', (t) => {
+  const filter = createFilter(['./index.js', './foo/../a.js']);
+  t.truthy(filter(resolve('index.js')));
+  t.truthy(filter(resolve('a.js')));
+  t.falsy(filter(resolve('foo/a.js')));
+});


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `pluginutils`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
(will need to look those up if some exist, sorry)

### Description
This fixes a regression between pluginutils@3.0.2 and @3.0.3 where a pattern starting with `./` would no longer match because it would just be concatenated with the base path to something like `/base/path/./my/path`.

This problem came up in rollup-plugin-node-resolve because this (correctly) uses `createFilter` to resolve package sideEffect specifications. These specifications however tend to use relative paths, hence the issue. Basically this was breaking the package side-effects feature.

Simple example:
```js
createFilter(['./index.js'])
filter(resolve('index.js')) // false before this PR, true afterwards
```