### PR TITLE
node-resolve: resolve symlinked entry point properly

### DIFF
--- a/packages/node-resolve/src/util.js
+++ b/packages/node-resolve/src/util.js
@@ -171,7 +171,12 @@ export function resolveImportSpecifiers(importSpecifierList, resolveOptions) {
         return value;
       }
 
-      return resolveId(importSpecifierList[i], resolveOptions);
+      return resolveId(importSpecifierList[i], resolveOptions).then((result) => {
+        if (!resolveOptions.preserveSymlinks) {
+          result = realpathSync(result);
+        }
+        return result;
+      });
     });
 
     if (i < importSpecifierList.length - 1) {

--- a/packages/node-resolve/test/fixtures/symlinked/second/index.browser.js
+++ b/packages/node-resolve/test/fixtures/symlinked/second/index.browser.js
@@ -1,0 +1,1 @@
+export default 'not random string';

--- a/packages/node-resolve/test/fixtures/symlinked/second/package.json
+++ b/packages/node-resolve/test/fixtures/symlinked/second/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "second",
+  "main": "./index.js",
+  "browser": {
+    "./index.js": "./index.browser.js"
+  }
+}

--- a/packages/node-resolve/test/symlinks.js
+++ b/packages/node-resolve/test/symlinks.js
@@ -53,6 +53,16 @@ test.serial('resolves symlinked packages', async (t) => {
   t.is(module.exports.number1, module.exports.number2);
 });
 
+test.serial('resolves symlinked packages with browser object', async (t) => {
+  const bundle = await rollup({
+    input: 'symlinked/first/index.js',
+    onwarn: () => t.fail('No warnings were expected'),
+    plugins: [nodeResolve({ browser: true })]
+  });
+  const { module } = await testBundle(t, bundle);
+  t.is(module.exports.number1, 'not random string');
+});
+
 test.serial('preserves symlinks if `preserveSymlinks` is true', async (t) => {
   const bundle = await rollup({
     input: 'symlinked/first/index.js',


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `node-resolve`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

The regression appeared here https://github.com/uuidjs/uuid/pull/402#discussion_r400711937
after upgrading from `rollup-plugin-node-resolve` to `@rollup/plugin-node-solve`

Dependencies entry points are resolved into symlinked path when browser
field map contains real paths.



<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
