### PR TITLE
feat(commonjs): export properties defined using Object.defineProperty(exports, ..)

### DIFF
--- a/packages/commonjs/src/transform.js
+++ b/packages/commonjs/src/transform.js
@@ -67,7 +67,7 @@ export function checkEsModule(parse, code, id) {
   return { isEsModule, hasDefaultExport: false, ast };
 }
 
-function defineProperty(node, targetName) {
+function isDefinePropertyCall(node, targetName) {
   if (node.type !== 'CallExpression') return;
 
   const {
@@ -318,8 +318,7 @@ export function transformCommonjs(
         return;
       }
 
-      // Is this a call to Object.defineProperty(exports, ...)?
-      const def = defineProperty(node, 'exports');
+      const def = isDefinePropertyCall(node, 'exports');
       if (def && def === makeLegalIdentifier(def)) namedExports[def] = true;
 
       // if this is `var x = require('x')`, we can do `import x from 'x'`

--- a/packages/commonjs/src/transform.js
+++ b/packages/commonjs/src/transform.js
@@ -67,7 +67,7 @@ export function checkEsModule(parse, code, id) {
   return { isEsModule, hasDefaultExport: false, ast };
 }
 
-function isDefinePropertyCall(node, targetName) {
+function getDefinePropertyCallName(node, targetName) {
   if (node.type !== 'CallExpression') return;
 
   const {
@@ -318,8 +318,8 @@ export function transformCommonjs(
         return;
       }
 
-      const def = isDefinePropertyCall(node, 'exports');
-      if (def && def === makeLegalIdentifier(def)) namedExports[def] = true;
+      const name = getDefinePropertyCallName(node, 'exports');
+      if (name && name === makeLegalIdentifier(name)) namedExports[name] = true;
 
       // if this is `var x = require('x')`, we can do `import x from 'x'`
       if (

--- a/packages/commonjs/test/fixtures/samples/define-property/foo.js
+++ b/packages/commonjs/test/fixtures/samples/define-property/foo.js
@@ -1,0 +1,6 @@
+Object.defineProperty(exports, "foo", {
+  enumerable: true,
+  get: function get() {
+    return "bar";
+  }
+});

--- a/packages/commonjs/test/fixtures/samples/define-property/main.js
+++ b/packages/commonjs/test/fixtures/samples/define-property/main.js
@@ -1,0 +1,1 @@
+export { foo } from "./foo";

--- a/packages/commonjs/test/test.js
+++ b/packages/commonjs/test/test.js
@@ -407,6 +407,15 @@ test('does not reexport named contents', async (t) => {
   }
 });
 
+test(`exports props defined by 'Object.defineProperty'`, async (t) => {
+  const bundle = await rollup({
+    input: 'fixtures/samples/define-property/main.js',
+    plugins: [commonjs()]
+  });
+  const m = await executeBundle(bundle, t);
+  t.is(m.exports.foo, 'bar');
+});
+
 test('respects other plugins', async (t) => {
   const bundle = await rollup({
     input: 'fixtures/samples/other-transforms/main.js',


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `commonjs `

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

### Description

This pr adds exports that have been defined using the `Object.defineProperty(exports, ...)` technique. I was running into an issue with a 3rd party lib (`@material-ui/core@3.9.4`) where it was using this technique to define the exports. Rollup was falling over with the error `export 'foo' is not exported by 'path/to/module'`. 
