### PR TITLE
feat(virtual): improve virtual entry input option support

### DIFF
--- a/packages/virtual/README.md
+++ b/packages/virtual/README.md
@@ -73,9 +73,9 @@ export default {
   plugins: [
     virtual({
       entry: `
-        import batman from 'batcave';
-        console.log(batman);
-      `
+import batman from 'batcave';
+console.log(batman);
+`
     })
   ]
 };

--- a/packages/virtual/README.md
+++ b/packages/virtual/README.md
@@ -43,12 +43,12 @@ Create a `rollup.config.js` [configuration file](https://www.rollupjs.org/guide/
 import virtual from '@rollup/plugin-virtual';
 
 export default {
-  entry: 'src/entry.js',
+  input: 'src/input.js',
   // ...
   plugins: [
     virtual({
-      batman: `export default 'na na na na na'`,
-      'src/robin.js': `export default 'batmannnnn'`
+      batman: `export default 'na na na na na';`,
+      'src/robin.js': `export default 'batmannnnn';`
     })
   ]
 };
@@ -73,9 +73,9 @@ export default {
   plugins: [
     virtual({
       entry: `
-import batman from 'batcave';
-console.log(batman);
-`
+        import batman from 'batcave';
+        console.log(batman);
+      `
     })
   ]
 };

--- a/packages/virtual/src/index.js
+++ b/packages/virtual/src/index.js
@@ -4,6 +4,7 @@ import path from 'path';
 const PREFIX = `\0virtual:`;
 
 export default function virtual(modules) {
+  const virtualInputIds = [];
   const resolvedIds = new Map();
 
   Object.keys(modules).forEach((id) => {
@@ -13,7 +14,49 @@ export default function virtual(modules) {
   return {
     name: 'virtual',
 
+    options(options) {
+      let updatedInput = options.input;
+
+      if (typeof updatedInput === 'string' && updatedInput in modules) {
+        const virtualId = PREFIX + updatedInput;
+        virtualInputIds.push(virtualId);
+        updatedInput = virtualId;
+      }
+
+      if (typeof updatedInput === 'object') {
+        if (Array.isArray(updatedInput)) {
+          updatedInput = updatedInput.map((id) => {
+            if (id in modules) {
+              const virtualId = PREFIX + id;
+              virtualInputIds.push(virtualId);
+              return virtualId;
+            }
+            return id;
+          });
+        } else {
+          updatedInput = Object.keys(updatedInput).reduce((nextUpdatedInput, key) => {
+            let id = key;
+            if (id in modules) {
+              const virtualId = PREFIX + id;
+              virtualInputIds.push(virtualId);
+              id = virtualId;
+            }
+            // eslint-disable-next-line no-param-reassign
+            nextUpdatedInput[id] = updatedInput[key];
+            return nextUpdatedInput;
+          }, {});
+        }
+      }
+
+      return {
+        ...options,
+        input: updatedInput
+      };
+    },
+
     resolveId(id, importer) {
+      if (virtualInputIds.includes(id)) return id;
+
       if (id in modules) return PREFIX + id;
 
       if (importer) {

--- a/packages/virtual/test/test.js
+++ b/packages/virtual/test/test.js
@@ -25,3 +25,35 @@ test('loads an absolute path from memory', (t) => {
   t.is(resolved, `\0virtual:${path.resolve('src/foo.js')}`);
   t.is(plugin.load(resolved), 'export default 42');
 });
+
+test('from memory input entry options are prefixed immediately', (t) => {
+  const plugin = virtual({
+    'foo.js': 'export default 42',
+    'src/foo.js': 'export default 42'
+  });
+
+  const singleInputOption = {
+    input: 'foo.js'
+  };
+
+  const multipleInputOption = {
+    input: ['foo.js', 'src/foo.js']
+  };
+
+  const mappedInputOption = {
+    input: {
+      'foo.js': 'lib/foo.js',
+      'src/foo.js': 'lib/index.js'
+    }
+  };
+
+  t.is(plugin.options(singleInputOption).input, '\0virtual:foo.js');
+  t.deepEqual(plugin.options(multipleInputOption).input, [
+    '\0virtual:foo.js',
+    '\0virtual:src/foo.js'
+  ]);
+  t.deepEqual(plugin.options(mappedInputOption).input, {
+    '\0virtual:foo.js': 'lib/foo.js',
+    '\0virtual:src/foo.js': 'lib/index.js'
+  });
+});


### PR DESCRIPTION
<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `virtual`

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [x] yes (_breaking changes will not be merged unless absolutely necessary_)
- [ ] no

### Description

The `virtual` plugin allows [to specify an inline script as the `input` entry point of a bundle](https://github.com/rollup/plugins/blob/master/packages/virtual/README.md#using-the-plugin-for-bundle-input). For handling virtual files it keeps a mapping of related module ids. Since [the `options` hook](https://github.com/rollup/rollup/blob/master/docs/05-plugin-development.md#options) is executed initially to handle input option modifications this PR extends the plugin to update the values so they can be further used in the next steps. Furthermore the example in the `README` was updated to avoid confusion by referring the correct `input` field.

While the change alone might not seem very helpful it allows other plugins to better handle the case of a virtual `input` entry point. In another PR the `@rollup/plugin-run` will be updated based on that.
