### PR TITLE
test(run): add test broken in the latest rollup

### DIFF
--- a/packages/run/test/fixtures/dynamic.js
+++ b/packages/run/test/fixtures/dynamic.js
@@ -1,0 +1,2 @@
+import { log } from './log.js';
+log(0)

--- a/packages/run/test/fixtures/input-with-dynamic.js
+++ b/packages/run/test/fixtures/input-with-dynamic.js
@@ -1,0 +1,5 @@
+import { log } from "./log.js";
+log(0);
+(async () => {
+  await import("./dynamic.js");
+})();

--- a/packages/run/test/fixtures/log.js
+++ b/packages/run/test/fixtures/log.js
@@ -1,0 +1,1 @@
+export const log = value => console.log(value);

--- a/packages/run/test/test.js
+++ b/packages/run/test/test.js
@@ -83,6 +83,16 @@ test('detects changes - forks a new child process and kills older process', asyn
   t.is(mockChildProcess().kill.callCount, 1);
 });
 
+test.only('works when chunk is use in entry and dynamic import', async (t) => {
+  const bundle = await rollup({
+    input: join(cwd, 'input-with-dynamic.js'),
+    plugins: [run()]
+  });
+  await t.notThrowsAsync(async () => {
+    await bundle.write({ dir: join(cwd, 'output'), format: 'cjs' });
+  });
+});
+
 test.after(async () => {
   await del(['output']);
 });


### PR DESCRIPTION
#192  Rollup Plugin Name: `run`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

### Description

I found case where new rollup fails with run plugin.
When entry point and dynamic import use the same module
chunk.modules becomes empty. Run checks `chunk.modules[input]` for some
reason which fails when chunk.modules is empty.

@lukastaegert could you take a look?