### PR TITLE
chore(typescript): refactor compiler host

### DIFF
--- a/packages/typescript/src/diagnostics/emit.ts
+++ b/packages/typescript/src/diagnostics/emit.ts
@@ -1,0 +1,34 @@
+import { PluginContext } from 'rollup';
+
+import { DiagnosticsHost } from './host';
+import diagnosticToWarning from './toWarning';
+
+// `Cannot compile modules into 'es6' when targeting 'ES5' or lower.`
+const CANNOT_COMPILE_ESM = 1204;
+
+/**
+ * For each type error reported by Typescript, emit a Rollup warning or error.
+ */
+export default function emitDiagnostics(
+  ts: typeof import('typescript'),
+  context: PluginContext,
+  host: DiagnosticsHost,
+  diagnostics: readonly import('typescript').Diagnostic[] | undefined
+) {
+  if (!diagnostics) return;
+  const { noEmitOnError } = host.getCompilationSettings();
+
+  diagnostics
+    .filter((diagnostic) => diagnostic.code !== CANNOT_COMPILE_ESM)
+    .forEach((diagnostic) => {
+      // Build a Rollup warning object from the diagnostics object.
+      const warning = diagnosticToWarning(ts, host, diagnostic);
+
+      // Errors are fatal. Otherwise emit warnings.
+      if (noEmitOnError && diagnostic.category === ts.DiagnosticCategory.Error) {
+        context.error(warning);
+      } else {
+        context.warn(warning);
+      }
+    });
+}

--- a/packages/typescript/src/diagnostics/host.ts
+++ b/packages/typescript/src/diagnostics/host.ts
@@ -1,0 +1,38 @@
+type FormatDiagnosticsHost = import('typescript').FormatDiagnosticsHost;
+
+export interface DiagnosticsHost extends FormatDiagnosticsHost {
+  getCompilationSettings(): import('typescript').CompilerOptions;
+}
+
+/**
+ * Create a format diagnostics host to use with the Typescript type checking APIs.
+ * Typescript hosts are used to represent the user's system,
+ * with an API for checking case sensitivity etc.
+ * @param compilerOptions Typescript compiler options. Affects functions such as `getNewLine`.
+ * @see https://github.com/Microsoft/TypeScript/wiki/Using-the-Compiler-API
+ */
+export default function createFormattingHost(
+  ts: typeof import('typescript'),
+  compilerOptions: import('typescript').CompilerOptions
+): DiagnosticsHost {
+  return {
+    /** Returns the compiler options for the project. */
+    getCompilationSettings: () => compilerOptions,
+    /** Returns the current working directory. */
+    getCurrentDirectory: () => process.cwd(),
+    /** Returns the string that corresponds with the selected `NewLineKind`. */
+    getNewLine() {
+      switch (compilerOptions.newLine) {
+        case ts.NewLineKind.CarriageReturnLineFeed:
+          return '\r\n';
+        case ts.NewLineKind.LineFeed:
+          return '\n';
+        default:
+          return ts.sys.newLine;
+      }
+    },
+    /** Returns a lower case name on case insensitive systems, otherwise the original name. */
+    getCanonicalFileName: (fileName) =>
+      ts.sys.useCaseSensitiveFileNames ? fileName : fileName.toLowerCase()
+  };
+}

--- a/packages/typescript/src/diagnostics/toWarning.ts
+++ b/packages/typescript/src/diagnostics/toWarning.ts
@@ -1,40 +1,9 @@
-import { PluginContext, RollupLogProps } from 'rollup';
-
-// `Cannot compile modules into 'es6' when targeting 'ES5' or lower.`
-const CANNOT_COMPILE_ESM = 1204;
-
-/**
- * For each type error reported by Typescript, emit a Rollup warning or error.
- */
-export function emitDiagnostics(
-  ts: typeof import('typescript'),
-  context: PluginContext,
-  host: import('typescript').FormatDiagnosticsHost &
-    Pick<import('typescript').LanguageServiceHost, 'getCompilationSettings'>,
-  diagnostics: readonly import('typescript').Diagnostic[] | undefined
-) {
-  if (!diagnostics) return;
-  const { noEmitOnError } = host.getCompilationSettings();
-
-  diagnostics
-    .filter((diagnostic) => diagnostic.code !== CANNOT_COMPILE_ESM)
-    .forEach((diagnostic) => {
-      // Build a Rollup warning object from the diagnostics object.
-      const warning = diagnosticToWarning(ts, host, diagnostic);
-
-      // Errors are fatal. Otherwise emit warnings.
-      if (noEmitOnError && diagnostic.category === ts.DiagnosticCategory.Error) {
-        context.error(warning);
-      } else {
-        context.warn(warning);
-      }
-    });
-}
+import { RollupLogProps } from 'rollup';
 
 /**
  * Converts a Typescript type error into an equivalent Rollup warning object.
  */
-export function diagnosticToWarning(
+export default function diagnosticToWarning(
   ts: typeof import('typescript'),
   host: import('typescript').FormatDiagnosticsHost | null,
   diagnostic: import('typescript').Diagnostic

--- a/packages/typescript/src/moduleResolution/host.ts
+++ b/packages/typescript/src/moduleResolution/host.ts
@@ -1,0 +1,19 @@
+export type ModuleResolutionHost = import('typescript').ModuleResolutionHost;
+
+/**
+ * Creates a module resolution host to use with the Typescript compiler API.
+ * Typescript hosts are used to represent the user's system,
+ * with an API for reading files, checking directories and case sensitivity etc.
+ * @see https://github.com/Microsoft/TypeScript/wiki/Using-the-Compiler-API
+ */
+export default function createModuleResolutionHost(
+  ts: typeof import('typescript')
+): ModuleResolutionHost {
+  return {
+    fileExists: ts.sys.fileExists,
+    readFile: ts.sys.readFile,
+    directoryExists: ts.sys.directoryExists,
+    realpath: ts.sys.realpath,
+    getDirectories: ts.sys.getDirectories
+  };
+}

--- a/packages/typescript/src/moduleResolution/resolver.ts
+++ b/packages/typescript/src/moduleResolution/resolver.ts
@@ -1,6 +1,7 @@
-type ModuleResolverHost = import('typescript').ModuleResolutionHost &
-  Pick<import('typescript').FormatDiagnosticsHost, 'getCanonicalFileName'> &
-  Pick<import('typescript').LanguageServiceHost, 'getCompilationSettings'>;
+import { DiagnosticsHost } from '../diagnostics/host';
+
+type ModuleResolutionHost = import('typescript').ModuleResolutionHost;
+type ModuleResolverHost = ModuleResolutionHost & DiagnosticsHost;
 
 export type Resolver = (
   moduleName: string,
@@ -9,6 +10,8 @@ export type Resolver = (
 
 /**
  * Create a helper for resolving modules using Typescript.
+ * @param host Typescript host that extends `ModuleResolutionHost`
+ * with methods for sanitizing filenames and getting compiler options.
  */
 export default function createModuleResolver(
   ts: typeof import('typescript'),

--- a/packages/typescript/test/test.js
+++ b/packages/typescript/test/test.js
@@ -352,9 +352,7 @@ test.serial('should support extends property with node resolution', async (t) =>
 
   const bundle = await rollup({
     input: 'main.tsx',
-    plugins: [
-      typescript()
-    ],
+    plugins: [typescript()],
     onwarn
   });
   const code = await getCode(bundle, outputOptions);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `typescript`

This PR contains:

- [ ] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
Separates the host object. This makes it easier for me to try out different compiler APIs as I don't need to refactor a single object every time.