### PR TITLE
Fix typescript sourcemap generated as null

### DIFF
--- a/packages/typescript/src/options/normalize.ts
+++ b/packages/typescript/src/options/normalize.ts
@@ -38,6 +38,9 @@ export function normalizeCompilerOptions(
     // Default to using source maps.
     // If the plugin user sets sourceMap to false we keep that option.
     compilerOptions.sourceMap = true;
+    // Using inlineSources to make sure typescript generate source content
+    // instead of source path.
+    compilerOptions.inlineSources = true;
     autoSetSourceMap = true;
   }
 

--- a/packages/typescript/test/test.js
+++ b/packages/typescript/test/test.js
@@ -626,6 +626,22 @@ test('prevents errors due to conflicting `sourceMap`/`inlineSourceMap` options',
   );
 });
 
+test('should not emit null sourceContent', async (t) => {
+  const bundle = await rollup({
+    input: 'fixtures/basic/main.ts',
+    plugins: [
+      typescript({
+        tsconfig: 'fixtures/basic/tsconfig.json'
+      })
+    ],
+    onwarn
+  });
+  const output = await getCode(bundle, { format: 'esm', sourcemap: true }, true);
+  const sourcemap = output[0].map;
+  // eslint-disable-next-line no-undefined
+  t.false(sourcemap.sourcesContent.includes(undefined));
+});
+
 test('should not fail if source maps are off', async (t) => {
   await t.notThrowsAsync(
     rollup({

--- a/util/test.js
+++ b/util/test.js
@@ -6,8 +6,8 @@ const getCode = async (bundle, outputOptions, allFiles = false) => {
   const { output } = await bundle.generate(outputOptions || { format: 'cjs' });
 
   if (allFiles) {
-    return output.map(({ code, fileName, source }) => {
-      return { code, fileName, source };
+    return output.map(({ code, fileName, source, map }) => {
+      return { code, fileName, source, map };
     });
   }
   const [{ code }] = output;


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `typescript`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
