### PR TITLE
Add example for passing code to Rollup's input

### DIFF
--- a/packages/virtual/README.md
+++ b/packages/virtual/README.md
@@ -56,25 +56,30 @@ export default {
 
 Then call `rollup` either via the [CLI](https://www.rollupjs.org/guide/en/#command-line-reference) or the [API](https://www.rollupjs.org/guide/en/#javascript-api).
 
-It's also possible to provide Rollup with a string of code as entry like this:
+## Options
+
+This plugin has no formal options. The lone parameter for this plugin is an `Object` containing properties that correspond to a `String` containing the virtual module's code.
+
+## Using the Plugin for Bundle Input
+
+It's possible to use the plugin to specify an entry point for a bundle. To do so, implement a pattern simple to what is shown below:
 
 ```js
 import virtual from '@rollup/plugin-virtual';
 
 export default {
-  input: 'hello',
+  input: 'entry',
   // ...
   plugins: [
     virtual({
-      hello: `console.log('Hello!')`
+      entry: `
+import batman from 'batcave';
+console.log(batman);
+`
     })
   ]
 };
 ```
-
-## Options
-
-This plugin has no formal options. The lone parameter for this plugin is an `Object` containing properties that correspond to a `String` containing the virtual module's code.
 
 ## License
 

--- a/packages/virtual/README.md
+++ b/packages/virtual/README.md
@@ -56,6 +56,22 @@ export default {
 
 Then call `rollup` either via the [CLI](https://www.rollupjs.org/guide/en/#command-line-reference) or the [API](https://www.rollupjs.org/guide/en/#javascript-api).
 
+It's also possible to provide Rollup with a string of code as entry like this:
+
+```js
+import virtual from '@rollup/plugin-virtual';
+
+export default {
+  input: 'hello',
+  // ...
+  plugins: [
+    virtual({
+      hello: `console.log('Hello!')`
+    })
+  ]
+};
+```
+
 ## Options
 
 This plugin has no formal options. The lone parameter for this plugin is an `Object` containing properties that correspond to a `String` containing the virtual module's code.


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `virtual`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

### Description

While possible, it's not obvious that the `virtual` plugin can pass a string of code to Rollup's input. 

This little example makes this obvious, specially for Rollup beginners.