### PR TITLE
Fix run plugin could fork before bundle generated

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,8 @@ indent_size = 2
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
+quote_type = single
+max_line_length = 100
 
 [*.md]
 insert_final_newline = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -8,8 +8,6 @@ indent_size = 2
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
-quote_type = single
-max_line_length = 100
 
 [*.md]
 insert_final_newline = true

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     }
   },
   "lint-staged": {
-    "*.js,*.ts": [
+    "*.{ts,js}": [
       "eslint --fix",
       "git add"
     ],

--- a/packages/run/lib/index.js
+++ b/packages/run/lib/index.js
@@ -35,7 +35,9 @@ module.exports = (opts = {}) => {
       if (!isWrite) {
         this.error(`@rollup/plugin-run currently only works with bundles that are written to disk`);
       }
+    },
 
+    writeBundle(outputOptions, bundle) {
       const dir = outputOptions.dir || path.dirname(outputOptions.file);
 
       let dest;


### PR DESCRIPTION
<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `run`

This PR contains:

- [x] bugfix

Are tests included?

Basically hard to create test on race condition, we have situation that 80% of our developers
has no issue at all as bundle has written to disk before fork, and other 20% sometimes can't start app at all

- [x] no 

Breaking Changes?

- [x] no


Description:

At the moment of fork inside run, there is possible that bundle file is not created at the moment. Or is in the process of writing. This cause fork to break without any errors.



PS:
also fixed editorconfig as its not in sync with eslint rules