### PR TITLE
chore(pluginutils): Don't bundle micromatch

### DIFF
--- a/packages/pluginutils/package.json
+++ b/packages/pluginutils/package.json
@@ -47,17 +47,17 @@
     "rollup": "^1.20.0"
   },
   "dependencies": {
-    "estree-walker": "^1.0.1"
+    "estree-walker": "^1.0.1",
+    "micromatch": "^4.0.2"
   },
   "devDependencies": {
+    "@rollup/plugin-commonjs": "^11.0.2",
+    "@rollup/plugin-node-resolve": "^7.1.1",
     "@rollup/plugin-typescript": "^3.0.0",
     "@types/estree": "0.0.39",
     "@types/jest": "^24.9.0",
     "@types/micromatch": "^3.1.1",
     "@types/node": "^12.12.25",
-    "micromatch": "^4.0.2",
-    "rollup-plugin-commonjs": "^10.1.0",
-    "rollup-plugin-node-resolve": "^5.2.0",
     "typescript": "^3.7.5"
   },
   "ava": {

--- a/packages/pluginutils/rollup.config.js
+++ b/packages/pluginutils/rollup.config.js
@@ -1,6 +1,6 @@
+import commonjs from '@rollup/plugin-commonjs';
+import resolve from '@rollup/plugin-node-resolve';
 import typescript from '@rollup/plugin-typescript';
-import resolve from 'rollup-plugin-node-resolve';
-import commonjs from 'rollup-plugin-commonjs';
 
 import pkg from './package.json';
 
@@ -11,11 +11,12 @@ export default {
     commonjs({ include: '../../node_modules/.pnpm/registry.npmjs.org/**' }),
     typescript({ include: '**/*.{ts,js}' })
   ],
-  external: ['estree-walker', 'path', 'util'],
+  external: Object.keys(pkg.dependencies).concat('path', 'util'),
   output: [
     {
       format: 'cjs',
-      file: pkg.main
+      file: pkg.main,
+      exports: 'named'
     },
     {
       format: 'es',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,7 +55,7 @@ importers:
     dependencies:
       slash: 3.0.0
     devDependencies:
-      '@rollup/plugin-node-resolve': 7.0.0_rollup@1.29.0
+      '@rollup/plugin-node-resolve': 7.1.1_rollup@1.29.0
       del-cli: 3.0.0
       rollup: 1.29.0
     specifiers:
@@ -67,7 +67,7 @@ importers:
     dependencies:
       node-noop: 1.0.0
     devDependencies:
-      '@rollup/plugin-node-resolve': 7.0.0_rollup@1.29.0
+      '@rollup/plugin-node-resolve': 7.1.1_rollup@1.29.0
       del: 5.1.0
       rollup: 1.29.0
     specifiers:
@@ -84,7 +84,7 @@ importers:
       strip-ansi: ^5.2.0
   packages/buble:
     dependencies:
-      '@rollup/pluginutils': 3.0.4_rollup@1.29.0
+      '@rollup/pluginutils': 3.0.8_rollup@1.29.0
       '@types/buble': 0.19.2
       buble: 0.19.8
     devDependencies:
@@ -102,7 +102,7 @@ importers:
       typescript: ^3.7.4
   packages/commonjs:
     dependencies:
-      '@rollup/pluginutils': 3.0.4_rollup@1.29.0
+      '@rollup/pluginutils': 3.0.8_rollup@1.29.0
       estree-walker: 1.0.1
       is-reference: 1.1.4
       magic-string: 0.25.6
@@ -112,7 +112,7 @@ importers:
       '@babel/preset-env': 7.8.3_@babel+core@7.8.3
       '@babel/register': 7.8.3_@babel+core@7.8.3
       '@rollup/plugin-json': 4.0.1_rollup@1.29.0
-      '@rollup/plugin-node-resolve': 7.0.0_rollup@1.29.0
+      '@rollup/plugin-node-resolve': 7.1.1_rollup@1.29.0
       acorn: 7.1.0
       locate-character: 2.0.5
       prettier: 1.19.1
@@ -147,7 +147,7 @@ importers:
   packages/data-uri:
     devDependencies:
       '@rollup/plugin-typescript': 3.0.0_rollup@1.29.0+typescript@3.7.5
-      '@rollup/pluginutils': 3.0.6_rollup@1.29.0
+      '@rollup/pluginutils': 3.0.8_rollup@1.29.0
       rollup: 1.29.0
       typescript: 3.7.5
     specifiers:
@@ -157,7 +157,7 @@ importers:
       typescript: ^3.7.4
   packages/dsv:
     dependencies:
-      '@rollup/pluginutils': 3.0.4_rollup@1.29.0
+      '@rollup/pluginutils': 3.0.8_rollup@1.29.0
       d3-dsv: 1.2.0
       tosource: 1.0.0
     devDependencies:
@@ -178,7 +178,7 @@ importers:
       rollup-plugin-postcss: ^2.0.3
   packages/image:
     dependencies:
-      '@rollup/pluginutils': 3.0.4_rollup@1.29.0
+      '@rollup/pluginutils': 3.0.8_rollup@1.29.0
       mini-svg-data-uri: 1.1.3
     devDependencies:
       '@rollup/plugin-buble': 0.21.0_rollup@1.29.0
@@ -190,7 +190,7 @@ importers:
       rollup: ^1.29.0
   packages/inject:
     dependencies:
-      '@rollup/pluginutils': 3.0.4_rollup@1.29.0
+      '@rollup/pluginutils': 3.0.8_rollup@1.29.0
       estree-walker: 1.0.1
       magic-string: 0.25.6
     devDependencies:
@@ -212,10 +212,10 @@ importers:
       typescript: ^3.7.4
   packages/json:
     dependencies:
-      '@rollup/pluginutils': 3.0.4
+      '@rollup/pluginutils': 3.0.8
     devDependencies:
       '@rollup/plugin-buble': 0.21.0
-      '@rollup/plugin-node-resolve': 7.0.0
+      '@rollup/plugin-node-resolve': 7.1.1
       source-map-support: 0.5.16
     specifiers:
       '@rollup/plugin-buble': ^0.21.0
@@ -247,7 +247,7 @@ importers:
       rollup-plugin-babel: ^4.0.3
   packages/node-resolve:
     dependencies:
-      '@rollup/pluginutils': 3.0.6_rollup@1.29.0
+      '@rollup/pluginutils': 3.0.8_rollup@1.29.0
       '@types/resolve': 0.0.8
       builtin-modules: 3.1.0
       is-module: 1.0.0
@@ -280,17 +280,19 @@ importers:
   packages/pluginutils:
     dependencies:
       estree-walker: 1.0.1
+      micromatch: 4.0.2
     devDependencies:
+      '@rollup/plugin-commonjs': 11.0.2
+      '@rollup/plugin-node-resolve': 7.1.1
       '@rollup/plugin-typescript': 3.0.0_typescript@3.7.5
       '@types/estree': 0.0.39
       '@types/jest': 24.9.0
       '@types/micromatch': 3.1.1
       '@types/node': 12.12.25
-      micromatch: 4.0.2
-      rollup-plugin-commonjs: 10.1.0
-      rollup-plugin-node-resolve: 5.2.0
       typescript: 3.7.5
     specifiers:
+      '@rollup/plugin-commonjs': ^11.0.2
+      '@rollup/plugin-node-resolve': ^7.1.1
       '@rollup/plugin-typescript': ^3.0.0
       '@types/estree': 0.0.39
       '@types/jest': ^24.9.0
@@ -298,12 +300,10 @@ importers:
       '@types/node': ^12.12.25
       estree-walker: ^1.0.1
       micromatch: ^4.0.2
-      rollup-plugin-commonjs: ^10.1.0
-      rollup-plugin-node-resolve: ^5.2.0
       typescript: ^3.7.5
   packages/replace:
     dependencies:
-      '@rollup/pluginutils': 3.0.4_rollup@1.29.0
+      '@rollup/pluginutils': 3.0.8_rollup@1.29.0
       magic-string: 0.25.6
     devDependencies:
       '@rollup/plugin-buble': 0.21.0_rollup@1.29.0
@@ -334,7 +334,7 @@ importers:
       sinon: 8.0.4
   packages/strip:
     dependencies:
-      '@rollup/pluginutils': 3.0.4_rollup@1.29.0
+      '@rollup/pluginutils': 3.0.8_rollup@1.29.0
       estree-walker: 1.0.1
       magic-string: 0.25.6
     devDependencies:
@@ -348,7 +348,7 @@ importers:
       rollup: ^1.27.14
   packages/sucrase:
     dependencies:
-      '@rollup/pluginutils': 3.0.4_rollup@1.29.0
+      '@rollup/pluginutils': 3.0.8_rollup@1.29.0
       sucrase: 3.12.1
     devDependencies:
       rollup: 1.29.0
@@ -358,11 +358,11 @@ importers:
       sucrase: ^3.10.1
   packages/typescript:
     dependencies:
-      '@rollup/pluginutils': 3.0.6_rollup@1.29.0
+      '@rollup/pluginutils': 3.0.8_rollup@1.29.0
       resolve: 1.14.2
     devDependencies:
       '@rollup/plugin-buble': 0.21.0_rollup@1.29.0
-      '@rollup/plugin-commonjs': 11.0.1_rollup@1.29.0
+      '@rollup/plugin-commonjs': 11.0.2_rollup@1.29.0
       '@rollup/plugin-typescript': 3.0.0_a8ccbbb8df3d541f86d9e2f77577b79b
       buble: 0.19.8
       rollup: 1.29.0
@@ -380,7 +380,7 @@ importers:
       typescript: ^3.7.4
   packages/url:
     dependencies:
-      '@rollup/pluginutils': 3.0.4_rollup@1.29.0
+      '@rollup/pluginutils': 3.0.8_rollup@1.29.0
       make-dir: 3.0.0
       mime: 2.4.4
     devDependencies:
@@ -404,7 +404,7 @@ importers:
       rollup-plugin-babel: ^4.3.3
   packages/virtual:
     devDependencies:
-      '@rollup/plugin-node-resolve': 7.0.0_rollup@1.29.0
+      '@rollup/plugin-node-resolve': 7.1.1_rollup@1.29.0
       rollup: 1.29.0
     specifiers:
       '@rollup/plugin-node-resolve': ^7.0.0
@@ -420,7 +420,7 @@ importers:
       source-map: ^0.7.3
   packages/yaml:
     dependencies:
-      '@rollup/pluginutils': 3.0.4_rollup@1.29.0
+      '@rollup/pluginutils': 3.0.8_rollup@1.29.0
       js-yaml: 3.13.1
       tosource: 1.0.0
     devDependencies:
@@ -1350,10 +1350,24 @@ packages:
       rollup: ^1.20.0
     resolution:
       integrity: sha512-n6N311RCrVvnsWGyo/if6K2kFoDW+x9r+/hkp+fI73MryLFGxN50Y3zJDg3k0ZTDjRHmveVzM6Nzwv9+plWiLA==
-  /@rollup/plugin-commonjs/11.0.1_rollup@1.29.0:
+  /@rollup/plugin-commonjs/11.0.2:
+    dependencies:
+      '@rollup/pluginutils': 3.0.4
+      estree-walker: 1.0.1
+      is-reference: 1.1.4
+      magic-string: 0.25.6
+      resolve: 1.14.2
+    dev: true
+    engines:
+      node: '>= 8.0.0'
+    peerDependencies:
+      rollup: ^1.20.0
+    resolution:
+      integrity: sha512-MPYGZr0qdbV5zZj8/2AuomVpnRVXRU5XKXb3HVniwRoRCreGlf5kOE081isNWeiLIi6IYkwTX9zE0/c7V8g81g==
+  /@rollup/plugin-commonjs/11.0.2_rollup@1.29.0:
     dependencies:
       '@rollup/pluginutils': 3.0.4_rollup@1.29.0
-      estree-walker: 0.6.1
+      estree-walker: 1.0.1
       is-reference: 1.1.4
       magic-string: 0.25.6
       resolve: 1.14.2
@@ -1364,7 +1378,7 @@ packages:
     peerDependencies:
       rollup: ^1.20.0
     resolution:
-      integrity: sha512-SaVUoaLDg3KnIXC5IBNIspr1APTYDzk05VaYcI6qz+0XX3ZlSCwAkfAhNSOxfd5GAdcm/63Noi4TowOY9MpcDg==
+      integrity: sha512-MPYGZr0qdbV5zZj8/2AuomVpnRVXRU5XKXb3HVniwRoRCreGlf5kOE081isNWeiLIi6IYkwTX9zE0/c7V8g81g==
   /@rollup/plugin-json/4.0.1_rollup@1.29.0:
     dependencies:
       rollup: 1.29.0
@@ -1389,9 +1403,9 @@ packages:
       rollup: ^1.20.0
     resolution:
       integrity: sha512-Cv7PDIvxdE40SWilY5WgZpqfIUEaDxFxs89zCAHjqyRwlTSuql4M5hjIuc5QYJkOH0/vyiyNXKD72O+LhRipGA==
-  /@rollup/plugin-node-resolve/7.0.0:
+  /@rollup/plugin-node-resolve/7.1.1:
     dependencies:
-      '@rollup/pluginutils': 3.0.4
+      '@rollup/pluginutils': 3.0.8
       '@types/resolve': 0.0.8
       builtin-modules: 3.1.0
       is-module: 1.0.0
@@ -1402,10 +1416,10 @@ packages:
     peerDependencies:
       rollup: ^1.20.0
     resolution:
-      integrity: sha512-+vOx2+WMBMFotYKM3yYeDGZxIvcQ7yO4g+SuKDFsjKaq8Lw3EPgfB6qNlp8Z/3ceDCEhHvC9/b+PgBGwDQGbzQ==
-  /@rollup/plugin-node-resolve/7.0.0_rollup@1.29.0:
+      integrity: sha512-14ddhD7TnemeHE97a4rLOhobfYvUVcaYuqTnL8Ti7Jxi9V9Jr5LY7Gko4HZ5k4h4vqQM0gBQt6tsp9xXW94WPA==
+  /@rollup/plugin-node-resolve/7.1.1_rollup@1.29.0:
     dependencies:
-      '@rollup/pluginutils': 3.0.4_rollup@1.29.0
+      '@rollup/pluginutils': 3.0.8_rollup@1.29.0
       '@types/resolve': 0.0.8
       builtin-modules: 3.1.0
       is-module: 1.0.0
@@ -1417,7 +1431,7 @@ packages:
     peerDependencies:
       rollup: ^1.20.0
     resolution:
-      integrity: sha512-+vOx2+WMBMFotYKM3yYeDGZxIvcQ7yO4g+SuKDFsjKaq8Lw3EPgfB6qNlp8Z/3ceDCEhHvC9/b+PgBGwDQGbzQ==
+      integrity: sha512-14ddhD7TnemeHE97a4rLOhobfYvUVcaYuqTnL8Ti7Jxi9V9Jr5LY7Gko4HZ5k4h4vqQM0gBQt6tsp9xXW94WPA==
   /@rollup/plugin-typescript/3.0.0_a8ccbbb8df3d541f86d9e2f77577b79b:
     dependencies:
       '@rollup/pluginutils': 3.0.6_rollup@1.29.0
@@ -1466,6 +1480,7 @@ packages:
   /@rollup/pluginutils/3.0.4:
     dependencies:
       estree-walker: 0.6.1
+    dev: true
     engines:
       node: '>= 8.0.0'
     peerDependencies:
@@ -1475,6 +1490,8 @@ packages:
   /@rollup/pluginutils/3.0.4_rollup@1.29.0:
     dependencies:
       estree-walker: 0.6.1
+      rollup: 1.29.0
+    dev: true
     engines:
       node: '>= 8.0.0'
     peerDependencies:
@@ -1495,12 +1512,32 @@ packages:
     dependencies:
       estree-walker: 1.0.1
       rollup: 1.29.0
+    dev: true
     engines:
       node: '>= 8.0.0'
     peerDependencies:
       rollup: ^1.20.0
     resolution:
       integrity: sha512-Nb6U7sg11v8D+E4mxRxwT+UumUL7MSnwI8V1SJB3THyW2MOGD/Q6GyxLtpnjrbT3zTRPSozzDMyVZwemgldO3w==
+  /@rollup/pluginutils/3.0.8:
+    dependencies:
+      estree-walker: 1.0.1
+    engines:
+      node: '>= 8.0.0'
+    peerDependencies:
+      rollup: ^1.20.0
+    resolution:
+      integrity: sha512-rYGeAc4sxcZ+kPG/Tw4/fwJODC3IXHYDH4qusdN/b6aLw5LPUbzpecYbEJh4sVQGPFJxd2dBU4kc1H3oy9/bnw==
+  /@rollup/pluginutils/3.0.8_rollup@1.29.0:
+    dependencies:
+      estree-walker: 1.0.1
+      rollup: 1.29.0
+    engines:
+      node: '>= 8.0.0'
+    peerDependencies:
+      rollup: ^1.20.0
+    resolution:
+      integrity: sha512-rYGeAc4sxcZ+kPG/Tw4/fwJODC3IXHYDH4qusdN/b6aLw5LPUbzpecYbEJh4sVQGPFJxd2dBU4kc1H3oy9/bnw==
   /@samverschueren/stream-to-observable/0.3.0:
     dependencies:
       any-observable: 0.3.0
@@ -1628,6 +1665,9 @@ packages:
     dev: true
     resolution:
       integrity: sha512-nf1LMGZvgFX186geVZR1xMZKKblJiRfiASTHw85zED2kI1yDKHDwTKMdkaCbTlXoRKlGKaDfYywt+V0As30q3w==
+  /@types/node/12.12.28:
+    resolution:
+      integrity: sha512-g73GJYJDXgf0jqg+P9S8h2acWbDXNkoCX8DLtJVu7Fkn788pzQ/oJsrdJz/2JejRf/SjfZaAhsw+3nd1D5EWGg==
   /@types/node/13.1.6:
     dev: true
     resolution:
@@ -1645,7 +1685,7 @@ packages:
       integrity: sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==
   /@types/resolve/0.0.8:
     dependencies:
-      '@types/node': 13.1.8
+      '@types/node': 12.12.28
     resolution:
       integrity: sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
   /@types/yargs-parser/15.0.0:
@@ -2139,7 +2179,6 @@ packages:
   /braces/3.0.2:
     dependencies:
       fill-range: 7.0.1
-    dev: true
     engines:
       node: '>=8'
     resolution:
@@ -3370,6 +3409,7 @@ packages:
     resolution:
       integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
   /estree-walker/0.6.1:
+    dev: true
     resolution:
       integrity: sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==
   /estree-walker/1.0.1:
@@ -3523,7 +3563,6 @@ packages:
   /fill-range/7.0.1:
     dependencies:
       to-regex-range: 5.0.1
-    dev: true
     engines:
       node: '>=8'
     resolution:
@@ -4166,7 +4205,6 @@ packages:
     resolution:
       integrity: sha512-wsigDr1Kkschp2opC4G3yA6r9EgVA6NjRpWzIi9axXqeIaAATPRJc4uLujXe3Nd9uO8KoDyA4MD6aZSeXTADhA==
   /is-number/7.0.0:
-    dev: true
     engines:
       node: '>=0.12.0'
     resolution:
@@ -4928,7 +4966,6 @@ packages:
     dependencies:
       braces: 3.0.2
       picomatch: 2.2.1
-    dev: true
     engines:
       node: '>=8'
     resolution:
@@ -5499,7 +5536,6 @@ packages:
     resolution:
       integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
   /picomatch/2.2.1:
-    dev: true
     engines:
       node: '>=8.6'
     resolution:
@@ -6429,19 +6465,6 @@ packages:
       rollup: '>=0.60.0 <2'
     resolution:
       integrity: sha512-tKzWOCmIJD/6aKNz0H1GMM+lW1q9KyFubbWzGiOG540zxPPifnEAHTZwjo0g991Y+DyOZcLqBgqOdqazYE5fkw==
-  /rollup-plugin-commonjs/10.1.0:
-    dependencies:
-      estree-walker: 0.6.1
-      is-reference: 1.1.4
-      magic-string: 0.25.6
-      resolve: 1.14.2
-      rollup-pluginutils: 2.8.2
-    deprecated: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-commonjs.
-    dev: true
-    peerDependencies:
-      rollup: '>=1.12.0'
-    resolution:
-      integrity: sha512-jlXbjZSQg8EIeAAvepNwhJj++qJWNJw1Cl0YnOqKtP5Djx+fFGkp3WRh+W0ASCaFG5w1jhmzDxgu3SJuVxPF4Q==
   /rollup-plugin-commonjs/10.1.0_rollup@1.29.0:
     dependencies:
       estree-walker: 0.6.1
@@ -6456,19 +6479,6 @@ packages:
       rollup: '>=1.12.0'
     resolution:
       integrity: sha512-jlXbjZSQg8EIeAAvepNwhJj++qJWNJw1Cl0YnOqKtP5Djx+fFGkp3WRh+W0ASCaFG5w1jhmzDxgu3SJuVxPF4Q==
-  /rollup-plugin-node-resolve/5.2.0:
-    dependencies:
-      '@types/resolve': 0.0.8
-      builtin-modules: 3.1.0
-      is-module: 1.0.0
-      resolve: 1.14.2
-      rollup-pluginutils: 2.8.2
-    deprecated: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-node-resolve.
-    dev: true
-    peerDependencies:
-      rollup: '>=1.11.0'
-    resolution:
-      integrity: sha512-jUlyaDXts7TW2CqQ4GaO5VJ4PwwaV8VUGA7+km3n6k6xtOEacf61u0VXwN80phY/evMcaS+9eIeJ9MOyDxt5Zw==
   /rollup-plugin-postcss/2.0.3:
     dependencies:
       chalk: 2.4.2
@@ -7149,7 +7159,6 @@ packages:
   /to-regex-range/5.0.1:
     dependencies:
       is-number: 7.0.0
-    dev: true
     engines:
       node: '>=8.0'
     resolution:


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `pluginutils`

This PR contains:

- [ ] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
Moving from rollup-* to \@rollup/* and making micromatch an external dependency.

Micromatch was bundled for Node 6 compatibility, but we no longer support that version. Unbundling it can help with tree shaking.