### PR TITLE
fix(run): use correct hook for reading options, handle facade chunks

### DIFF
--- a/packages/run/test/fixtures/facade-entry/dynamic.js
+++ b/packages/run/test/fixtures/facade-entry/dynamic.js
@@ -1,0 +1,3 @@
+import log from './library';
+
+log(0);

--- a/packages/run/test/fixtures/facade-entry/index.js
+++ b/packages/run/test/fixtures/facade-entry/index.js
@@ -1,0 +1,6 @@
+import log from './library';
+
+log(0);
+(async () => {
+  await import('./dynamic');
+})();

--- a/packages/run/test/fixtures/facade-entry/library.js
+++ b/packages/run/test/fixtures/facade-entry/library.js
@@ -1,0 +1,2 @@
+const log = (value) => console.log(value);
+export default log;

--- a/packages/run/test/test.js
+++ b/packages/run/test/test.js
@@ -38,6 +38,33 @@ test('builds the bundle and forks a child process', async (t) => {
   t.true(mockChildProcess.calledWithExactly(outputOptions.file, [], {}));
 });
 
+test('takes input from the latest options', async (t) => {
+  const bundle = await rollup({
+    input: 'incorrect',
+    plugins: [
+      run(),
+      {
+        options(options) {
+          options.input = input;
+          return options;
+        }
+      }
+    ]
+  });
+  await bundle.write(outputOptions);
+  t.true(mockChildProcess.calledWithExactly(outputOptions.file, [], {}));
+});
+
+test('checks entry point facade module', async (t) => {
+  const bundle = await rollup({
+    input: join(cwd, 'facade-entry/index.js'),
+    plugins: [run()]
+  });
+  const outputDir = join(cwd, 'output');
+  await bundle.write({ dir: outputDir, format: 'cjs' });
+  t.true(mockChildProcess.calledWithExactly(join(outputDir, 'index.js'), [], {}));
+});
+
 test('allows pass-through options for child_process.fork', async (t) => {
   const forkOptions = {
     cwd,
@@ -48,7 +75,6 @@ test('allows pass-through options for child_process.fork', async (t) => {
     input,
     plugins: [run(forkOptions)]
   });
-
   await bundle.write(outputOptions);
   t.true(mockChildProcess.calledWithExactly(outputOptions.file, [], forkOptions));
 });


### PR DESCRIPTION

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `run`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description
Ref https://github.com/rollup/plugins/pull/241#issuecomment-605697947

- take input from latest options when build is started
- check facade id instead of modules list
