### PR TITLE
Make wasm plugin work with service workers

### DIFF
--- a/packages/wasm/src/index.js
+++ b/packages/wasm/src/index.js
@@ -30,7 +30,9 @@ export default function wasm(options = {}) {
         if (isNode) {
           buf = Buffer.from(src, 'base64')
         } else {
-          var raw = window.atob(src)
+          var raw;
+          if (typeof window === 'object') raw = window.atob(src)
+          else raw = self.atob(src)
           var rawLength = raw.length
           buf = new Uint8Array(new ArrayBuffer(rawLength))
           for(var i = 0; i < rawLength; i++) {

--- a/packages/wasm/src/index.js
+++ b/packages/wasm/src/index.js
@@ -30,9 +30,7 @@ export default function wasm(options = {}) {
         if (isNode) {
           buf = Buffer.from(src, 'base64')
         } else {
-          var raw;
-          if (typeof window === 'object') raw = window.atob(src)
-          else raw = self.atob(src)
+          var raw = globalThis.atob(src)
           var rawLength = raw.length
           buf = new Uint8Array(new ArrayBuffer(rawLength))
           for(var i = 0; i < rawLength; i++) {

--- a/packages/wasm/test/fixtures/worker.js
+++ b/packages/wasm/test/fixtures/worker.js
@@ -1,0 +1,11 @@
+import sample from './sample.wasm';
+// atob doesn't exist in node, so we fake it
+// in the browser, globalThis.atob will exist
+// eslint-disable-next-line no-undef
+globalThis.atob = (str) => Buffer.from(str, 'base64').toString('binary');
+// trick the wasm loader into thinking we are in the browser
+const realProcess = process;
+// eslint-disable-next-line no-global-assign, no-undefined
+process = undefined;
+sample({});
+realProcess.exit(0);

--- a/packages/wasm/test/test.js
+++ b/packages/wasm/test/test.js
@@ -4,13 +4,19 @@ import test from 'ava';
 // eslint-disable-next-line no-unused-vars, import/no-unresolved, import/extensions
 import wasm from '../dist/index';
 
+const { Worker } = require('worker_threads');
+
 const AsyncFunction = Object.getPrototypeOf(async () => {}).constructor;
 
-const testBundle = async (t, bundle) => {
+const generateCode = async (bundle) => {
   const { output } = await bundle.generate({ format: 'cjs' });
   const [{ code }] = output;
-  const func = new AsyncFunction('t', `let result;\n\n${code}\n\nreturn result;`);
+  return code;
+};
 
+const testBundle = async (t, bundle) => {
+  const code = await generateCode(bundle);
+  const func = new AsyncFunction('t', `let result;\n\n${code}\n\nreturn result;`);
   return func(t);
 };
 
@@ -60,4 +66,25 @@ test('imports', async (t) => {
     ]
   });
   await testBundle(t, bundle);
+});
+
+test('worker', async (t) => {
+  t.plan(2);
+
+  const bundle = await rollup({
+    input: 'test/fixtures/worker.js',
+    plugins: [wasm()]
+  });
+  const code = await generateCode(bundle);
+  const executeWorker = () => {
+    const worker = new Worker(code, { eval: true });
+    return new Promise((resolve, reject) => {
+      worker.on('error', (err) => reject(err));
+      worker.on('exit', (exitCode) => resolve(exitCode));
+    });
+  };
+  await t.notThrowsAsync(async () => {
+    const result = await executeWorker();
+    t.true(result === 0);
+  });
 });


### PR DESCRIPTION
The code generated by @rollup/plugin-wasm breaks when executed in a
service worker because window is undefined.

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `wasm`

This PR contains:

- [X] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [X] yes (_bugfixes and features will not be merged without tests_)
- [] no

~~This is a draft PR because I'm not sure how to write a test that runs code inside a service worker. Once I figure that out, I will add a test and update the above checkbox.~~

Breaking Changes?

- [x] yes (_breaking changes will not be merged unless absolutely necessary_)
- [ ] no

List any relevant issue numbers: #333 

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

~~This PR adds a check for whether `window` is undefined.~~ This PR makes the loader function use `globalThis` instead of `window`. Prior to this, `@rollup/plugin-wasm` would break when the resulting generated code was run in a service worker, because it assumed `window` was defined.