### PR TITLE
fix export of __moduleExports as undefined (caused by newest NODE ES6…

### DIFF
--- a/packages/commonjs/src/transform.js
+++ b/packages/commonjs/src/transform.js
@@ -441,10 +441,12 @@ export function transformCommonjs(
   function addExport(x) {
     const deconflicted = deconflict(scope, globals, name);
 
+    const path = x === '__moduleExports' ? moduleName : `${moduleName}.${x}`;
+
     const declaration =
       deconflicted === name
-        ? `export var ${x} = ${moduleName}.${x};`
-        : `var ${deconflicted} = ${moduleName}.${x};\nexport { ${deconflicted} as ${x} };`;
+        ? `export var ${x} = ${path};`
+        : `var ${deconflicted} = ${path};\nexport { ${deconflicted} as ${x} };`;
 
     namedExportDeclarations.push({
       str: declaration,


### PR DESCRIPTION
… system?)

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `commonjs`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
