### PR TITLE
 feat(run): use resolved input if file exists

### DIFF
--- a/packages/run/package.json
+++ b/packages/run/package.json
@@ -50,6 +50,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^3.0.0",
+    "@rollup/plugin-virtual": "^2.0.1",
     "del": "^5.1.0",
     "rollup": "^2.0.0",
     "sinon": "8.0.4"

--- a/packages/run/rollup.config.js
+++ b/packages/run/rollup.config.js
@@ -5,7 +5,7 @@ import pkg from './package.json';
 export default {
   input: 'src/index.ts',
   plugins: [typescript()],
-  external: Object.keys(pkg.dependencies).concat(['path', 'child_process']),
+  external: Object.keys(pkg.dependencies).concat(['path', 'child_process', 'fs']),
   output: [
     { format: 'cjs', file: pkg.main },
     { format: 'esm', file: pkg.module }

--- a/packages/run/src/index.ts
+++ b/packages/run/src/index.ts
@@ -1,5 +1,6 @@
 import { ChildProcess, fork } from 'child_process';
 import * as path from 'path';
+import * as fs from 'fs';
 
 import { Plugin, RenderedChunk } from 'rollup';
 
@@ -31,7 +32,13 @@ export default function run(opts: RollupRunOptions = {}): Plugin {
         throw new Error(`@rollup/plugin-run only works with a single entry point`);
       }
 
-      input = path.resolve(inputs[0]);
+      // eslint-disable-next-line prefer-destructuring
+      input = inputs[0];
+
+      const resolvedInputPath = path.resolve(input);
+      if (fs.existsSync(resolvedInputPath)) {
+        input = resolvedInputPath;
+      }
     },
 
     generateBundle(_outputOptions, _bundle, isWrite) {

--- a/packages/run/test/test.js
+++ b/packages/run/test/test.js
@@ -14,6 +14,8 @@ const sinon = require('sinon');
 
 const run = require('../');
 
+const virtual = require('../../virtual');
+
 const cwd = join(__dirname, 'fixtures/');
 const file = join(cwd, 'output/bundle.js');
 const input = join(cwd, 'input.js');
@@ -49,6 +51,20 @@ test('takes input from the latest options', async (t) => {
           return options;
         }
       }
+    ]
+  });
+  await bundle.write(outputOptions);
+  t.true(mockChildProcess.calledWithExactly(outputOptions.file, [], {}));
+});
+
+test('uses resolved input path if it refers to an existing file', async (t) => {
+  const bundle = await rollup({
+    input: 'entry',
+    plugins: [
+      virtual({
+        entry: 'console.log("No real path example")'
+      }),
+      run()
     ]
   });
   await bundle.write(outputOptions);

--- a/packages/virtual/README.md
+++ b/packages/virtual/README.md
@@ -43,12 +43,12 @@ Create a `rollup.config.js` [configuration file](https://www.rollupjs.org/guide/
 import virtual from '@rollup/plugin-virtual';
 
 export default {
-  entry: 'src/entry.js',
+  input: 'src/input.js',
   // ...
   plugins: [
     virtual({
-      batman: `export default 'na na na na na'`,
-      'src/robin.js': `export default 'batmannnnn'`
+      batman: `export default 'na na na na na';`,
+      'src/robin.js': `export default 'batmannnnn';`
     })
   ]
 };
@@ -73,9 +73,9 @@ export default {
   plugins: [
     virtual({
       entry: `
-import batman from 'batcave';
-console.log(batman);
-`
+        import batman from 'batcave';
+        console.log(batman);
+      `
     })
   ]
 };

--- a/packages/virtual/src/index.js
+++ b/packages/virtual/src/index.js
@@ -4,6 +4,7 @@ import path from 'path';
 const PREFIX = `\0virtual:`;
 
 export default function virtual(modules) {
+  const virtualInputIds = [];
   const resolvedIds = new Map();
 
   Object.keys(modules).forEach((id) => {
@@ -13,7 +14,49 @@ export default function virtual(modules) {
   return {
     name: 'virtual',
 
+    options(options) {
+      let updatedInput = options.input;
+
+      if (typeof updatedInput === 'string' && updatedInput in modules) {
+        const virtualId = PREFIX + updatedInput;
+        virtualInputIds.push(virtualId);
+        updatedInput = virtualId;
+      }
+
+      if (typeof updatedInput === 'object') {
+        if (Array.isArray(updatedInput)) {
+          updatedInput = updatedInput.map((id) => {
+            if (id in modules) {
+              const virtualId = PREFIX + id;
+              virtualInputIds.push(virtualId);
+              return virtualId;
+            }
+            return id;
+          });
+        } else {
+          updatedInput = Object.keys(updatedInput).reduce((nextUpdatedInput, key) => {
+            let id = key;
+            if (id in modules) {
+              const virtualId = PREFIX + id;
+              virtualInputIds.push(virtualId);
+              id = virtualId;
+            }
+            // eslint-disable-next-line no-param-reassign
+            nextUpdatedInput[id] = updatedInput[key];
+            return nextUpdatedInput;
+          }, {});
+        }
+      }
+
+      return {
+        ...options,
+        input: updatedInput
+      };
+    },
+
     resolveId(id, importer) {
+      if (virtualInputIds.includes(id)) return id;
+
       if (id in modules) return PREFIX + id;
 
       if (importer) {

--- a/packages/virtual/test/test.js
+++ b/packages/virtual/test/test.js
@@ -25,3 +25,35 @@ test('loads an absolute path from memory', (t) => {
   t.is(resolved, `\0virtual:${path.resolve('src/foo.js')}`);
   t.is(plugin.load(resolved), 'export default 42');
 });
+
+test('from memory input entry options are prefixed immediately', (t) => {
+  const plugin = virtual({
+    'foo.js': 'export default 42',
+    'src/foo.js': 'export default 42'
+  });
+
+  const singleInputOption = {
+    input: 'foo.js'
+  };
+
+  const multipleInputOption = {
+    input: ['foo.js', 'src/foo.js']
+  };
+
+  const mappedInputOption = {
+    input: {
+      'foo.js': 'lib/foo.js',
+      'src/foo.js': 'lib/index.js'
+    }
+  };
+
+  t.is(plugin.options(singleInputOption).input, '\0virtual:foo.js');
+  t.deepEqual(plugin.options(multipleInputOption).input, [
+    '\0virtual:foo.js',
+    '\0virtual:src/foo.js'
+  ]);
+  t.deepEqual(plugin.options(mappedInputOption).input, {
+    '\0virtual:foo.js': 'lib/foo.js',
+    '\0virtual:src/foo.js': 'lib/index.js'
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -339,11 +339,13 @@ importers:
       '@types/node': 13.1.6
     devDependencies:
       '@rollup/plugin-typescript': 3.0.0_rollup@2.2.0
+      '@rollup/plugin-virtual': 2.0.1_rollup@2.2.0
       del: 5.1.0
       rollup: 2.2.0
       sinon: 8.0.4
     specifiers:
       '@rollup/plugin-typescript': ^3.0.0
+      '@rollup/plugin-virtual': ^2.0.1
       '@types/node': 13.1.6
       del: ^5.1.0
       rollup: ^2.0.0
@@ -1733,6 +1735,14 @@ packages:
       typescript: '>=2.1.0'
     resolution:
       integrity: sha512-O6915Ril3+Q0B4P898PULAcPFZfPuatEB/4nox7bnK48ekGrmamMYhMB5tOqWjihEWrw4oz/NL+c+/kS3Fk95g==
+  /@rollup/plugin-virtual/2.0.1_rollup@2.2.0:
+    dependencies:
+      rollup: 2.2.0
+    dev: true
+    peerDependencies:
+      rollup: ^1.20.0
+    resolution:
+      integrity: sha512-p1OmbadojpfF1olZ0YS0SQE256+0eiTTJYeBURtsWuahTRcNpjLELvI87cwx1gOe4OwVUom+Mvl9tiUy5T2p2Q==
   /@rollup/pluginutils/3.0.8:
     dependencies:
       estree-walker: 1.0.1


### PR DESCRIPTION
## NOTE
This PR is is based on #335 as changes there are connected with this use case. It will be rebased as there are updates and also [refer then in the test to the `@rollup/plugin-virtual` module rather than the relative path.

The modified files are:
- [packages/run/rollup.config.js](https://github.com/Autarc/plugins/blob/7fb9cf1ed96f546beae6caa1613db59c40316b5c/packages/run/rollup.config.js)
- [packages/run/src/index.ts](https://github.com/Autarc/plugins/blob/7fb9cf1ed96f546beae6caa1613db59c40316b5c/packages/run/src/index.ts)
- [packages/run/test/test.js](https://github.com/Autarc/plugins/blob/7fb9cf1ed96f546beae6caa1613db59c40316b5c/packages/run/test/test.js) (will be updated with a new version of `@rollup/plugin-virtual`)
- [packages/run/package.json](https://github.com/Autarc/plugins/blob/7fb9cf1ed96f546beae6caa1613db59c40316b5c/packages/run/package.json) (will be updated with a new version of `@rollup/plugin-virtual`)
- [pnpm-lock.yaml](https://github.com/Autarc/plugins/blob/7fb9cf1ed96f546beae6caa1613db59c40316b5c/pnpm-lock.yaml) (will be updated with a new version of `@rollup/plugin-virtual`)

## Rollup Plugin Name: `run`

This PR contains:

- [x] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

### Description

The `run` plugin allows to run a bundle directly after its output is written to the disk. For figuring out the correct entry filename it uses the `input` entry point. As [the `virtual` plugin allows to specify inline scripts](https://github.com/rollup/plugins/blob/master/packages/virtual/README.md#using-the-plugin-for-bundle-input) instead of real paths [the matching is currently failing](https://github.com/rollup/plugins/blob/master/packages/run/src/index.ts#L47). To solve the issue its initially checked if the `input` entry is pointing to an existing file, otherwise the value is taken as is.

Along with the update of the `virtual` plugin in #335 this allows to successfully run the output of bundles initiated through virtual files.