### PR TITLE
fix(typescript): Use builtin extends resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ pnpm-debug.log
 
 !packages/node-resolve/test/fixtures/**/node_modules
 !packages/commonjs/test/**/node_modules
+!packages/typescript/test/fixtures/**/node_modules

--- a/packages/typescript/src/options.ts
+++ b/packages/typescript/src/options.ts
@@ -114,12 +114,6 @@ function readTsConfigFile(ts: typeof import('typescript'), tsConfigPath: string)
     throw Object.assign(Error(), diagnosticToWarning(ts, null, error));
   }
 
-  const extendedTsConfig: string = config?.extends;
-  if (extendedTsConfig) {
-    // Get absolute path of `extends`, starting at basedir of the tsconfig file.
-    config.extends = resolve(process.cwd(), tsConfigPath, '..', extendedTsConfig);
-  }
-
   return config || {};
 }
 

--- a/packages/typescript/test/fixtures/tsconfig-extends-module/main.tsx
+++ b/packages/typescript/test/fixtures/tsconfig-extends-module/main.tsx
@@ -1,0 +1,3 @@
+const props = {};
+// @ts-ignore
+export default <span {...props}>Yo!</span>;

--- a/packages/typescript/test/fixtures/tsconfig-extends-module/node_modules/shared-config/package.json
+++ b/packages/typescript/test/fixtures/tsconfig-extends-module/node_modules/shared-config/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "shared-config",
+  "tsconfig": "tsconfig.json"
+}

--- a/packages/typescript/test/fixtures/tsconfig-extends-module/node_modules/shared-config/tsconfig.json
+++ b/packages/typescript/test/fixtures/tsconfig-extends-module/node_modules/shared-config/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "jsx": "react"
+  }
+}

--- a/packages/typescript/test/fixtures/tsconfig-extends-module/tsconfig.json
+++ b/packages/typescript/test/fixtures/tsconfig-extends-module/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "shared-config",
+  "compilerOptions": {
+    "allowJs": true
+  }
+}

--- a/packages/typescript/test/test.js
+++ b/packages/typescript/test/test.js
@@ -347,6 +347,22 @@ test.serial('should support extends property with given tsconfig', async (t) => 
   t.not(usage, -1, 'should contain usage');
 });
 
+test.serial('should support extends property with node resolution', async (t) => {
+  process.chdir('fixtures/tsconfig-extends-module');
+
+  const bundle = await rollup({
+    input: 'main.tsx',
+    plugins: [
+      typescript()
+    ],
+    onwarn
+  });
+  const code = await getCode(bundle, outputOptions);
+
+  const usage = code.includes('React.createElement("span", __assign({}, props), "Yo!")');
+  t.true(usage, 'should contain usage');
+});
+
 test('complies code that uses browser functions', async (t) => {
   const bundle = await rollup({
     input: 'fixtures/dom/main.ts',


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `typescript`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers: #70 

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
Adds test for extending a node module in tsconfig.json. 

Passing the path to `parseJsonConfigFileContent` means that we don't need the previous `extends` fix, so we can fully rely on built-in Typescript behaviour.