### PR TITLE
Upgrade buble and issue babel/babel#11216

### DIFF
--- a/packages/buble/package.json
+++ b/packages/buble/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@rollup/pluginutils": "^3.0.8",
     "@types/buble": "^0.19.2",
-    "buble": "^0.19.8"
+    "buble": "^0.20.0"
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^3.0.0",

--- a/packages/commonjs/package.json
+++ b/packages/commonjs/package.json
@@ -58,12 +58,12 @@
     "resolve": "^1.11.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.7.7",
-    "@babel/preset-env": "^7.7.7",
-    "@babel/register": "^7.7.7",
+    "@babel/core": "^7.9.0",
+    "@babel/preset-env": "^7.9.0",
+    "@babel/register": "^7.9.0",
     "@rollup/plugin-json": "^4.0.1",
     "@rollup/plugin-node-resolve": "^7.0.0",
-    "acorn": "^7.1.0",
+    "acorn": "^7.1.1",
     "locate-character": "^2.0.5",
     "prettier": "^1.19.1",
     "require-relative": "^0.8.7",

--- a/packages/multi-entry/package.json
+++ b/packages/multi-entry/package.json
@@ -47,10 +47,10 @@
     "matched": "^1.0.2"
   },
   "devDependencies": {
-    "@babel/core": "^7.2.0",
-    "@babel/preset-env": "^7.2.0",
+    "@babel/core": "^7.9.0",
+    "@babel/preset-env": "^7.9.0",
     "rollup": "^2.0.0",
-    "rollup-plugin-babel": "^4.0.3"
+    "rollup-plugin-babel": "^4.4.0"
   },
   "ava": {
     "files": [

--- a/packages/node-resolve/package.json
+++ b/packages/node-resolve/package.json
@@ -55,8 +55,8 @@
     "resolve": "^1.14.2"
   },
   "devDependencies": {
-    "@babel/core": "^7.8.3",
-    "@babel/preset-env": "^7.8.3",
+    "@babel/core": "^7.9.0",
+    "@babel/preset-env": "^7.9.0",
     "@rollup/plugin-json": "^4.0.1",
     "es5-ext": "^0.10.53",
     "rollup": "^2.0.0",

--- a/packages/url/package.json
+++ b/packages/url/package.json
@@ -49,9 +49,9 @@
     "mime": "^2.4.4"
   },
   "devDependencies": {
-    "@babel/core": "^7.7.7",
-    "@babel/preset-env": "^7.7.7",
-    "@babel/register": "^7.7.7",
+    "@babel/core": "^7.9.0",
+    "@babel/preset-env": "^7.9.0",
+    "@babel/register": "^7.9.0",
     "del": "^5.1.0",
     "globby": "^10.0.1",
     "rollup": "^2.0.0",

--- a/packages/yaml/package.json
+++ b/packages/yaml/package.json
@@ -46,9 +46,9 @@
     "tosource": "^1.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.7.7",
-    "@babel/preset-env": "^7.7.7",
-    "@rollup/plugin-node-resolve": "^6.0.0",
+    "@babel/core": "^7.9.0",
+    "@babel/preset-env": "^7.9.0",
+    "@rollup/plugin-node-resolve": "^7.1.1",
     "del-cli": "^3.0.0",
     "rollup": "^2.0.0",
     "rollup-plugin-babel": "^4.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,7 +100,7 @@ importers:
       '@rollup/plugin-typescript': ^3.0.0
       '@rollup/pluginutils': ^3.0.8
       '@types/buble': ^0.19.2
-      buble: ^0.19.8
+      buble: ^0.20.0
       del-cli: ^3.0.0
       rollup: ^2.0.0
       source-map: ^0.7.3
@@ -115,29 +115,29 @@ importers:
       magic-string: 0.25.6
       resolve: 1.15.0
     devDependencies:
-      '@babel/core': 7.8.3
-      '@babel/preset-env': 7.8.3_@babel+core@7.8.3
-      '@babel/register': 7.8.3_@babel+core@7.8.3
-      '@rollup/plugin-json': 4.0.1_rollup@2.2.0
+      '@babel/core': 7.9.0
+      '@babel/preset-env': 7.9.0_@babel+core@7.9.0
+      '@babel/register': 7.9.0_@babel+core@7.9.0
+      '@rollup/plugin-json': 4.0.2_rollup@2.2.0
       '@rollup/plugin-node-resolve': 7.1.1_rollup@2.2.0
-      acorn: 7.1.0
+      acorn: 7.1.1
       locate-character: 2.0.5
       prettier: 1.19.1
       require-relative: 0.8.7
       rollup: 2.2.0
-      rollup-plugin-babel: 4.3.3_@babel+core@7.8.3+rollup@2.2.0
+      rollup-plugin-babel: 4.3.3_@babel+core@7.9.0+rollup@2.2.0
       shx: 0.3.2
       source-map: 0.6.1
       source-map-support: 0.5.16
       typescript: 3.7.5
     specifiers:
-      '@babel/core': ^7.7.7
-      '@babel/preset-env': ^7.7.7
-      '@babel/register': ^7.7.7
+      '@babel/core': ^7.9.0
+      '@babel/preset-env': ^7.9.0
+      '@babel/register': ^7.9.0
       '@rollup/plugin-json': ^4.0.1
       '@rollup/plugin-node-resolve': ^7.0.0
       '@rollup/pluginutils': ^3.0.8
-      acorn: ^7.1.0
+      acorn: ^7.1.1
       commondir: ^1.0.1
       estree-walker: ^1.0.1
       glob: ^7.1.2
@@ -244,16 +244,16 @@ importers:
     dependencies:
       matched: 1.0.2
     devDependencies:
-      '@babel/core': 7.8.3
-      '@babel/preset-env': 7.8.3_@babel+core@7.8.3
+      '@babel/core': 7.9.0
+      '@babel/preset-env': 7.9.0_@babel+core@7.9.0
       rollup: 2.2.0
-      rollup-plugin-babel: 4.3.3_@babel+core@7.8.3+rollup@2.2.0
+      rollup-plugin-babel: 4.4.0_@babel+core@7.9.0+rollup@2.2.0
     specifiers:
-      '@babel/core': ^7.2.0
-      '@babel/preset-env': ^7.2.0
+      '@babel/core': ^7.9.0
+      '@babel/preset-env': ^7.9.0
       matched: ^1.0.2
       rollup: ^2.0.0
-      rollup-plugin-babel: ^4.0.3
+      rollup-plugin-babel: ^4.4.0
   packages/node-resolve:
     dependencies:
       '@rollup/pluginutils': 3.0.8_rollup@2.2.0
@@ -262,18 +262,18 @@ importers:
       is-module: 1.0.0
       resolve: 1.15.0
     devDependencies:
-      '@babel/core': 7.8.3
-      '@babel/preset-env': 7.8.3_@babel+core@7.8.3
-      '@rollup/plugin-json': 4.0.1_rollup@2.2.0
+      '@babel/core': 7.9.0
+      '@babel/preset-env': 7.9.0_@babel+core@7.9.0
+      '@rollup/plugin-json': 4.0.2_rollup@2.2.0
       es5-ext: 0.10.53
       rollup: 2.2.0
-      rollup-plugin-babel: 4.3.3_@babel+core@7.8.3+rollup@2.2.0
+      rollup-plugin-babel: 4.3.3_@babel+core@7.9.0+rollup@2.2.0
       rollup-plugin-commonjs: 10.1.0_rollup@2.2.0
       source-map: 0.7.3
       string-capitalize: 1.0.1
     specifiers:
-      '@babel/core': ^7.8.3
-      '@babel/preset-env': ^7.8.3
+      '@babel/core': ^7.9.0
+      '@babel/preset-env': ^7.9.0
       '@rollup/plugin-json': ^4.0.1
       '@rollup/pluginutils': ^3.0.8
       '@types/resolve': 0.0.8
@@ -393,17 +393,17 @@ importers:
       make-dir: 3.0.0
       mime: 2.4.4
     devDependencies:
-      '@babel/core': 7.8.3
-      '@babel/preset-env': 7.8.3_@babel+core@7.8.3
-      '@babel/register': 7.8.3_@babel+core@7.8.3
+      '@babel/core': 7.9.0
+      '@babel/preset-env': 7.9.0_@babel+core@7.9.0
+      '@babel/register': 7.9.0_@babel+core@7.9.0
       del: 5.1.0
       globby: 10.0.2
       rollup: 2.2.0
-      rollup-plugin-babel: 4.3.3_@babel+core@7.8.3+rollup@2.2.0
+      rollup-plugin-babel: 4.3.3_@babel+core@7.9.0+rollup@2.2.0
     specifiers:
-      '@babel/core': ^7.7.7
-      '@babel/preset-env': ^7.7.7
-      '@babel/register': ^7.7.7
+      '@babel/core': ^7.9.0
+      '@babel/preset-env': ^7.9.0
+      '@babel/register': ^7.9.0
       '@rollup/pluginutils': ^3.0.4
       del: ^5.1.0
       globby: ^10.0.1
@@ -433,17 +433,17 @@ importers:
       js-yaml: 3.13.1
       tosource: 1.0.0
     devDependencies:
-      '@babel/core': 7.8.3
-      '@babel/preset-env': 7.8.3_@babel+core@7.8.3
-      '@rollup/plugin-node-resolve': 6.1.0_rollup@2.2.0
+      '@babel/core': 7.9.0
+      '@babel/preset-env': 7.9.0_@babel+core@7.9.0
+      '@rollup/plugin-node-resolve': 7.1.1_rollup@2.2.0
       del-cli: 3.0.0
       rollup: 2.2.0
-      rollup-plugin-babel: 4.3.3_@babel+core@7.8.3+rollup@2.2.0
+      rollup-plugin-babel: 4.3.3_@babel+core@7.9.0+rollup@2.2.0
       source-map-support: 0.5.16
     specifiers:
-      '@babel/core': ^7.7.7
-      '@babel/preset-env': ^7.7.7
-      '@rollup/plugin-node-resolve': ^6.0.0
+      '@babel/core': ^7.9.0
+      '@babel/preset-env': ^7.9.0
+      '@rollup/plugin-node-resolve': ^7.1.1
       '@rollup/pluginutils': ^3.0.1
       del-cli: ^3.0.0
       js-yaml: ^3.13.1
@@ -484,18 +484,18 @@ packages:
       integrity: sha512-8eKhFzZp7Qcq1VLfoC75ggGT8nQs9q8fIxltU47yCB7Wi7Y8Qf6oqY1Bm0z04fIec24vEgr0ENhDHEOUGVDqnA==
   /@babel/code-frame/7.8.3:
     dependencies:
-      '@babel/highlight': 7.8.3
+      '@babel/highlight': 7.9.0
     dev: true
     resolution:
       integrity: sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==
-  /@babel/compat-data/7.8.1:
+  /@babel/compat-data/7.9.0:
     dependencies:
-      browserslist: 4.8.3
+      browserslist: 4.11.0
       invariant: 2.2.4
       semver: 5.7.1
     dev: true
     resolution:
-      integrity: sha512-Z+6ZOXvyOWYxJ50BwxzdhRnRsGST8Y3jaZgxYig575lTjVSs3KtJnmESwZegg6e2Dn0td1eDhoWlp1wI4BTCPw==
+      integrity: sha512-zeFQrr+284Ekvd9e7KAX954LkapWiOmQtsfHirhxqfdlX6MEC32iRE+pqUGlYIBchdevaCwvzxWGSy/YBNI85g==
   /@babel/core/7.8.3:
     dependencies:
       '@babel/code-frame': 7.8.3
@@ -518,6 +518,29 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-4XFkf8AwyrEG7Ziu3L2L0Cv+WyY47Tcsp70JFmpftbAA1K7YL/sgE9jh9HyNj08Y/U50ItUchpN0w6HxAoX1rA==
+  /@babel/core/7.9.0:
+    dependencies:
+      '@babel/code-frame': 7.8.3
+      '@babel/generator': 7.9.4
+      '@babel/helper-module-transforms': 7.9.0
+      '@babel/helpers': 7.9.2
+      '@babel/parser': 7.9.4
+      '@babel/template': 7.8.6
+      '@babel/traverse': 7.9.0
+      '@babel/types': 7.9.0
+      convert-source-map: 1.7.0
+      debug: 4.1.1
+      gensync: 1.0.0-beta.1
+      json5: 2.1.2
+      lodash: 4.17.15
+      resolve: 1.15.1
+      semver: 5.7.1
+      source-map: 0.5.7
+    dev: true
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==
   /@babel/generator/7.8.3:
     dependencies:
       '@babel/types': 7.8.3
@@ -527,94 +550,107 @@ packages:
     dev: true
     resolution:
       integrity: sha512-WjoPk8hRpDRqqzRpvaR8/gDUPkrnOOeuT2m8cNICJtZH6mwaCo3v0OKMI7Y6SM1pBtyijnLtAL0HDi41pf41ug==
+  /@babel/generator/7.9.4:
+    dependencies:
+      '@babel/types': 7.9.0
+      jsesc: 2.5.2
+      lodash: 4.17.15
+      source-map: 0.5.7
+    dev: true
+    resolution:
+      integrity: sha512-rjP8ahaDy/ouhrvCoU1E5mqaitWrxwuNGU+dy1EpaoK48jZay4MdkskKGIMHLZNewg8sAsqpGSREJwP0zH3YQA==
   /@babel/helper-annotate-as-pure/7.8.3:
     dependencies:
-      '@babel/types': 7.8.3
+      '@babel/types': 7.9.0
     dev: true
     resolution:
       integrity: sha512-6o+mJrZBxOoEX77Ezv9zwW7WV8DdluouRKNY/IR5u/YTMuKHgugHOzYWlYvYLpLA9nPsQCAAASpCIbjI9Mv+Uw==
   /@babel/helper-builder-binary-assignment-operator-visitor/7.8.3:
     dependencies:
       '@babel/helper-explode-assignable-expression': 7.8.3
-      '@babel/types': 7.8.3
+      '@babel/types': 7.9.0
     dev: true
     resolution:
       integrity: sha512-5eFOm2SyFPK4Rh3XMMRDjN7lBH0orh3ss0g3rTYZnBQ+r6YPj7lgDyCvPphynHvUrobJmeMignBr6Acw9mAPlw==
-  /@babel/helper-call-delegate/7.8.3:
+  /@babel/helper-compilation-targets/7.8.7_@babel+core@7.9.0:
     dependencies:
-      '@babel/helper-hoist-variables': 7.8.3
-      '@babel/traverse': 7.8.3
-      '@babel/types': 7.8.3
-    dev: true
-    resolution:
-      integrity: sha512-6Q05px0Eb+N4/GTyKPPvnkig7Lylw+QzihMpws9iiZQv7ZImf84ZsZpQH7QoWN4n4tm81SnSzPgHw2qtO0Zf3A==
-  /@babel/helper-compilation-targets/7.8.3_@babel+core@7.8.3:
-    dependencies:
-      '@babel/compat-data': 7.8.1
-      '@babel/core': 7.8.3
-      browserslist: 4.8.3
+      '@babel/compat-data': 7.9.0
+      '@babel/core': 7.9.0
+      browserslist: 4.11.0
       invariant: 2.2.4
-      levenary: 1.1.0
+      levenary: 1.1.1
       semver: 5.7.1
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0
     resolution:
-      integrity: sha512-JLylPCsFjhLN+6uBSSh3iYdxKdeO9MNmoY96PE/99d8kyBFaXLORtAVhqN6iHa+wtPeqxKLghDOZry0+Aiw9Tw==
-  /@babel/helper-create-regexp-features-plugin/7.8.3_@babel+core@7.8.3:
+      integrity: sha512-4mWm8DCK2LugIS+p1yArqvG1Pf162upsIsjE7cNBjez+NjliQpVhj20obE520nao0o14DaTnFJv+Fw5a0JpoUw==
+  /@babel/helper-create-regexp-features-plugin/7.8.8_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
+      '@babel/helper-annotate-as-pure': 7.8.3
       '@babel/helper-regex': 7.8.3
-      regexpu-core: 4.6.0
+      regexpu-core: 4.7.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0
     resolution:
-      integrity: sha512-Gcsm1OHCUr9o9TcJln57xhWHtdXbA2pgQ58S0Lxlks0WMGNXuki4+GLfX0p+L2ZkINUGZvfkz8rzoqJQSthI+Q==
+      integrity: sha512-LYVPdwkrQEiX9+1R29Ld/wTrmQu1SSKYnuOk3g0CkcZMA1p0gsNxJFj/3gBdaJ7Cg0Fnek5z0DsMULePP7Lrqg==
+  /@babel/helper-create-regexp-features-plugin/7.8.8_@babel+core@7.9.0:
+    dependencies:
+      '@babel/core': 7.9.0
+      '@babel/helper-annotate-as-pure': 7.8.3
+      '@babel/helper-regex': 7.8.3
+      regexpu-core: 4.7.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    resolution:
+      integrity: sha512-LYVPdwkrQEiX9+1R29Ld/wTrmQu1SSKYnuOk3g0CkcZMA1p0gsNxJFj/3gBdaJ7Cg0Fnek5z0DsMULePP7Lrqg==
   /@babel/helper-define-map/7.8.3:
     dependencies:
       '@babel/helper-function-name': 7.8.3
-      '@babel/types': 7.8.3
+      '@babel/types': 7.9.0
       lodash: 4.17.15
     dev: true
     resolution:
       integrity: sha512-PoeBYtxoZGtct3md6xZOCWPcKuMuk3IHhgxsRRNtnNShebf4C8YonTSblsK4tvDbm+eJAw2HAPOfCr+Q/YRG/g==
   /@babel/helper-explode-assignable-expression/7.8.3:
     dependencies:
-      '@babel/traverse': 7.8.3
-      '@babel/types': 7.8.3
+      '@babel/traverse': 7.9.0
+      '@babel/types': 7.9.0
     dev: true
     resolution:
       integrity: sha512-N+8eW86/Kj147bO9G2uclsg5pwfs/fqqY5rwgIL7eTBklgXjcOJ3btzS5iM6AitJcftnY7pm2lGsrJVYLGjzIw==
   /@babel/helper-function-name/7.8.3:
     dependencies:
       '@babel/helper-get-function-arity': 7.8.3
-      '@babel/template': 7.8.3
-      '@babel/types': 7.8.3
+      '@babel/template': 7.8.6
+      '@babel/types': 7.9.0
     dev: true
     resolution:
       integrity: sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==
   /@babel/helper-get-function-arity/7.8.3:
     dependencies:
-      '@babel/types': 7.8.3
+      '@babel/types': 7.9.0
     dev: true
     resolution:
       integrity: sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==
   /@babel/helper-hoist-variables/7.8.3:
     dependencies:
-      '@babel/types': 7.8.3
+      '@babel/types': 7.9.0
     dev: true
     resolution:
       integrity: sha512-ky1JLOjcDUtSc+xkt0xhYff7Z6ILTAHKmZLHPxAhOP0Nd77O+3nCsd6uSVYur6nJnCI029CrNbYlc0LoPfAPQg==
   /@babel/helper-member-expression-to-functions/7.8.3:
     dependencies:
-      '@babel/types': 7.8.3
+      '@babel/types': 7.9.0
     dev: true
     resolution:
       integrity: sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==
   /@babel/helper-module-imports/7.8.3:
     dependencies:
-      '@babel/types': 7.8.3
+      '@babel/types': 7.9.0
     dev: true
     resolution:
       integrity: sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==
@@ -629,9 +665,21 @@ packages:
     dev: true
     resolution:
       integrity: sha512-C7NG6B7vfBa/pwCOshpMbOYUmrYQDfCpVL/JCRu0ek8B5p8kue1+BCXpg2vOYs7w5ACB9GTOBYQ5U6NwrMg+3Q==
+  /@babel/helper-module-transforms/7.9.0:
+    dependencies:
+      '@babel/helper-module-imports': 7.8.3
+      '@babel/helper-replace-supers': 7.8.6
+      '@babel/helper-simple-access': 7.8.3
+      '@babel/helper-split-export-declaration': 7.8.3
+      '@babel/template': 7.8.6
+      '@babel/types': 7.9.0
+      lodash: 4.17.15
+    dev: true
+    resolution:
+      integrity: sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==
   /@babel/helper-optimise-call-expression/7.8.3:
     dependencies:
-      '@babel/types': 7.8.3
+      '@babel/types': 7.9.0
     dev: true
     resolution:
       integrity: sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==
@@ -649,40 +697,44 @@ packages:
     dependencies:
       '@babel/helper-annotate-as-pure': 7.8.3
       '@babel/helper-wrap-function': 7.8.3
-      '@babel/template': 7.8.3
-      '@babel/traverse': 7.8.3
-      '@babel/types': 7.8.3
+      '@babel/template': 7.8.6
+      '@babel/traverse': 7.9.0
+      '@babel/types': 7.9.0
     dev: true
     resolution:
       integrity: sha512-kgwDmw4fCg7AVgS4DukQR/roGp+jP+XluJE5hsRZwxCYGg+Rv9wSGErDWhlI90FODdYfd4xG4AQRiMDjjN0GzA==
-  /@babel/helper-replace-supers/7.8.3:
+  /@babel/helper-replace-supers/7.8.6:
     dependencies:
       '@babel/helper-member-expression-to-functions': 7.8.3
       '@babel/helper-optimise-call-expression': 7.8.3
-      '@babel/traverse': 7.8.3
-      '@babel/types': 7.8.3
+      '@babel/traverse': 7.9.0
+      '@babel/types': 7.9.0
     dev: true
     resolution:
-      integrity: sha512-xOUssL6ho41U81etpLoT2RTdvdus4VfHamCuAm4AHxGr+0it5fnwoVdwUJ7GFEqCsQYzJUhcbsN9wB9apcYKFA==
+      integrity: sha512-PeMArdA4Sv/Wf4zXwBKPqVj7n9UF/xg6slNRtZW84FM7JpE1CbG8B612FyM4cxrf4fMAMGO0kR7voy1ForHHFA==
   /@babel/helper-simple-access/7.8.3:
     dependencies:
-      '@babel/template': 7.8.3
-      '@babel/types': 7.8.3
+      '@babel/template': 7.8.6
+      '@babel/types': 7.9.0
     dev: true
     resolution:
       integrity: sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==
   /@babel/helper-split-export-declaration/7.8.3:
     dependencies:
-      '@babel/types': 7.8.3
+      '@babel/types': 7.9.0
     dev: true
     resolution:
       integrity: sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==
+  /@babel/helper-validator-identifier/7.9.0:
+    dev: true
+    resolution:
+      integrity: sha512-6G8bQKjOh+of4PV/ThDm/rRqlU7+IGoJuofpagU5GlEl29Vv0RGqqt86ZGRV8ZuSOY3o+8yXl5y782SMcG7SHw==
   /@babel/helper-wrap-function/7.8.3:
     dependencies:
       '@babel/helper-function-name': 7.8.3
-      '@babel/template': 7.8.3
-      '@babel/traverse': 7.8.3
-      '@babel/types': 7.8.3
+      '@babel/template': 7.8.6
+      '@babel/traverse': 7.9.0
+      '@babel/types': 7.9.0
     dev: true
     resolution:
       integrity: sha512-LACJrbUET9cQDzb6kG7EeD7+7doC3JNvUgTEQOx2qaO1fKlzE/Bf05qs9w1oXQMmXlPO65lC3Tq9S6gZpTErEQ==
@@ -694,14 +746,22 @@ packages:
     dev: true
     resolution:
       integrity: sha512-LmU3q9Pah/XyZU89QvBgGt+BCsTPoQa+73RxAQh8fb8qkDyIfeQnmgs+hvzhTCKTzqOyk7JTkS3MS1S8Mq5yrQ==
-  /@babel/highlight/7.8.3:
+  /@babel/helpers/7.9.2:
     dependencies:
+      '@babel/template': 7.8.6
+      '@babel/traverse': 7.9.0
+      '@babel/types': 7.9.0
+    dev: true
+    resolution:
+      integrity: sha512-JwLvzlXVPjO8eU9c/wF9/zOIN7X6h8DYf7mG4CiFRZRvZNKEF5dQ3H3V+ASkHoIB3mWhatgl5ONhyqHRI6MppA==
+  /@babel/highlight/7.9.0:
+    dependencies:
+      '@babel/helper-validator-identifier': 7.9.0
       chalk: 2.4.2
-      esutils: 2.0.3
       js-tokens: 4.0.0
     dev: true
     resolution:
-      integrity: sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==
+      integrity: sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==
   /@babel/parser/7.8.3:
     dev: true
     engines:
@@ -709,12 +769,30 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-/V72F4Yp/qmHaTALizEm9Gf2eQHV3QyTL3K0cNfijwnMnb1L+LDlAubb/ZnSdGAVzVSWakujHYs1I26x66sMeQ==
+  /@babel/parser/7.9.4:
+    dev: true
+    engines:
+      node: '>=6.0.0'
+    hasBin: true
+    resolution:
+      integrity: sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA==
   /@babel/plugin-proposal-async-generator-functions/7.8.3_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
       '@babel/helper-plugin-utils': 7.8.3
       '@babel/helper-remap-async-to-generator': 7.8.3
       '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.8.3
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-NZ9zLv848JsV3hs8ryEh7Uaz/0KsmPLqv0+PdkDJL1cJy0K4kOCFa8zc1E3mp+RHPQcpdfb/6GovEsW4VDrOMw==
+  /@babel/plugin-proposal-async-generator-functions/7.8.3_@babel+core@7.9.0:
+    dependencies:
+      '@babel/core': 7.9.0
+      '@babel/helper-plugin-utils': 7.8.3
+      '@babel/helper-remap-async-to-generator': 7.8.3
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.9.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -730,36 +808,56 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-NyaBbyLFXFLT9FP+zk0kYlUlA8XtCUbehs67F0nnEg7KICgMc2mNkIeu9TYhKzyXMkrapZFwAhXLdnt4IYHy1w==
-  /@babel/plugin-proposal-json-strings/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-proposal-dynamic-import/7.8.3_@babel+core@7.9.0:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.9.0
       '@babel/helper-plugin-utils': 7.8.3
-      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.8.3
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.9.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-NyaBbyLFXFLT9FP+zk0kYlUlA8XtCUbehs67F0nnEg7KICgMc2mNkIeu9TYhKzyXMkrapZFwAhXLdnt4IYHy1w==
+  /@babel/plugin-proposal-json-strings/7.8.3_@babel+core@7.9.0:
+    dependencies:
+      '@babel/core': 7.9.0
+      '@babel/helper-plugin-utils': 7.8.3
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.9.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-KGhQNZ3TVCQG/MjRbAUwuH+14y9q0tpxs1nWWs3pbSleRdDro9SAMMDyye8HhY1gqZ7/NqIc8SKhya0wRDgP1Q==
-  /@babel/plugin-proposal-nullish-coalescing-operator/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-proposal-nullish-coalescing-operator/7.8.3_@babel+core@7.9.0:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.9.0
       '@babel/helper-plugin-utils': 7.8.3
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.8.3
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.9.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-TS9MlfzXpXKt6YYomudb/KU7nQI6/xnapG6in1uZxoxDghuSMZsPb6D2fyUwNYSAp4l1iR7QtFOjkqcRYcUsfw==
-  /@babel/plugin-proposal-object-rest-spread/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-proposal-numeric-separator/7.8.3_@babel+core@7.9.0:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.9.0
       '@babel/helper-plugin-utils': 7.8.3
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.8.3
+      '@babel/plugin-syntax-numeric-separator': 7.8.3_@babel+core@7.9.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-8qvuPwU/xxUCt78HocNlv0mXXo0wdh9VT1R04WU8HGOfaOob26pF+9P5/lYjN/q7DHOX1bvX60hnhOvuQUJdbA==
+      integrity: sha512-jWioO1s6R/R+wEHizfaScNsAx+xKgwTLNXSh7tTC4Usj3ItsPEhYkEpU4h+lpnBwq7NBVOJXfO6cRFYcX69JUQ==
+  /@babel/plugin-proposal-object-rest-spread/7.9.0_@babel+core@7.9.0:
+    dependencies:
+      '@babel/core': 7.9.0
+      '@babel/helper-plugin-utils': 7.8.3
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.9.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-UgqBv6bjq4fDb8uku9f+wcm1J7YxJ5nT7WO/jBr0cl0PLKb7t1O6RNR1kZbjgx2LQtsDI9hwoQVmn0yhXeQyow==
   /@babel/plugin-proposal-optional-catch-binding/7.8.3_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -770,20 +868,30 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-0gkX7J7E+AtAw9fcwlVQj8peP61qhdg/89D5swOkjYbkboA2CVckn3kiyum1DE0wskGb7KJJxBdyEBApDLLVdw==
-  /@babel/plugin-proposal-optional-chaining/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-proposal-optional-catch-binding/7.8.3_@babel+core@7.9.0:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.9.0
       '@babel/helper-plugin-utils': 7.8.3
-      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.8.3
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.9.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-QIoIR9abkVn+seDE3OjA08jWcs3eZ9+wJCKSRgo3WdEU2csFYgdScb+8qHB3+WXsGJD55u+5hWCISI7ejXS+kg==
-  /@babel/plugin-proposal-unicode-property-regex/7.8.3_@babel+core@7.8.3:
+      integrity: sha512-0gkX7J7E+AtAw9fcwlVQj8peP61qhdg/89D5swOkjYbkboA2CVckn3kiyum1DE0wskGb7KJJxBdyEBApDLLVdw==
+  /@babel/plugin-proposal-optional-chaining/7.9.0_@babel+core@7.9.0:
     dependencies:
-      '@babel/core': 7.8.3
-      '@babel/helper-create-regexp-features-plugin': 7.8.3_@babel+core@7.8.3
+      '@babel/core': 7.9.0
+      '@babel/helper-plugin-utils': 7.8.3
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.9.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-NDn5tu3tcv4W30jNhmc2hyD5c56G6cXx4TesJubhxrJeCvuuMpttxr0OnNCqbZGhFjLrg+NIhxxC+BK5F6yS3w==
+  /@babel/plugin-proposal-unicode-property-regex/7.8.8_@babel+core@7.9.0:
+    dependencies:
+      '@babel/core': 7.9.0
+      '@babel/helper-create-regexp-features-plugin': 7.8.8_@babel+core@7.9.0
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     engines:
@@ -791,10 +899,19 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-1/1/rEZv2XGweRwwSkLpY+s60za9OZ1hJs4YDqFHCw0kYWYwL5IFljVY1MYBL+weT1l9pokDO2uhSTLVxzoHkQ==
+      integrity: sha512-EVhjVsMpbhLw9ZfHWSx2iy13Q8Z/eg8e8ccVWt23sWQK5l1UdkoLJPN5w69UA4uITGBnEZD2JOe4QOHycYKv8A==
   /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
+      '@babel/helper-plugin-utils': 7.8.3
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==
+  /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.9.0:
+    dependencies:
+      '@babel/core': 7.9.0
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
@@ -810,27 +927,45 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==
-  /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-syntax-dynamic-import/7.8.3_@babel+core@7.9.0:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.9.0
+      '@babel/helper-plugin-utils': 7.8.3
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==
+  /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.9.0:
+    dependencies:
+      '@babel/core': 7.9.0
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==
-  /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.9.0:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.9.0
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==
-  /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-syntax-numeric-separator/7.8.3_@babel+core@7.9.0:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.9.0
+      '@babel/helper-plugin-utils': 7.8.3
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-H7dCMAdN83PcCmqmkHB5dtp+Xa9a6LKSvA2hiFBC/5alSHxM5VgWZXFqDi0YFe8XNGT6iCa+z4V4zSt/PdZ7Dw==
+  /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.9.0:
+    dependencies:
+      '@babel/core': 7.9.0
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
@@ -846,36 +981,45 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==
-  /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.9.0:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.9.0
+      '@babel/helper-plugin-utils': 7.8.3
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==
+  /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.9.0:
+    dependencies:
+      '@babel/core': 7.9.0
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==
-  /@babel/plugin-syntax-top-level-await/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-syntax-top-level-await/7.8.3_@babel+core@7.9.0:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.9.0
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-kwj1j9lL/6Wd0hROD3b/OZZ7MSrZLqqn9RAZ5+cYYsflQ9HZBIKCUkr3+uL1MEJ1NePiUbf98jjiMQSv0NMR9g==
-  /@babel/plugin-transform-arrow-functions/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-arrow-functions/7.8.3_@babel+core@7.9.0:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.9.0
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-0MRF+KC8EqH4dbuITCWwPSzsyO3HIWWlm30v8BbbpOrS1B++isGxPnnuq/IZvOX5J2D/p7DQalQm+/2PnlKGxg==
-  /@babel/plugin-transform-async-to-generator/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-async-to-generator/7.8.3_@babel+core@7.9.0:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.9.0
       '@babel/helper-module-imports': 7.8.3
       '@babel/helper-plugin-utils': 7.8.3
       '@babel/helper-remap-async-to-generator': 7.8.3
@@ -884,18 +1028,18 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-imt9tFLD9ogt56Dd5CI/6XgpukMwd/fLGSrix2httihVe7LOGVPhyhMh1BU5kDM7iHD08i8uUtmV2sWaBFlHVQ==
-  /@babel/plugin-transform-block-scoped-functions/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-block-scoped-functions/7.8.3_@babel+core@7.9.0:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.9.0
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-vo4F2OewqjbB1+yaJ7k2EJFHlTP3jR634Z9Cj9itpqNjuLXvhlVxgnjsHsdRgASR8xYDrx6onw4vW5H6We0Jmg==
-  /@babel/plugin-transform-block-scoping/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-block-scoping/7.8.3_@babel+core@7.9.0:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.9.0
       '@babel/helper-plugin-utils': 7.8.3
       lodash: 4.17.15
     dev: true
@@ -903,62 +1047,72 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-pGnYfm7RNRgYRi7bids5bHluENHqJhrV4bCZRwc5GamaWIIs07N4rZECcmJL6ZClwjDz1GbdMZFtPs27hTB06w==
-  /@babel/plugin-transform-classes/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-classes/7.9.2_@babel+core@7.9.0:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.9.0
       '@babel/helper-annotate-as-pure': 7.8.3
       '@babel/helper-define-map': 7.8.3
       '@babel/helper-function-name': 7.8.3
       '@babel/helper-optimise-call-expression': 7.8.3
       '@babel/helper-plugin-utils': 7.8.3
-      '@babel/helper-replace-supers': 7.8.3
+      '@babel/helper-replace-supers': 7.8.6
       '@babel/helper-split-export-declaration': 7.8.3
       globals: 11.12.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-SjT0cwFJ+7Rbr1vQsvphAHwUHvSUPmMjMU/0P59G8U2HLFqSa082JO7zkbDNWs9kH/IUqpHI6xWNesGf8haF1w==
-  /@babel/plugin-transform-computed-properties/7.8.3_@babel+core@7.8.3:
+      integrity: sha512-TC2p3bPzsfvSsqBZo0kJnuelnoK9O3welkUpqSqBQuBF6R5MN2rysopri8kNvtlGIb2jmUO7i15IooAZJjZuMQ==
+  /@babel/plugin-transform-computed-properties/7.8.3_@babel+core@7.9.0:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.9.0
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-O5hiIpSyOGdrQZRQ2ccwtTVkgUDBBiCuK//4RJ6UfePllUTCENOzKxfh6ulckXKc0DixTFLCfb2HVkNA7aDpzA==
-  /@babel/plugin-transform-destructuring/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-destructuring/7.8.8_@babel+core@7.9.0:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.9.0
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-H4X646nCkiEcHZUZaRkhE2XVsoz0J/1x3VVujnn96pSoGCtKPA99ZZA+va+gK+92Zycd6OBKCD8tDb/731bhgQ==
+      integrity: sha512-eRJu4Vs2rmttFCdhPUM3bV0Yo/xPSdPw6ML9KHs/bjB4bLA5HXlbvYXPOD5yASodGod+krjYx21xm1QmL8dCJQ==
   /@babel/plugin-transform-dotall-regex/7.8.3_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
-      '@babel/helper-create-regexp-features-plugin': 7.8.3_@babel+core@7.8.3
+      '@babel/helper-create-regexp-features-plugin': 7.8.8_@babel+core@7.8.3
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-kLs1j9Nn4MQoBYdRXH6AeaXMbEJFaFu/v1nQkvib6QzTj8MZI5OQzqmD83/2jEM1z0DLilra5aWO5YpyC0ALIw==
-  /@babel/plugin-transform-duplicate-keys/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-dotall-regex/7.8.3_@babel+core@7.9.0:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.9.0
+      '@babel/helper-create-regexp-features-plugin': 7.8.8_@babel+core@7.9.0
+      '@babel/helper-plugin-utils': 7.8.3
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-kLs1j9Nn4MQoBYdRXH6AeaXMbEJFaFu/v1nQkvib6QzTj8MZI5OQzqmD83/2jEM1z0DLilra5aWO5YpyC0ALIw==
+  /@babel/plugin-transform-duplicate-keys/7.8.3_@babel+core@7.9.0:
+    dependencies:
+      '@babel/core': 7.9.0
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-s8dHiBUbcbSgipS4SMFuWGqCvyge5V2ZeAWzR6INTVC3Ltjig/Vw1G2Gztv0vU/hRG9X8IvKvYdoksnUfgXOEQ==
-  /@babel/plugin-transform-exponentiation-operator/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-exponentiation-operator/7.8.3_@babel+core@7.9.0:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.9.0
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.8.3
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
@@ -966,18 +1120,18 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-zwIpuIymb3ACcInbksHaNcR12S++0MDLKkiqXHl3AzpgdKlFNhog+z/K0+TGW+b0w5pgTq4H6IwV/WhxbGYSjQ==
-  /@babel/plugin-transform-for-of/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-for-of/7.9.0_@babel+core@7.9.0:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.9.0
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-ZjXznLNTxhpf4Q5q3x1NsngzGA38t9naWH8Gt+0qYZEJAcvPI9waSStSh56u19Ofjr7QmD0wUsQ8hw8s/p1VnA==
-  /@babel/plugin-transform-function-name/7.8.3_@babel+core@7.8.3:
+      integrity: sha512-lTAnWOpMwOXpyDx06N+ywmF3jNbafZEqZ96CGYabxHrxNX8l5ny7dt4bK/rGwAh9utyP2b2Hv7PlZh1AAS54FQ==
+  /@babel/plugin-transform-function-name/7.8.3_@babel+core@7.9.0:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.9.0
       '@babel/helper-function-name': 7.8.3
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
@@ -985,35 +1139,35 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-rO/OnDS78Eifbjn5Py9v8y0aR+aSYhDhqAwVfsTl0ERuMZyr05L1aFSCJnbv2mmsLkit/4ReeQ9N2BgLnOcPCQ==
-  /@babel/plugin-transform-literals/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-literals/7.8.3_@babel+core@7.9.0:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.9.0
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-3Tqf8JJ/qB7TeldGl+TT55+uQei9JfYaregDcEAyBZ7akutriFrt6C/wLYIer6OYhleVQvH/ntEhjE/xMmy10A==
-  /@babel/plugin-transform-member-expression-literals/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-member-expression-literals/7.8.3_@babel+core@7.9.0:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.9.0
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-3Wk2EXhnw+rP+IDkK6BdtPKsUE5IeZ6QOGrPYvw52NwBStw9V1ZVzxgK6fSKSxqUvH9eQPR3tm3cOq79HlsKYA==
-  /@babel/plugin-transform-modules-amd/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-modules-amd/7.9.0_@babel+core@7.9.0:
     dependencies:
-      '@babel/core': 7.8.3
-      '@babel/helper-module-transforms': 7.8.3
+      '@babel/core': 7.9.0
+      '@babel/helper-module-transforms': 7.9.0
       '@babel/helper-plugin-utils': 7.8.3
       babel-plugin-dynamic-import-node: 2.3.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-MadJiU3rLKclzT5kBH4yxdry96odTUwuqrZM+GllFI/VhxfPz+k9MshJM+MwhfkCdxxclSbSBbUGciBngR+kEQ==
+      integrity: sha512-vZgDDF003B14O8zJy0XXLnPH4sg+9X5hFBBGN1V+B2rgrB+J2xIypSN6Rk9imB2hSTHQi5OHLrFWsZab1GMk+Q==
   /@babel/plugin-transform-modules-commonjs/7.8.3_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -1026,115 +1180,126 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-JpdMEfA15HZ/1gNuB9XEDlZM1h/gF/YOH7zaZzQu2xCFRfwc01NXBMHHSTT6hRjlXJJs5x/bfODM3LiCk94Sxg==
-  /@babel/plugin-transform-modules-systemjs/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-modules-commonjs/7.9.0_@babel+core@7.9.0:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.9.0
+      '@babel/helper-module-transforms': 7.9.0
+      '@babel/helper-plugin-utils': 7.8.3
+      '@babel/helper-simple-access': 7.8.3
+      babel-plugin-dynamic-import-node: 2.3.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-qzlCrLnKqio4SlgJ6FMMLBe4bySNis8DFn1VkGmOcxG9gqEyPIOzeQrA//u0HAKrWpJlpZbZMPB1n/OPa4+n8g==
+  /@babel/plugin-transform-modules-systemjs/7.9.0_@babel+core@7.9.0:
+    dependencies:
+      '@babel/core': 7.9.0
       '@babel/helper-hoist-variables': 7.8.3
-      '@babel/helper-module-transforms': 7.8.3
+      '@babel/helper-module-transforms': 7.9.0
       '@babel/helper-plugin-utils': 7.8.3
       babel-plugin-dynamic-import-node: 2.3.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-8cESMCJjmArMYqa9AO5YuMEkE4ds28tMpZcGZB/jl3n0ZzlsxOAi3mC+SKypTfT8gjMupCnd3YiXCkMjj2jfOg==
-  /@babel/plugin-transform-modules-umd/7.8.3_@babel+core@7.8.3:
+      integrity: sha512-FsiAv/nao/ud2ZWy4wFacoLOm5uxl0ExSQ7ErvP7jpoihLR6Cq90ilOFyX9UXct3rbtKsAiZ9kFt5XGfPe/5SQ==
+  /@babel/plugin-transform-modules-umd/7.9.0_@babel+core@7.9.0:
     dependencies:
-      '@babel/core': 7.8.3
-      '@babel/helper-module-transforms': 7.8.3
+      '@babel/core': 7.9.0
+      '@babel/helper-module-transforms': 7.9.0
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-evhTyWhbwbI3/U6dZAnx/ePoV7H6OUG+OjiJFHmhr9FPn0VShjwC2kdxqIuQ/+1P50TMrneGzMeyMTFOjKSnAw==
-  /@babel/plugin-transform-named-capturing-groups-regex/7.8.3_@babel+core@7.8.3:
+      integrity: sha512-uTWkXkIVtg/JGRSIABdBoMsoIeoHQHPTL0Y2E7xf5Oj7sLqwVsNXOkNk0VJc7vF0IMBsPeikHxFjGe+qmwPtTQ==
+  /@babel/plugin-transform-named-capturing-groups-regex/7.8.3_@babel+core@7.9.0:
     dependencies:
-      '@babel/core': 7.8.3
-      '@babel/helper-create-regexp-features-plugin': 7.8.3_@babel+core@7.8.3
+      '@babel/core': 7.9.0
+      '@babel/helper-create-regexp-features-plugin': 7.8.8_@babel+core@7.9.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-f+tF/8UVPU86TrCb06JoPWIdDpTNSGGcAtaD9mLP0aYGA0OS0j7j7DHJR0GTFrUZPUU6loZhbsVZgTh0N+Qdnw==
-  /@babel/plugin-transform-new-target/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-new-target/7.8.3_@babel+core@7.9.0:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.9.0
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-QuSGysibQpyxexRyui2vca+Cmbljo8bcRckgzYV4kRIsHpVeyeC3JDO63pY+xFZ6bWOBn7pfKZTqV4o/ix9sFw==
-  /@babel/plugin-transform-object-super/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-object-super/7.8.3_@babel+core@7.9.0:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.9.0
       '@babel/helper-plugin-utils': 7.8.3
-      '@babel/helper-replace-supers': 7.8.3
+      '@babel/helper-replace-supers': 7.8.6
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-57FXk+gItG/GejofIyLIgBKTas4+pEU47IXKDBWFTxdPd7F80H8zybyAY7UoblVfBhBGs2EKM+bJUu2+iUYPDQ==
-  /@babel/plugin-transform-parameters/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-parameters/7.9.3_@babel+core@7.9.0:
     dependencies:
-      '@babel/core': 7.8.3
-      '@babel/helper-call-delegate': 7.8.3
+      '@babel/core': 7.9.0
       '@babel/helper-get-function-arity': 7.8.3
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-/pqngtGb54JwMBZ6S/D3XYylQDFtGjWrnoCF4gXZOUpFV/ujbxnoNGNvDGu6doFWRPBveE72qTx/RRU44j5I/Q==
-  /@babel/plugin-transform-property-literals/7.8.3_@babel+core@7.8.3:
+      integrity: sha512-fzrQFQhp7mIhOzmOtPiKffvCYQSK10NR8t6BBz2yPbeUHb9OLW8RZGtgDRBn8z2hGcwvKDL3vC7ojPTLNxmqEg==
+  /@babel/plugin-transform-property-literals/7.8.3_@babel+core@7.9.0:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.9.0
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-uGiiXAZMqEoQhRWMK17VospMZh5sXWg+dlh2soffpkAl96KAm+WZuJfa6lcELotSRmooLqg0MWdH6UUq85nmmg==
-  /@babel/plugin-transform-regenerator/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-regenerator/7.8.7_@babel+core@7.9.0:
     dependencies:
-      '@babel/core': 7.8.3
-      regenerator-transform: 0.14.1
+      '@babel/core': 7.9.0
+      regenerator-transform: 0.14.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-qt/kcur/FxrQrzFR432FGZznkVAjiyFtCOANjkAKwCbt465L6ZCiUQh2oMYGU3Wo8LRFJxNDFwWn106S5wVUNA==
-  /@babel/plugin-transform-reserved-words/7.8.3_@babel+core@7.8.3:
+      integrity: sha512-TIg+gAl4Z0a3WmD3mbYSk+J9ZUH6n/Yc57rtKRnlA/7rcCvpekHXe0CMZHP1gYp7/KLe9GHTuIba0vXmls6drA==
+  /@babel/plugin-transform-reserved-words/7.8.3_@babel+core@7.9.0:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.9.0
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-mwMxcycN3omKFDjDQUl+8zyMsBfjRFr0Zn/64I41pmjv4NJuqcYlEtezwYtw9TFd9WR1vN5kiM+O0gMZzO6L0A==
-  /@babel/plugin-transform-shorthand-properties/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-shorthand-properties/7.8.3_@babel+core@7.9.0:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.9.0
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-I9DI6Odg0JJwxCHzbzW08ggMdCezoWcuQRz3ptdudgwaHxTjxw5HgdFJmZIkIMlRymL6YiZcped4TTCB0JcC8w==
-  /@babel/plugin-transform-spread/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-spread/7.8.3_@babel+core@7.9.0:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.9.0
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-CkuTU9mbmAoFOI1tklFWYYbzX5qCIZVXPVy0jpXgGwkplCndQAa58s2jr66fTeQnA64bDox0HL4U56CFYoyC7g==
-  /@babel/plugin-transform-sticky-regex/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-sticky-regex/7.8.3_@babel+core@7.9.0:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.9.0
       '@babel/helper-plugin-utils': 7.8.3
       '@babel/helper-regex': 7.8.3
     dev: true
@@ -1142,9 +1307,9 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-9Spq0vGCD5Bb4Z/ZXXSK5wbbLFMG085qd2vhL1JYu1WcQ5bXqZBAYRzU1d+p79GcHs2szYv5pVQCX13QgldaWw==
-  /@babel/plugin-transform-template-literals/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-template-literals/7.8.3_@babel+core@7.9.0:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.9.0
       '@babel/helper-annotate-as-pure': 7.8.3
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
@@ -1152,93 +1317,109 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-820QBtykIQOLFT8NZOcTRJ1UNuztIELe4p9DCgvj4NK+PwluSJ49we7s9FB1HIGNIYT7wFUJ0ar2QpCDj0escQ==
-  /@babel/plugin-transform-typeof-symbol/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-typeof-symbol/7.8.4_@babel+core@7.9.0:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.9.0
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-3TrkKd4LPqm4jHs6nPtSDI/SV9Cm5PRJkHLUgTcqRQQTMAZ44ZaAdDZJtvWFSaRcvT0a1rTmJ5ZA5tDKjleF3g==
-  /@babel/plugin-transform-unicode-regex/7.8.3_@babel+core@7.8.3:
+      integrity: sha512-2QKyfjGdvuNfHsb7qnBBlKclbD4CfshH2KvDabiijLMGXPHJXGxtDzwIF7bQP+T0ysw8fYTtxPafgfs/c1Lrqg==
+  /@babel/plugin-transform-unicode-regex/7.8.3_@babel+core@7.9.0:
     dependencies:
-      '@babel/core': 7.8.3
-      '@babel/helper-create-regexp-features-plugin': 7.8.3_@babel+core@7.8.3
+      '@babel/core': 7.9.0
+      '@babel/helper-create-regexp-features-plugin': 7.8.8_@babel+core@7.9.0
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-+ufgJjYdmWfSQ+6NS9VGUR2ns8cjJjYbrbi11mZBTaWm+Fui/ncTLFF28Ei1okavY+xkojGr1eJxNsWYeA5aZw==
-  /@babel/preset-env/7.8.3_@babel+core@7.8.3:
+  /@babel/preset-env/7.9.0_@babel+core@7.9.0:
     dependencies:
-      '@babel/compat-data': 7.8.1
-      '@babel/core': 7.8.3
-      '@babel/helper-compilation-targets': 7.8.3_@babel+core@7.8.3
+      '@babel/compat-data': 7.9.0
+      '@babel/core': 7.9.0
+      '@babel/helper-compilation-targets': 7.8.7_@babel+core@7.9.0
       '@babel/helper-module-imports': 7.8.3
       '@babel/helper-plugin-utils': 7.8.3
-      '@babel/plugin-proposal-async-generator-functions': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-proposal-dynamic-import': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-proposal-json-strings': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-proposal-object-rest-spread': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-proposal-optional-catch-binding': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-proposal-optional-chaining': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-proposal-unicode-property-regex': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.8.3
-      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-syntax-top-level-await': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-arrow-functions': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-async-to-generator': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-block-scoped-functions': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-block-scoping': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-classes': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-computed-properties': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-destructuring': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-dotall-regex': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-duplicate-keys': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-exponentiation-operator': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-for-of': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-function-name': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-literals': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-member-expression-literals': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-modules-amd': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-modules-commonjs': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-modules-systemjs': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-modules-umd': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-new-target': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-object-super': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-parameters': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-property-literals': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-regenerator': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-reserved-words': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-shorthand-properties': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-spread': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-sticky-regex': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-template-literals': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-typeof-symbol': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-unicode-regex': 7.8.3_@babel+core@7.8.3
-      '@babel/types': 7.8.3
-      browserslist: 4.8.3
+      '@babel/plugin-proposal-async-generator-functions': 7.8.3_@babel+core@7.9.0
+      '@babel/plugin-proposal-dynamic-import': 7.8.3_@babel+core@7.9.0
+      '@babel/plugin-proposal-json-strings': 7.8.3_@babel+core@7.9.0
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.8.3_@babel+core@7.9.0
+      '@babel/plugin-proposal-numeric-separator': 7.8.3_@babel+core@7.9.0
+      '@babel/plugin-proposal-object-rest-spread': 7.9.0_@babel+core@7.9.0
+      '@babel/plugin-proposal-optional-catch-binding': 7.8.3_@babel+core@7.9.0
+      '@babel/plugin-proposal-optional-chaining': 7.9.0_@babel+core@7.9.0
+      '@babel/plugin-proposal-unicode-property-regex': 7.8.8_@babel+core@7.9.0
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.9.0
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.9.0
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.9.0
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.9.0
+      '@babel/plugin-syntax-numeric-separator': 7.8.3_@babel+core@7.9.0
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.9.0
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.9.0
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.9.0
+      '@babel/plugin-syntax-top-level-await': 7.8.3_@babel+core@7.9.0
+      '@babel/plugin-transform-arrow-functions': 7.8.3_@babel+core@7.9.0
+      '@babel/plugin-transform-async-to-generator': 7.8.3_@babel+core@7.9.0
+      '@babel/plugin-transform-block-scoped-functions': 7.8.3_@babel+core@7.9.0
+      '@babel/plugin-transform-block-scoping': 7.8.3_@babel+core@7.9.0
+      '@babel/plugin-transform-classes': 7.9.2_@babel+core@7.9.0
+      '@babel/plugin-transform-computed-properties': 7.8.3_@babel+core@7.9.0
+      '@babel/plugin-transform-destructuring': 7.8.8_@babel+core@7.9.0
+      '@babel/plugin-transform-dotall-regex': 7.8.3_@babel+core@7.9.0
+      '@babel/plugin-transform-duplicate-keys': 7.8.3_@babel+core@7.9.0
+      '@babel/plugin-transform-exponentiation-operator': 7.8.3_@babel+core@7.9.0
+      '@babel/plugin-transform-for-of': 7.9.0_@babel+core@7.9.0
+      '@babel/plugin-transform-function-name': 7.8.3_@babel+core@7.9.0
+      '@babel/plugin-transform-literals': 7.8.3_@babel+core@7.9.0
+      '@babel/plugin-transform-member-expression-literals': 7.8.3_@babel+core@7.9.0
+      '@babel/plugin-transform-modules-amd': 7.9.0_@babel+core@7.9.0
+      '@babel/plugin-transform-modules-commonjs': 7.9.0_@babel+core@7.9.0
+      '@babel/plugin-transform-modules-systemjs': 7.9.0_@babel+core@7.9.0
+      '@babel/plugin-transform-modules-umd': 7.9.0_@babel+core@7.9.0
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.8.3_@babel+core@7.9.0
+      '@babel/plugin-transform-new-target': 7.8.3_@babel+core@7.9.0
+      '@babel/plugin-transform-object-super': 7.8.3_@babel+core@7.9.0
+      '@babel/plugin-transform-parameters': 7.9.3_@babel+core@7.9.0
+      '@babel/plugin-transform-property-literals': 7.8.3_@babel+core@7.9.0
+      '@babel/plugin-transform-regenerator': 7.8.7_@babel+core@7.9.0
+      '@babel/plugin-transform-reserved-words': 7.8.3_@babel+core@7.9.0
+      '@babel/plugin-transform-shorthand-properties': 7.8.3_@babel+core@7.9.0
+      '@babel/plugin-transform-spread': 7.8.3_@babel+core@7.9.0
+      '@babel/plugin-transform-sticky-regex': 7.8.3_@babel+core@7.9.0
+      '@babel/plugin-transform-template-literals': 7.8.3_@babel+core@7.9.0
+      '@babel/plugin-transform-typeof-symbol': 7.8.4_@babel+core@7.9.0
+      '@babel/plugin-transform-unicode-regex': 7.8.3_@babel+core@7.9.0
+      '@babel/preset-modules': 0.1.3_@babel+core@7.9.0
+      '@babel/types': 7.9.0
+      browserslist: 4.11.0
       core-js-compat: 3.6.4
       invariant: 2.2.4
-      levenary: 1.1.0
+      levenary: 1.1.1
       semver: 5.7.1
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-Rs4RPL2KjSLSE2mWAx5/iCH+GC1ikKdxPrhnRS6PfFVaiZeom22VFKN4X8ZthyN61kAaR05tfXTbCvatl9WIQg==
-  /@babel/register/7.8.3_@babel+core@7.8.3:
+      integrity: sha512-712DeRXT6dyKAM/FMbQTV/FvRCms2hPCx+3weRjZ8iQVQWZejWWk1wwG6ViWMyqb/ouBbGOl5b6aCk0+j1NmsQ==
+  /@babel/preset-modules/0.1.3_@babel+core@7.9.0:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.9.0
+      '@babel/helper-plugin-utils': 7.8.3
+      '@babel/plugin-proposal-unicode-property-regex': 7.8.8_@babel+core@7.9.0
+      '@babel/plugin-transform-dotall-regex': 7.8.3_@babel+core@7.9.0
+      '@babel/types': 7.9.0
+      esutils: 2.0.3
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-Ra3JXOHBq2xd56xSF7lMKXdjBn3T772Y1Wet3yWnkDly9zHvJki029tAFzvAAK5cf4YV3yoxuP61crYRol6SVg==
+  /@babel/register/7.9.0_@babel+core@7.9.0:
+    dependencies:
+      '@babel/core': 7.9.0
       find-cache-dir: 2.1.0
       lodash: 4.17.15
       make-dir: 2.1.0
@@ -1248,13 +1429,19 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-t7UqebaWwo9nXWClIPLPloa5pN33A2leVs8Hf0e9g9YwUP8/H9NeR7DJU+4CXo23QtjChQv5a3DjEtT83ih1rg==
+      integrity: sha512-Tv8Zyi2J2VRR8g7pC5gTeIN8Ihultbmk0ocyNz8H2nEZbmhp1N6q0A1UGsQbDvGP/sNinQKUHf3SqXwqjtFv4Q==
   /@babel/runtime/7.8.3:
     dependencies:
       regenerator-runtime: 0.13.3
     dev: true
     resolution:
       integrity: sha512-fVHx1rzEmwB130VTkLnxR+HmxcTjGzH12LYQcFFoBwakMd3aOMD4OsRN7tGG/UOYE2ektgFrS8uACAoRk1CY0w==
+  /@babel/runtime/7.9.2:
+    dependencies:
+      regenerator-runtime: 0.13.5
+    dev: true
+    resolution:
+      integrity: sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==
   /@babel/template/7.8.3:
     dependencies:
       '@babel/code-frame': 7.8.3
@@ -1263,6 +1450,14 @@ packages:
     dev: true
     resolution:
       integrity: sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==
+  /@babel/template/7.8.6:
+    dependencies:
+      '@babel/code-frame': 7.8.3
+      '@babel/parser': 7.9.4
+      '@babel/types': 7.9.0
+    dev: true
+    resolution:
+      integrity: sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==
   /@babel/traverse/7.8.3:
     dependencies:
       '@babel/code-frame': 7.8.3
@@ -1277,6 +1472,20 @@ packages:
     dev: true
     resolution:
       integrity: sha512-we+a2lti+eEImHmEXp7bM9cTxGzxPmBiVJlLVD+FuuQMeeO7RaDbutbgeheDkw+Xe3mCfJHnGOWLswT74m2IPg==
+  /@babel/traverse/7.9.0:
+    dependencies:
+      '@babel/code-frame': 7.8.3
+      '@babel/generator': 7.9.4
+      '@babel/helper-function-name': 7.8.3
+      '@babel/helper-split-export-declaration': 7.8.3
+      '@babel/parser': 7.9.4
+      '@babel/types': 7.9.0
+      debug: 4.1.1
+      globals: 11.12.0
+      lodash: 4.17.15
+    dev: true
+    resolution:
+      integrity: sha512-jAZQj0+kn4WTHO5dUZkZKhbFrqZE7K5LAQ5JysMnmvGij+wOdr+8lWqPeW0BcF4wFwrEXXtdGO7wcV6YPJcf3w==
   /@babel/types/7.8.3:
     dependencies:
       esutils: 2.0.3
@@ -1285,6 +1494,14 @@ packages:
     dev: true
     resolution:
       integrity: sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==
+  /@babel/types/7.9.0:
+    dependencies:
+      '@babel/helper-validator-identifier': 7.9.0
+      lodash: 4.17.15
+      to-fast-properties: 2.0.0
+    dev: true
+    resolution:
+      integrity: sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==
   /@concordance/react/2.0.0:
     dependencies:
       arrify: 1.0.1
@@ -1388,37 +1605,22 @@ packages:
       rollup: ^1.20.0
     resolution:
       integrity: sha512-MPYGZr0qdbV5zZj8/2AuomVpnRVXRU5XKXb3HVniwRoRCreGlf5kOE081isNWeiLIi6IYkwTX9zE0/c7V8g81g==
-  /@rollup/plugin-json/4.0.1_rollup@2.2.0:
-    dependencies:
-      rollup: 2.2.0
-      rollup-pluginutils: 2.8.2
-    dev: true
-    peerDependencies:
-      rollup: ^1.20.0
-    resolution:
-      integrity: sha512-soxllkhOGgchswBAAaTe7X9G80U2tjjHvXv0sBrriLJcC/89PkP59iTrKPOfbz3SjX088mKDmMhAscuyLz8ZSg==
-  /@rollup/plugin-node-resolve/6.1.0_rollup@2.2.0:
+  /@rollup/plugin-json/4.0.2_rollup@2.2.0:
     dependencies:
       '@rollup/pluginutils': 3.0.8_rollup@2.2.0
-      '@types/resolve': 0.0.8
-      builtin-modules: 3.1.0
-      is-module: 1.0.0
-      resolve: 1.15.0
       rollup: 2.2.0
     dev: true
-    engines:
-      node: '>= 8.0.0'
     peerDependencies:
       rollup: ^1.20.0
     resolution:
-      integrity: sha512-Cv7PDIvxdE40SWilY5WgZpqfIUEaDxFxs89zCAHjqyRwlTSuql4M5hjIuc5QYJkOH0/vyiyNXKD72O+LhRipGA==
+      integrity: sha512-t4zJMc98BdH42mBuzjhQA7dKh0t4vMJlUka6Fz0c+iO5IVnWaEMiYBy1uBj9ruHZzXBW23IPDGL9oCzBkQ9Udg==
   /@rollup/plugin-node-resolve/7.1.1:
     dependencies:
       '@rollup/pluginutils': 3.0.8
       '@types/resolve': 0.0.8
       builtin-modules: 3.1.0
       is-module: 1.0.0
-      resolve: 1.15.0
+      resolve: 1.15.1
     dev: true
     engines:
       node: '>= 8.0.0'
@@ -1432,7 +1634,7 @@ packages:
       '@types/resolve': 0.0.8
       builtin-modules: 3.1.0
       is-module: 1.0.0
-      resolve: 1.15.0
+      resolve: 1.15.1
       rollup: 2.2.0
     dev: true
     engines:
@@ -1648,8 +1850,12 @@ packages:
     resolution:
       integrity: sha512-Jg1F+bmxcpENHP23sVKkNuU3uaxPnsBMW0cLjleiikFKomJQbsn0Cqk2yDvQArqzZN6ABfBkZ0To7pQ8sLdWDg==
   /@types/node/13.1.8:
+    dev: true
     resolution:
       integrity: sha512-6XzyyNM9EKQW4HKuzbo/CkOIjn/evtCmsU+MUM1xDfJ+3/rNjBttM1NgN7AOQvN6tP1Sl1D1PIKMreTArnxM9A==
+  /@types/node/13.9.5:
+    resolution:
+      integrity: sha512-hkzMMD3xu6BrJpGVLeQ3htQQNAcOrJjX7WFmtK8zWQpz2UJf13LCFF2ALA7c9OVdvc2vQJeDdjfR35M0sBCxvw==
   /@types/normalize-package-data/2.4.0:
     dev: true
     resolution:
@@ -1660,7 +1866,7 @@ packages:
       integrity: sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==
   /@types/resolve/0.0.8:
     dependencies:
-      '@types/node': 13.1.8
+      '@types/node': 13.9.5
     resolution:
       integrity: sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
   /@types/yargs-parser/15.0.0:
@@ -1767,14 +1973,14 @@ packages:
       acorn: ^6.0.0 || ^7.0.0
     resolution:
       integrity: sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==
-  /acorn-jsx/5.1.0_acorn@7.1.0:
+  /acorn-jsx/5.2.0_acorn@7.1.1:
     dependencies:
-      acorn: 7.1.0
+      acorn: 7.1.1
     dev: true
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0
     resolution:
-      integrity: sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==
+      integrity: sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==
   /acorn/6.4.0:
     engines:
       node: '>=0.4.0'
@@ -1788,6 +1994,13 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==
+  /acorn/7.1.1:
+    dev: true
+    engines:
+      node: '>=0.4.0'
+    hasBin: true
+    resolution:
+      integrity: sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==
   /aggregate-error/3.0.1:
     dependencies:
       clean-stack: 2.2.0
@@ -1797,7 +2010,7 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==
-  /ajv/6.11.0:
+  /ajv/6.12.0:
     dependencies:
       fast-deep-equal: 3.1.1
       fast-json-stable-stringify: 2.1.0
@@ -1805,7 +2018,7 @@ packages:
       uri-js: 4.2.2
     dev: true
     resolution:
-      integrity: sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==
+      integrity: sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==
   /alphanum-sort/1.0.2:
     dev: true
     resolution:
@@ -1830,6 +2043,14 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-EiYhwo0v255HUL6eDyuLrXEkTi7WwVCLAw+SeOQ7M7qdun1z1pum4DEm/nuqIVbPvi9RPPc9k9LbyBv6H0DwVg==
+  /ansi-escapes/4.3.1:
+    dependencies:
+      type-fest: 0.11.0
+    dev: true
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==
   /ansi-regex/2.1.1:
     dev: true
     engines:
@@ -2159,6 +2380,16 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
+  /browserslist/4.11.0:
+    dependencies:
+      caniuse-lite: 1.0.30001038
+      electron-to-chromium: 1.3.390
+      node-releases: 1.1.53
+      pkg-up: 3.1.0
+    dev: true
+    hasBin: true
+    resolution:
+      integrity: sha512-WqEC7Yr5wUH5sg6ruR++v2SGOQYpyUdYYd4tZoAq1F7y+QXoLoYGXVbxhtaIqWmAJjtNTRjVD3HuJc1OXTel2A==
   /browserslist/4.8.3:
     dependencies:
       caniuse-lite: 1.0.30001021
@@ -2291,6 +2522,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-wuMhT7/hwkgd8gldgp2jcrUjOU9RXJ4XxGumQeOsUr91l3WwmM68Cpa/ymCnWEDqakwFXhuDQbaKNHXBPgeE9g==
+  /caniuse-lite/1.0.30001038:
+    dev: true
+    resolution:
+      integrity: sha512-zii9quPo96XfOiRD4TrfYGs+QsGZpb2cGiMAzPjtf/hpFgB6zCPZgJb7I1+EATeMw/o+lG8FyRAnI+CWStHcaQ==
   /chalk/1.1.3:
     dependencies:
       ansi-styles: 2.2.1
@@ -2312,6 +2547,15 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
+  /chalk/3.0.0:
+    dependencies:
+      ansi-styles: 4.2.1
+      supports-color: 7.1.0
+    dev: true
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
   /chardet/0.7.0:
     dev: true
     resolution:
@@ -2584,7 +2828,7 @@ packages:
       integrity: sha1-fj5Iu+bZl7FBfdyihoIEtNPYVxU=
   /core-js-compat/3.6.4:
     dependencies:
-      browserslist: 4.8.3
+      browserslist: 4.11.0
       semver: 7.0.0
     dev: true
     resolution:
@@ -3070,6 +3314,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-uJ+wLjslYQ/2rAusDg+6FlK8DLhHWTLCe7gkofBehTifW7KCkPVTn5rhKSCncWYNq34Iy/o4OfswuEkAO2RBaw==
+  /electron-to-chromium/1.3.390:
+    dev: true
+    resolution:
+      integrity: sha512-4RvbM5x+002gKI8sltkqWEk5pptn0UnzekUx8RTThAMPDSb8jjpm6SwGiSnEve7f85biyZl8DMXaipaCxDjXag==
   /elegant-spinner/1.0.1:
     dev: true
     engines:
@@ -3282,7 +3530,7 @@ packages:
   /eslint/6.8.0:
     dependencies:
       '@babel/code-frame': 7.8.3
-      ajv: 6.11.0
+      ajv: 6.12.0
       chalk: 2.4.2
       cross-spawn: 6.0.5
       debug: 4.1.1
@@ -3290,24 +3538,24 @@ packages:
       eslint-scope: 5.0.0
       eslint-utils: 1.4.3
       eslint-visitor-keys: 1.1.0
-      espree: 6.1.2
-      esquery: 1.0.1
+      espree: 6.2.1
+      esquery: 1.2.0
       esutils: 2.0.3
       file-entry-cache: 5.0.1
       functional-red-black-tree: 1.0.1
-      glob-parent: 5.1.0
-      globals: 12.3.0
+      glob-parent: 5.1.1
+      globals: 12.4.0
       ignore: 4.0.6
       import-fresh: 3.2.1
       imurmurhash: 0.1.4
-      inquirer: 7.0.3
+      inquirer: 7.1.0
       is-glob: 4.0.1
       js-yaml: 3.13.1
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.3.0
       lodash: 4.17.15
       minimatch: 3.0.4
-      mkdirp: 0.5.1
+      mkdirp: 0.5.4
       natural-compare: 1.4.0
       optionator: 0.8.3
       progress: 2.0.3
@@ -3339,16 +3587,16 @@ packages:
     dev: true
     resolution:
       integrity: sha1-oXt+zFnTDheeK+9z+0E3cEyzMbU=
-  /espree/6.1.2:
+  /espree/6.2.1:
     dependencies:
-      acorn: 7.1.0
-      acorn-jsx: 5.1.0_acorn@7.1.0
+      acorn: 7.1.1
+      acorn-jsx: 5.2.0_acorn@7.1.1
       eslint-visitor-keys: 1.1.0
     dev: true
     engines:
       node: '>=6.0.0'
     resolution:
-      integrity: sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==
+      integrity: sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==
   /esprima/4.0.1:
     engines:
       node: '>=4'
@@ -3361,14 +3609,14 @@ packages:
     dev: true
     resolution:
       integrity: sha512-ZDko6eY/o+D/gHCWyHTU85mKDgYcS4FJj7S+YD6WIInm7GQ6AnOjmcL4+buFV/JOztVLELi/7MmuGU5NHta0Mg==
-  /esquery/1.0.1:
+  /esquery/1.2.0:
     dependencies:
-      estraverse: 4.3.0
+      estraverse: 5.0.0
     dev: true
     engines:
-      node: '>=0.6'
+      node: '>=8.0'
     resolution:
-      integrity: sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==
+      integrity: sha512-weltsSqdeWIX9G2qQZz7KlTRJdkkOCTPgLYJUz1Hacf48R4YOwGPHO3+ORfWedqJKbq5WQmsgK90n+pFLIKt/Q==
   /esrecurse/4.2.1:
     dependencies:
       estraverse: 4.3.0
@@ -3383,6 +3631,12 @@ packages:
       node: '>=4.0'
     resolution:
       integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
+  /estraverse/5.0.0:
+    dev: true
+    engines:
+      node: '>=4.0'
+    resolution:
+      integrity: sha512-j3acdrMzqrxmJTNj5dbr1YbjacrYgAxVMeF0gK16E3j494mOe7xygM/ZLIguEQ0ETwAg2hlJCtHRGav+y0Ny5A==
   /estree-walker/0.6.1:
     dev: true
     resolution:
@@ -3527,6 +3781,14 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-ravh8VRXqHuMvZt/d8GblBeqDMkdJMBdv/2KntFH+ra5MXkO7nxNKpzQ3n6QD/2da1kH0aWmNISdvhM7gl2gVg==
+  /figures/3.2.0:
+    dependencies:
+      escape-string-regexp: 1.0.5
+    dev: true
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
   /file-entry-cache/5.0.1:
     dependencies:
       flat-cache: 2.0.1
@@ -3680,6 +3942,14 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==
+  /glob-parent/5.1.1:
+    dependencies:
+      is-glob: 4.0.1
+    dev: true
+    engines:
+      node: '>= 6'
+    resolution:
+      integrity: sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
   /glob/7.1.6:
     dependencies:
       fs.realpath: 1.0.0
@@ -3726,14 +3996,14 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
-  /globals/12.3.0:
+  /globals/12.4.0:
     dependencies:
       type-fest: 0.8.1
     dev: true
     engines:
       node: '>=8'
     resolution:
-      integrity: sha512-wAfjdLgFsPZsklLJvOBUBmzYE8/CwhEqSBEMRXA3qxIiNtyqvjYurAtIfDh6chlEPUfmTY3MnZh5Hfh4q0UlIw==
+      integrity: sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==
   /globby/10.0.2:
     dependencies:
       '@types/glob': 7.1.1
@@ -4016,26 +4286,26 @@ packages:
   /ini/1.3.5:
     resolution:
       integrity: sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
-  /inquirer/7.0.3:
+  /inquirer/7.1.0:
     dependencies:
-      ansi-escapes: 4.3.0
-      chalk: 2.4.2
+      ansi-escapes: 4.3.1
+      chalk: 3.0.0
       cli-cursor: 3.1.0
       cli-width: 2.2.0
       external-editor: 3.1.0
-      figures: 3.1.0
+      figures: 3.2.0
       lodash: 4.17.15
       mute-stream: 0.0.8
-      run-async: 2.3.0
+      run-async: 2.4.0
       rxjs: 6.5.4
       string-width: 4.2.0
-      strip-ansi: 5.2.0
+      strip-ansi: 6.0.0
       through: 2.3.8
     dev: true
     engines:
       node: '>=6.0.0'
     resolution:
-      integrity: sha512-+OiOVeVydu4hnCGLCSX+wedovR/Yzskv9BFqUNNKq9uU2qg7LCcCo3R86S2E7WLo0y/x2pnEZfZe1CoYnORUAw==
+      integrity: sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==
   /interpret/1.2.0:
     dev: true
     engines:
@@ -4507,6 +4777,15 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==
+  /json5/2.1.2:
+    dependencies:
+      minimist: 1.2.5
+    dev: true
+    engines:
+      node: '>=6'
+    hasBin: true
+    resolution:
+      integrity: sha512-MoUOQ4WdiN3yxhm7NEVJSJrieAo5hNSLQ5sj05OTRHPL9HOBy8u4Bu88jsC1jvqAdN+E1bJmsUcZH+1HQxliqQ==
   /jsonparse/1.3.1:
     dev: false
     engines:
@@ -4537,14 +4816,14 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==
-  /levenary/1.1.0:
+  /levenary/1.1.1:
     dependencies:
       leven: 3.1.0
     dev: true
     engines:
-      node: '>= 8'
+      node: '>= 6'
     resolution:
-      integrity: sha512-VHcwhO0UTpUW7rLPN2/OiWJdgA1e9BqEDALhrgCe/F+uUJnep6CoUsTzMeP8Rh0NGr9uKquXxqe7lwLZo509nQ==
+      integrity: sha512-mkAdOIt79FD6irqjYSs4rdbnlT5vRonMEvBVPVb3XmevfS8kgRXwfes0dhPdEtzTWD/1eNE/Bm/G1iRt6DcnQQ==
   /levn/0.3.0:
     dependencies:
       prelude-ls: 1.1.2
@@ -4995,6 +5274,10 @@ packages:
   /minimist/1.2.0:
     resolution:
       integrity: sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
+  /minimist/1.2.5:
+    dev: true
+    resolution:
+      integrity: sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
   /mkdirp/0.5.1:
     dependencies:
       minimist: 0.0.8
@@ -5003,6 +5286,14 @@ packages:
     hasBin: true
     resolution:
       integrity: sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
+  /mkdirp/0.5.4:
+    dependencies:
+      minimist: 1.2.5
+    deprecated: Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)
+    dev: true
+    hasBin: true
+    resolution:
+      integrity: sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==
   /ms/2.0.0:
     dev: true
     resolution:
@@ -5065,6 +5356,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-YOjdx+Uoh9FbRO7yVYbnbt1puRWPQMemR3SutLeyv2XfxKs1ihpe0OLAUwBPEP2ImNH/PZC7SEiC6j32dwRZ7g==
+  /node-releases/1.1.53:
+    dev: true
+    resolution:
+      integrity: sha512-wp8zyQVwef2hpZ/dJH7SfSrIPD6YoJz6BDQDpGEkcA0s3LpAQoxBIYmfIq6QAhC1DhwsyCgTaTTcONwX8qzCuQ==
   /normalize-package-data/2.5.0:
     dependencies:
       hosted-git-info: 2.8.5
@@ -5587,6 +5882,14 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
+  /pkg-up/3.1.0:
+    dependencies:
+      find-up: 3.0.0
+    dev: true
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
   /please-upgrade-node/3.2.0:
     dependencies:
       semver-compare: 1.0.0
@@ -6201,6 +6504,14 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==
+  /regenerate-unicode-properties/8.2.0:
+    dependencies:
+      regenerate: 1.4.0
+    dev: true
+    engines:
+      node: '>=4'
+    resolution:
+      integrity: sha512-F9DjY1vKLo/tPePDycuH3dn9H1OTPIkVD9Kz4LODu+F2C75mgjAJ7x/gwy6ZcSNRAAkhNlJSOHRe8k3p+K9WhA==
   /regenerate/1.4.0:
     resolution:
       integrity: sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==
@@ -6208,12 +6519,17 @@ packages:
     dev: true
     resolution:
       integrity: sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
-  /regenerator-transform/0.14.1:
+  /regenerator-runtime/0.13.5:
+    dev: true
+    resolution:
+      integrity: sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==
+  /regenerator-transform/0.14.4:
     dependencies:
+      '@babel/runtime': 7.9.2
       private: 0.1.8
     dev: true
     resolution:
-      integrity: sha512-flVuee02C3FKRISbxhXl9mGzdbWUVHubl1SMaknjxkFB1/iqpJhArQUvRxOOPEc/9tAiX0BaQ28FJH10E4isSQ==
+      integrity: sha512-EaJaKPBI9GvKpvUz2mz4fhx7WPgvwRLY9v3hlNHWmAuJHI13T4nwKnNvm5RWJzEdnI5g5UwtOww+S8IdoUC2bw==
   /regexp.prototype.flags/1.3.0:
     dependencies:
       define-properties: 1.1.3
@@ -6255,6 +6571,19 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==
+  /regexpu-core/4.7.0:
+    dependencies:
+      regenerate: 1.4.0
+      regenerate-unicode-properties: 8.2.0
+      regjsgen: 0.5.1
+      regjsparser: 0.6.4
+      unicode-match-property-ecmascript: 1.0.4
+      unicode-match-property-value-ecmascript: 1.2.0
+    dev: true
+    engines:
+      node: '>=4'
+    resolution:
+      integrity: sha512-TQ4KXRnIn6tz6tjnrXEkD/sshygKH/j5KzK86X8MkeHyZ8qst/LZ89j3X4/8HEIfHANTFIP/AbXakeRhWIl5YQ==
   /registry-auth-token/4.1.0:
     dependencies:
       rc: 1.2.8
@@ -6292,6 +6621,13 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-E9ghzUtoLwDekPT0DYCp+c4h+bvuUpe6rRHCTYn6eGoqj1LgKXxT6I0Il4WbjhQkOghzi/V+y03bPKvbllL93Q==
+  /regjsparser/0.6.4:
+    dependencies:
+      jsesc: 0.5.0
+    dev: true
+    hasBin: true
+    resolution:
+      integrity: sha512-64O87/dPDgfk8/RQqC4gkZoGyyWFIEUTTh80CU6CWuK5vkCGyekIx+oKcEIYtP/RAxSQltCZHCNu/mdd7fqlJw==
   /release-zalgo/1.0.0:
     dependencies:
       es6-error: 4.1.1
@@ -6364,6 +6700,12 @@ packages:
       path-parse: 1.0.6
     resolution:
       integrity: sha512-+hTmAldEGE80U2wJJDC1lebb5jWqvTYAfm3YZ1ckk1gBr0MnCqUKlwK1e+anaFljIl+F5tR5IoZcm4ZDA1zMQw==
+  /resolve/1.15.1:
+    dependencies:
+      path-parse: 1.0.6
+    dev: true
+    resolution:
+      integrity: sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==
   /responselike/1.0.2:
     dependencies:
       lowercase-keys: 1.0.1
@@ -6382,7 +6724,7 @@ packages:
   /restore-cursor/3.1.0:
     dependencies:
       onetime: 5.1.0
-      signal-exit: 3.0.2
+      signal-exit: 3.0.3
     dev: true
     engines:
       node: '>=8'
@@ -6424,9 +6766,9 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==
-  /rollup-plugin-babel/4.3.3_@babel+core@7.8.3+rollup@2.2.0:
+  /rollup-plugin-babel/4.3.3_@babel+core@7.9.0+rollup@2.2.0:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.9.0
       '@babel/helper-module-imports': 7.8.3
       rollup: 2.2.0
       rollup-pluginutils: 2.8.2
@@ -6436,6 +6778,18 @@ packages:
       rollup: '>=0.60.0 <2'
     resolution:
       integrity: sha512-tKzWOCmIJD/6aKNz0H1GMM+lW1q9KyFubbWzGiOG540zxPPifnEAHTZwjo0g991Y+DyOZcLqBgqOdqazYE5fkw==
+  /rollup-plugin-babel/4.4.0_@babel+core@7.9.0+rollup@2.2.0:
+    dependencies:
+      '@babel/core': 7.9.0
+      '@babel/helper-module-imports': 7.8.3
+      rollup: 2.2.0
+      rollup-pluginutils: 2.8.2
+    dev: true
+    peerDependencies:
+      '@babel/core': 7 || ^7.0.0-rc.2
+      rollup: '>=0.60.0 <3'
+    resolution:
+      integrity: sha512-Lek/TYp1+7g7I+uMfJnnSJ7YWoD58ajo6Oarhlex7lvUce+RCKRuGRSgztDO3/MF/PuGKmUL5iTHKf208UNszw==
   /rollup-plugin-commonjs/10.1.0_rollup@2.2.0:
     dependencies:
       estree-walker: 0.6.1
@@ -6485,14 +6839,14 @@ packages:
       fsevents: 2.1.2
     resolution:
       integrity: sha512-iAu/j9/WJ0i+zT0sAMuQnsEbmOKzdQ4Yxu5rbPs9aUCyqveI1Kw3H4Fi9NWfCOpb8luEySD2lDyFWL9CrLE8iw==
-  /run-async/2.3.0:
+  /run-async/2.4.0:
     dependencies:
       is-promise: 2.1.0
     dev: true
     engines:
       node: '>=0.12.0'
     resolution:
-      integrity: sha1-A3GrSuC91yDUFm19/aZP96RFpsA=
+      integrity: sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==
   /run-node/1.0.0:
     dev: true
     engines:
@@ -6510,7 +6864,7 @@ packages:
       integrity: sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q=
   /rxjs/6.5.4:
     dependencies:
-      tslib: 1.10.0
+      tslib: 1.11.1
     dev: true
     engines:
       npm: '>=2.0.0'
@@ -6624,6 +6978,10 @@ packages:
   /signal-exit/3.0.2:
     resolution:
       integrity: sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
+  /signal-exit/3.0.3:
+    dev: true
+    resolution:
+      integrity: sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
   /simple-swizzle/0.2.2:
     dependencies:
       is-arrayish: 0.3.2
@@ -7029,7 +7387,7 @@ packages:
       integrity: sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
   /table/5.4.6:
     dependencies:
-      ajv: 6.11.0
+      ajv: 6.12.0
       lodash: 4.17.15
       slice-ansi: 2.1.0
       string-width: 3.1.0
@@ -7189,6 +7547,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
+  /tslib/1.11.1:
+    dev: true
+    resolution:
+      integrity: sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
   /tsutils/3.17.1_typescript@3.7.5:
     dependencies:
       tslib: 1.10.0
@@ -7214,6 +7576,12 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
+  /type-fest/0.11.0:
+    dev: true
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==
   /type-fest/0.3.1:
     dev: true
     engines:
@@ -7271,7 +7639,7 @@ packages:
   /unicode-match-property-ecmascript/1.0.4:
     dependencies:
       unicode-canonical-property-names-ecmascript: 1.0.4
-      unicode-property-aliases-ecmascript: 1.0.5
+      unicode-property-aliases-ecmascript: 1.1.0
     engines:
       node: '>=4'
     resolution:
@@ -7281,11 +7649,17 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g==
-  /unicode-property-aliases-ecmascript/1.0.5:
+  /unicode-match-property-value-ecmascript/1.2.0:
+    dev: true
     engines:
       node: '>=4'
     resolution:
-      integrity: sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==
+      integrity: sha512-wjuQHGQVofmSJv1uVISKLE5zO2rNGzM/KCYZch/QQvez7C1hUhBIuZ701fYXExuufJFMPhv2SyL8CyoIfMLbIQ==
+  /unicode-property-aliases-ecmascript/1.1.0:
+    engines:
+      node: '>=4'
+    resolution:
+      integrity: sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg==
   /uniq/1.0.1:
     dev: true
     resolution:
@@ -7489,7 +7863,7 @@ packages:
       integrity: sha512-v2UQ+50TNf2rNHJ8NyWttfm/EJUBWMJcx6ZTYZr6Qp52uuegWw/lBkCtCbnYZEmPRNL61m+u67dAmGxo+HTULA==
   /write/1.0.3:
     dependencies:
-      mkdirp: 0.5.1
+      mkdirp: 0.5.4
     dev: true
     engines:
       node: '>=4'


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `{name}`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

> actually this kinda does not apply because this is not a code change, only dependencies upgrades

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

babel/babel#11216

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

The first intention was to upgrade `buble` in `@rollup/plugin-buble` because of a npm audit warning:

```
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Moderate      │ Regular Expression Denial of Service                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ acorn                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ @rollup/plugin-buble [dev]                                   │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ @rollup/plugin-buble > buble > acorn                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/1488                            │
└───────────────┴──────────────────────────────────────────────────────────────┘
```

This was fixed in `buble@0.20.0` but `@rollup/plugin-buble` was still depending on `buble@0.19.8`.

The other changes were in babel core, preset-env and register because of https://github.com/babel/babel/issues/11216 :

```
[!] (plugin babel) Error: No "exports" main resolved in /<path>/@rollup/plugins/node_modules/.pnp  
│ src/index.js
│ Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main resolved
```