### PR TITLE
chore: Use typechecking with some plugins

### DIFF
--- a/packages/data-uri/package.json
+++ b/packages/data-uri/package.json
@@ -48,7 +48,7 @@
     "rollup": "^1.20.0"
   },
   "devDependencies": {
-    "@rollup/plugin-typescript": "^2.1.0",
+    "@rollup/plugin-typescript": "^3.0.0",
     "@rollup/pluginutils": "^3.0.1",
     "rollup": "^1.27.14",
     "typescript": "^3.7.4"

--- a/packages/data-uri/tsconfig.json
+++ b/packages/data-uri/tsconfig.json
@@ -4,5 +4,9 @@
     "lib": ["es6", "dom"],
     "esModuleInterop": true
   },
+  "include": [
+    "src/**/*",
+    "types/**/*"
+  ],
   "exclude": ["test/fixtures/*.*"]
 }

--- a/packages/pluginutils/package.json
+++ b/packages/pluginutils/package.json
@@ -50,6 +50,7 @@
     "estree-walker": "^1.0.1"
   },
   "devDependencies": {
+    "@rollup/plugin-typescript": "^3.0.0",
     "@types/estree": "0.0.39",
     "@types/jest": "^24.0.23",
     "@types/micromatch": "^3.1.1",
@@ -57,7 +58,6 @@
     "micromatch": "^4.0.2",
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-node-resolve": "^5.2.0",
-    "rollup-plugin-typescript": "^1.0.1",
     "typescript": "^3.7.2"
   },
   "ava": {

--- a/packages/pluginutils/rollup.config.js
+++ b/packages/pluginutils/rollup.config.js
@@ -1,4 +1,4 @@
-import typescript from 'rollup-plugin-typescript';
+import typescript from '@rollup/plugin-typescript';
 import resolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
 

--- a/packages/pluginutils/src/attachScopes.ts
+++ b/packages/pluginutils/src/attachScopes.ts
@@ -1,4 +1,4 @@
-import { Node, walk } from 'estree-walker';
+import { walk } from 'estree-walker';
 
 import { AttachedScope, AttachScopes } from '../types';
 
@@ -16,7 +16,7 @@ const blockDeclarations: BlockDeclaration = {
 interface ScopeOptions {
   parent?: AttachedScope;
   block?: boolean;
-  params?: Array<Node>;
+  params?: import('estree').Node[];
 }
 
 class Scope implements AttachedScope {
@@ -39,13 +39,13 @@ class Scope implements AttachedScope {
     }
   }
 
-  addDeclaration(node: Node, isBlockDeclaration: boolean, isVar: boolean): void {
+  addDeclaration(node: import('estree').Node, isBlockDeclaration: boolean, isVar: boolean): void {
     if (!isBlockDeclaration && this.isBlockScope) {
       // it's a `var` or function node, and this
       // is a block scope, so we need to go up
       this.parent!.addDeclaration(node, isBlockDeclaration, isVar);
-    } else if (node.id) {
-      extractAssignedNames(node.id).forEach((name) => {
+    } else if ((node as any).id) {
+      extractAssignedNames((node as any).id).forEach((name) => {
         this.declarations[name] = true;
       });
     }
@@ -60,7 +60,8 @@ const attachScopes: AttachScopes = function attachScopes(ast, propertyName = 'sc
   let scope = new Scope();
 
   walk(ast, {
-    enter(node, parent) {
+    enter(n, parent) {
+      const node = n as import('estree').Node;
       // function foo () {...}
       // class Foo {...}
       if (/(Function|Class)Declaration/.test(node.type)) {
@@ -74,7 +75,7 @@ const attachScopes: AttachScopes = function attachScopes(ast, propertyName = 'sc
         // don't add const/let declarations in the body of a for loop #113
         const parentType = parent ? parent.type : '';
         if (!(isBlockDeclaration && /ForOfStatement/.test(parentType))) {
-          node.declarations.forEach((declaration: Node) => {
+          node.declarations.forEach((declaration) => {
             scope.addDeclaration(declaration, isBlockDeclaration, true);
           });
         }
@@ -84,16 +85,17 @@ const attachScopes: AttachScopes = function attachScopes(ast, propertyName = 'sc
 
       // create new function scope
       if (/Function/.test(node.type)) {
+        const func = node as import('estree').Function;
         newScope = new Scope({
           parent: scope,
           block: false,
-          params: node.params
+          params: func.params
         });
 
         // named function expressions - the name is considered
         // part of the function's scope
-        if (node.type === 'FunctionExpression' && node.id) {
-          newScope.addDeclaration(node, false, false);
+        if (func.type === 'FunctionExpression' && func.id) {
+          newScope.addDeclaration(func, false, false);
         }
       }
 
@@ -123,7 +125,8 @@ const attachScopes: AttachScopes = function attachScopes(ast, propertyName = 'sc
         scope = newScope;
       }
     },
-    leave(node) {
+    leave(n) {
+      const node = n as import('estree').Node & Record<string, any>;
       if (node[propertyName]) scope = scope.parent!;
     }
   });

--- a/packages/pluginutils/src/dataToEsm.ts
+++ b/packages/pluginutils/src/dataToEsm.ts
@@ -71,20 +71,18 @@ const dataToEsm: DataToEsm = function dataToEsm(data, options = {}) {
 
   let namedExportCode = '';
   const defaultExportRows = [];
-  const dataKeys = Object.keys(data);
-  for (let i = 0; i < dataKeys.length; i++) {
-    const key = dataKeys[i];
+  for (const [key, value] of Object.entries(data)) {
     if (key === makeLegalIdentifier(key)) {
       if (options.objectShorthand) defaultExportRows.push(key);
       else defaultExportRows.push(`${key}:${_}${key}`);
       namedExportCode += `export ${declarationType} ${key}${_}=${_}${serialize(
-        data[key],
+        value,
         options.compact ? null : t,
         ''
       )};${n}`;
     } else {
       defaultExportRows.push(
-        `${stringify(key)}:${_}${serialize(data[key], options.compact ? null : t, '')}`
+        `${stringify(key)}:${_}${serialize(value, options.compact ? null : t, '')}`
       );
     }
   }

--- a/packages/pluginutils/src/extractAssignedNames.ts
+++ b/packages/pluginutils/src/extractAssignedNames.ts
@@ -1,28 +1,29 @@
-import { Node } from 'estree-walker';
+import { ExtractAssignedNames } from '../types';
 
 interface Extractors {
-  [key: string]: (names: Array<string>, param: Node) => void;
+  [key: string]: (names: string[], param: any) => void;
 }
 
 const extractors: Extractors = {
-  ArrayPattern(names: Array<string>, param: Node) {
+  ArrayPattern(names: string[], param: import('estree').ArrayPattern) {
     for (const element of param.elements) {
       if (element) extractors[element.type](names, element);
     }
   },
 
-  AssignmentPattern(names: Array<string>, param: Node) {
+  AssignmentPattern(names: string[], param: import('estree').AssignmentPattern) {
     extractors[param.left.type](names, param.left);
   },
 
-  Identifier(names: Array<string>, param: Node) {
+  Identifier(names: string[], param: import('estree').Identifier) {
     names.push(param.name);
   },
 
   MemberExpression() {},
 
-  ObjectPattern(names: Array<string>, param: Node) {
+  ObjectPattern(names: string[], param: import('estree').ObjectPattern) {
     for (const prop of param.properties) {
+      // @ts-ignore Typescript reports that this is not a valid type
       if (prop.type === 'RestElement') {
         extractors.RestElement(names, prop);
       } else {
@@ -31,13 +32,13 @@ const extractors: Extractors = {
     }
   },
 
-  RestElement(names: Array<string>, param: Node) {
+  RestElement(names: string[], param: import('estree').RestElement) {
     extractors[param.argument.type](names, param.argument);
   }
 };
 
-const extractAssignedNames = function extractAssignedNames(param: Node): Array<string> {
-  const names: Array<string> = [];
+const extractAssignedNames: ExtractAssignedNames = function extractAssignedNames(param) {
+  const names: string[] = [];
 
   extractors[param.type](names, param);
   return names;

--- a/packages/pluginutils/tsconfig.json
+++ b/packages/pluginutils/tsconfig.json
@@ -3,5 +3,9 @@
   "compilerOptions": {
     "lib": ["es6"],
     "esModuleInterop": true
-  }
+  },
+  "include": [
+    "src/**/*",
+    "types/**/*"
+  ]
 }

--- a/packages/pluginutils/types/index.d.ts
+++ b/packages/pluginutils/types/index.d.ts
@@ -1,10 +1,14 @@
-import { Node } from 'estree-walker';
+import { BaseNode } from 'estree';
 
 export interface AttachedScope {
   parent?: AttachedScope;
   isBlockScope: boolean;
   declarations: { [key: string]: boolean };
-  addDeclaration(node: Node, isBlockDeclaration: boolean, isVar: boolean): void;
+  addDeclaration(
+    node: BaseNode,
+    isBlockDeclaration: boolean,
+    isVar: boolean
+  ): void;
   contains(name: string): boolean;
 }
 
@@ -19,12 +23,17 @@ export interface DataToEsmOptions {
 export type AddExtension = (filename: string, ext?: string) => string;
 export const addExtension: AddExtension;
 
-export type AttachScopes = (ast: Node, propertyName?: string) => AttachedScope;
+export type AttachScopes = (
+  ast: BaseNode,
+  propertyName?: string
+) => AttachedScope;
 export const attachScopes: AttachScopes;
 
+export type FilterPattern = Array<string | RegExp> | string | RegExp | null;
+
 export type CreateFilter = (
-  include?: Array<string | RegExp> | string | RegExp | null,
-  exclude?: Array<string | RegExp> | string | RegExp | null,
+  include?: FilterPattern,
+  exclude?: FilterPattern,
   options?: { resolve?: string | false | null }
 ) => (id: string | any) => boolean;
 export const createFilter: CreateFilter;
@@ -32,10 +41,10 @@ export const createFilter: CreateFilter;
 export type MakeLegalIdentifier = (str: string) => string;
 export const makeLegalIdentifier: MakeLegalIdentifier;
 
-export type DataToEsm = (data: any, options?: DataToEsmOptions) => string;
+export type DataToEsm = (data: unknown, options?: DataToEsmOptions) => string;
 export const dataToEsm: DataToEsm;
 
-export type ExtractAssignedNames = (param: Node) => Array<string>;
+export type ExtractAssignedNames = (param: BaseNode) => string[];
 export const extractAssignedNames: ExtractAssignedNames;
 
 declare const defaultExport: {

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "@rollup/plugin-buble": "^0.21.0",
     "@rollup/plugin-commonjs": "^11.0.1",
-    "@rollup/plugin-typescript": "^2.0.1",
+    "@rollup/plugin-typescript": "^3.0.0",
     "buble": "^0.19.8",
     "rollup": "^1.27.14",
     "tslib": "^1.10.0",

--- a/packages/typescript/src/diagnostics.ts
+++ b/packages/typescript/src/diagnostics.ts
@@ -50,7 +50,7 @@ export function diagnosticToWarning(
 
   if (diagnostic.file) {
     // Add information about the file location
-    const { line, character } = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);
+    const { line, character } = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start!);
 
     warning.loc = {
       column: character + 1,

--- a/packages/typescript/src/documentRegistry.ts
+++ b/packages/typescript/src/documentRegistry.ts
@@ -15,7 +15,7 @@ export default function getDocumentRegistry(ts: typeof import('typescript'), cwd
   if (!globalRegistryCache.has(ts)) {
     globalRegistryCache.set(ts, new Map());
   }
-  const instanceRegistryCache = globalRegistryCache.get(ts);
+  const instanceRegistryCache = globalRegistryCache.get(ts)!;
   if (!instanceRegistryCache.has(cwd)) {
     instanceRegistryCache.set(
       cwd,

--- a/packages/typescript/src/host.ts
+++ b/packages/typescript/src/host.ts
@@ -72,7 +72,7 @@ export default function createHost(
       }
       addFile(id, code);
     }
-    return files.get(id);
+    return files.get(id)!;
   }
 
   parsedOptions.fileNames.forEach((id) => getFile(id));

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -65,7 +65,7 @@ export default function typescript(options: RollupTypescriptOptions = {}): Plugi
 
       if (output.emitSkipped) {
         // Emit failed, print all diagnostics for this file
-        const allDiagnostics: import('typescript').Diagnostic[] = []
+        const allDiagnostics = ([] as import('typescript').Diagnostic[])
           .concat(services.getSyntacticDiagnostics(id))
           .concat(services.getSemanticDiagnostics(id));
         emitDiagnostics(ts, this, host, allDiagnostics);

--- a/packages/typescript/src/options.ts
+++ b/packages/typescript/src/options.ts
@@ -84,7 +84,7 @@ export function getPluginOptions(options: RollupTypescriptOptions) {
  * If `false` is passed, then a null path is returned.
  * @returns The absolute path, or null if the file does not exist.
  */
-function getTsConfigPath(ts: typeof import('typescript'), relativePath: string | false) {
+function getTsConfigPath(ts: typeof import('typescript'), relativePath?: string | false) {
   if (relativePath === false) return null;
 
   // Resolve path to file. `tsConfigOption` defaults to 'tsconfig.json'.

--- a/packages/typescript/src/tslib.ts
+++ b/packages/typescript/src/tslib.ts
@@ -9,7 +9,7 @@ const readFileAsync = (file: string) =>
     readFile(file, 'utf-8', (err, contents) => (err ? reject(err) : fulfil(contents)))
   );
 
-const resolveIdAsync = (file: string, opts?: AsyncOpts) =>
+const resolveIdAsync = (file: string, opts: AsyncOpts) =>
   new Promise<string>((fulfil, reject) =>
     resolveId(file, opts, (err, contents) => (err ? reject(err) : fulfil(contents)))
   );

--- a/packages/typescript/tsconfig.json
+++ b/packages/typescript/tsconfig.json
@@ -3,10 +3,10 @@
   "compilerOptions": {
     "lib": ["es6"],
     "module": "esnext",
-    "allowJs": true,
-    "target": "es2017"
+    "allowJs": true
   },
   "include": [
+    "src/**/*",
     "types/**/*",
     "typings-test.js"
   ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,12 +146,12 @@ importers:
       typescript: ^3.7.4
   packages/data-uri:
     devDependencies:
-      '@rollup/plugin-typescript': 2.1.0_rollup@1.29.0+typescript@3.7.5
-      '@rollup/pluginutils': 3.0.4_rollup@1.29.0
+      '@rollup/plugin-typescript': 3.0.0_rollup@1.29.0+typescript@3.7.5
+      '@rollup/pluginutils': 3.0.6_rollup@1.29.0
       rollup: 1.29.0
       typescript: 3.7.5
     specifiers:
-      '@rollup/plugin-typescript': ^2.1.0
+      '@rollup/plugin-typescript': ^3.0.0
       '@rollup/pluginutils': ^3.0.1
       rollup: ^1.27.14
       typescript: ^3.7.4
@@ -279,6 +279,7 @@ importers:
     dependencies:
       estree-walker: 1.0.1
     devDependencies:
+      '@rollup/plugin-typescript': 3.0.0_typescript@3.7.5
       '@types/estree': 0.0.39
       '@types/jest': 24.9.0
       '@types/micromatch': 3.1.1
@@ -286,9 +287,9 @@ importers:
       micromatch: 4.0.2
       rollup-plugin-commonjs: 10.1.0
       rollup-plugin-node-resolve: 5.2.0
-      rollup-plugin-typescript: 1.0.1_typescript@3.7.5
       typescript: 3.7.5
     specifiers:
+      '@rollup/plugin-typescript': ^3.0.0
       '@types/estree': 0.0.39
       '@types/jest': ^24.0.23
       '@types/micromatch': ^3.1.1
@@ -297,7 +298,6 @@ importers:
       micromatch: ^4.0.2
       rollup-plugin-commonjs: ^10.1.0
       rollup-plugin-node-resolve: ^5.2.0
-      rollup-plugin-typescript: ^1.0.1
       typescript: ^3.7.2
   packages/replace:
     dependencies:
@@ -356,12 +356,12 @@ importers:
       sucrase: ^3.10.1
   packages/typescript:
     dependencies:
-      '@rollup/pluginutils': 3.0.4_rollup@1.29.0
+      '@rollup/pluginutils': 3.0.6_rollup@1.29.0
       resolve: 1.14.2
     devDependencies:
       '@rollup/plugin-buble': 0.21.0_rollup@1.29.0
       '@rollup/plugin-commonjs': 11.0.1_rollup@1.29.0
-      '@rollup/plugin-typescript': 2.1.0_a8ccbbb8df3d541f86d9e2f77577b79b
+      '@rollup/plugin-typescript': 3.0.0_a8ccbbb8df3d541f86d9e2f77577b79b
       buble: 0.19.8
       rollup: 1.29.0
       tslib: 1.10.0
@@ -369,7 +369,7 @@ importers:
     specifiers:
       '@rollup/plugin-buble': ^0.21.0
       '@rollup/plugin-commonjs': ^11.0.1
-      '@rollup/plugin-typescript': ^2.0.1
+      '@rollup/plugin-typescript': ^3.0.0
       '@rollup/pluginutils': ^3.0.1
       buble: ^0.19.8
       resolve: ^1.14.1
@@ -1416,10 +1416,10 @@ packages:
       rollup: ^1.20.0
     resolution:
       integrity: sha512-+vOx2+WMBMFotYKM3yYeDGZxIvcQ7yO4g+SuKDFsjKaq8Lw3EPgfB6qNlp8Z/3ceDCEhHvC9/b+PgBGwDQGbzQ==
-  /@rollup/plugin-typescript/2.1.0_a8ccbbb8df3d541f86d9e2f77577b79b:
+  /@rollup/plugin-typescript/3.0.0_a8ccbbb8df3d541f86d9e2f77577b79b:
     dependencies:
-      '@rollup/pluginutils': 3.0.4_rollup@1.29.0
-      resolve: 1.14.2
+      '@rollup/pluginutils': 3.0.6_rollup@1.29.0
+      resolve: 1.15.0
       rollup: 1.29.0
       tslib: 1.10.0
       typescript: 3.7.5
@@ -1431,11 +1431,11 @@ packages:
       tslib: '*'
       typescript: '>=2.1.0'
     resolution:
-      integrity: sha512-7lXKGY06aofrceVez/YnN2axttFdHSqlUBpCJ6ebzDfxwLDKMgSV5lD4ykBcdgE7aK3egxuLkD/HKyRB5L8Log==
-  /@rollup/plugin-typescript/2.1.0_rollup@1.29.0+typescript@3.7.5:
+      integrity: sha512-O6915Ril3+Q0B4P898PULAcPFZfPuatEB/4nox7bnK48ekGrmamMYhMB5tOqWjihEWrw4oz/NL+c+/kS3Fk95g==
+  /@rollup/plugin-typescript/3.0.0_rollup@1.29.0+typescript@3.7.5:
     dependencies:
-      '@rollup/pluginutils': 3.0.4_rollup@1.29.0
-      resolve: 1.14.2
+      '@rollup/pluginutils': 3.0.6_rollup@1.29.0
+      resolve: 1.15.0
       rollup: 1.29.0
       typescript: 3.7.5
     dev: true
@@ -1446,7 +1446,21 @@ packages:
       tslib: '*'
       typescript: '>=2.1.0'
     resolution:
-      integrity: sha512-7lXKGY06aofrceVez/YnN2axttFdHSqlUBpCJ6ebzDfxwLDKMgSV5lD4ykBcdgE7aK3egxuLkD/HKyRB5L8Log==
+      integrity: sha512-O6915Ril3+Q0B4P898PULAcPFZfPuatEB/4nox7bnK48ekGrmamMYhMB5tOqWjihEWrw4oz/NL+c+/kS3Fk95g==
+  /@rollup/plugin-typescript/3.0.0_typescript@3.7.5:
+    dependencies:
+      '@rollup/pluginutils': 3.0.6
+      resolve: 1.15.0
+      typescript: 3.7.5
+    dev: true
+    engines:
+      node: '>=8.0.0'
+    peerDependencies:
+      rollup: ^1.20.0
+      tslib: '*'
+      typescript: '>=2.1.0'
+    resolution:
+      integrity: sha512-O6915Ril3+Q0B4P898PULAcPFZfPuatEB/4nox7bnK48ekGrmamMYhMB5tOqWjihEWrw4oz/NL+c+/kS3Fk95g==
   /@rollup/pluginutils/3.0.4:
     dependencies:
       estree-walker: 0.6.1
@@ -1465,11 +1479,20 @@ packages:
       rollup: ^1.20.0
     resolution:
       integrity: sha512-buc0oeq2zqQu2mpMyvZgAaQvitikYjT/4JYhA4EXwxX8/g0ZGHoGiX+0AwmfhrNqH4oJv67gn80sTZFQ/jL1bw==
+  /@rollup/pluginutils/3.0.6:
+    dependencies:
+      estree-walker: 1.0.1
+    dev: true
+    engines:
+      node: '>= 8.0.0'
+    peerDependencies:
+      rollup: ^1.20.0
+    resolution:
+      integrity: sha512-Nb6U7sg11v8D+E4mxRxwT+UumUL7MSnwI8V1SJB3THyW2MOGD/Q6GyxLtpnjrbT3zTRPSozzDMyVZwemgldO3w==
   /@rollup/pluginutils/3.0.6_rollup@1.29.0:
     dependencies:
       estree-walker: 1.0.1
       rollup: 1.29.0
-    dev: false
     engines:
       node: '>= 8.0.0'
     peerDependencies:
@@ -3348,7 +3371,6 @@ packages:
     resolution:
       integrity: sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==
   /estree-walker/1.0.1:
-    dev: false
     resolution:
       integrity: sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==
   /esutils/2.0.3:
@@ -6323,6 +6345,12 @@ packages:
       path-parse: 1.0.6
     resolution:
       integrity: sha512-EjlOBLBO1kxsUxsKjLt7TAECyKW6fOh1VRkykQkKGzcBbjjPIxBqGh0jf7GJ3k/f5mxMqW3htMD3WdTUVtW8HQ==
+  /resolve/1.15.0:
+    dependencies:
+      path-parse: 1.0.6
+    dev: true
+    resolution:
+      integrity: sha512-+hTmAldEGE80U2wJJDC1lebb5jWqvTYAfm3YZ1ckk1gBr0MnCqUKlwK1e+anaFljIl+F5tR5IoZcm4ZDA1zMQw==
   /responselike/1.0.2:
     dependencies:
       lowercase-keys: 1.0.1
@@ -6456,18 +6484,6 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-d12oKl6za/GGXmlytzVPzzTdPCKgti/Kq2kNhtfm5vv9hkNbyrTvizMBm6zZ5rRWX/sIWl3znjIJ8xy6Hofoeg==
-  /rollup-plugin-typescript/1.0.1_typescript@3.7.5:
-    dependencies:
-      resolve: 1.14.2
-      rollup-pluginutils: 2.8.2
-      typescript: 3.7.5
-    deprecated: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-typescript.
-    dev: true
-    peerDependencies:
-      tslib: '*'
-      typescript: '>=2.1.0'
-    resolution:
-      integrity: sha512-rwJDNn9jv/NsKZuyBb/h0jsclP4CJ58qbvZt2Q9zDIGILF2LtdtvCqMOL+Gq9IVq5MTrTlHZNrn8h7VjQgd8tw==
   /rollup-pluginutils/2.8.2:
     dependencies:
       estree-walker: 0.6.1

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,14 +4,15 @@
     "lib": ["es6"],
     "module": "commonjs",
     "moduleResolution": "node",
-    "noEmitOnError": true,
+    "noEmit": true,
+    "noEmitOnError": false,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "pretty": true,
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
-    "target": "es2015"
+    "target": "es2017"
   },
   "exclude": ["dist", "node_modules", "test/types"]
 }


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Names: `data-uri, pluginutils, typescript`

This PR contains:

- [ ] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
Now that the new Typescript plugin is released lets start using it for typechecking our plugins! 

I've worked to normalize the tsconfig settings we use across the different plugins. The es2017 target was chosen because its the highest that Node 8 supports. The `src` glob is used so that VSCode and other IDEs can tell that a tsconfig file affects the corresponding plugin.

estree-walker doesn't export the `Node` type so its imported from `@types/estree` instead. I use an inline import because ESLint complains about importing a module we don't depend on.