### PR TITLE
fix(run): Support assets

### DIFF
--- a/packages/run/lib/index.js
+++ b/packages/run/lib/index.js
@@ -39,7 +39,6 @@ module.exports = (opts = {}) => {
       const dir = outputOptions.dir || path.dirname(outputOptions.file);
 
       let dest;
-      let hasEntry = false;
 
       for (const fileName in bundle) {
         if (Object.prototype.hasOwnProperty.call(bundle, fileName)) {
@@ -48,17 +47,11 @@ module.exports = (opts = {}) => {
           // eslint-disable-next-line no-continue
           if (!chunk.isEntry) continue;
 
-          hasEntry = true;
-
           if (chunk.modules[input]) {
             dest = path.join(dir, fileName);
             break;
           }
         }
-      }
-
-      if (hasEntry === false) {
-        this.error(`@rollup/plugin-run requires Rollup 0.65 or higher`);
       }
 
       if (dest) {

--- a/packages/run/lib/index.js
+++ b/packages/run/lib/index.js
@@ -39,23 +39,26 @@ module.exports = (opts = {}) => {
       const dir = outputOptions.dir || path.dirname(outputOptions.file);
 
       let dest;
+      let hasEntry = false;
 
       for (const fileName in bundle) {
         if (Object.prototype.hasOwnProperty.call(bundle, fileName)) {
           const chunk = bundle[fileName];
 
-          if (!('isEntry' in chunk)) {
-            this.error(`@rollup/plugin-run requires Rollup 0.65 or higher`);
-          }
-
           // eslint-disable-next-line no-continue
           if (!chunk.isEntry) continue;
+
+          hasEntry = true;
 
           if (chunk.modules[input]) {
             dest = path.join(dir, fileName);
             break;
           }
         }
+      }
+
+      if (hasEntry === false) {
+        this.error(`@rollup/plugin-run requires Rollup 0.65 or higher`);
       }
 
       if (dest) {

--- a/packages/run/test/test.js
+++ b/packages/run/test/test.js
@@ -83,6 +83,27 @@ test('detects changes - forks a new child process and kills older process', asyn
   t.is(mockChildProcess().kill.callCount, 1);
 });
 
+test('allow assets in output', async t => {
+  const bundle = await rollup({
+    input: join(cwd, 'input.js'),
+    plugins: [
+      {
+        transform(code) {
+          this.emitFile({
+            type: 'asset',
+            source: 'empty'
+          });
+          return code;
+        }
+      },
+      run()
+    ]
+  });
+  await t.notThrowsAsync(async () => {
+    await bundle.write({ dir: join(cwd, 'output'), format: 'cjs' });
+  });
+});
+
 test.after(async () => {
   await del(['output']);
 });

--- a/packages/run/test/test.js
+++ b/packages/run/test/test.js
@@ -83,27 +83,6 @@ test('detects changes - forks a new child process and kills older process', asyn
   t.is(mockChildProcess().kill.callCount, 1);
 });
 
-test('allow assets in output', async t => {
-  const bundle = await rollup({
-    input: join(cwd, 'input.js'),
-    plugins: [
-      {
-        transform(code) {
-          this.emitFile({
-            type: 'asset',
-            source: 'empty'
-          });
-          return code;
-        }
-      },
-      run()
-    ]
-  });
-  await t.notThrowsAsync(async () => {
-    await bundle.write({ dir: join(cwd, 'output'), format: 'cjs' });
-  });
-});
-
 test.after(async () => {
   await del(['output']);
 });


### PR DESCRIPTION
## Rollup Plugin Name: `run`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

### Description

In bundle assets are placed before entry point and run plugin fails with
```
@rollup/plugin-run requires Rollup 0.65 or higher
```
