### PR TITLE
fix(node-resolve): Resolve local files if `resolveOption` is set

### DIFF
--- a/packages/node-resolve/src/index.js
+++ b/packages/node-resolve/src/index.js
@@ -111,6 +111,7 @@ export const nodeResolve = (opts = {}) => {
 
       const parts = importee.split(/[/\\]/);
       let id = parts.shift();
+      let isRelativeImport = false;
 
       if (id[0] === '@' && parts.length > 0) {
         // scoped packages
@@ -118,11 +119,15 @@ export const nodeResolve = (opts = {}) => {
       } else if (id[0] === '.') {
         // an import relative to the parent dir of the importer
         id = resolve(basedir, importee);
+        isRelativeImport = true;
       }
 
       const input = normalizeInput(rollupOptions.input);
-
-      if (resolveOnly.length && !resolveOnly.some((pattern) => pattern.test(id))) {
+      if (
+        !isRelativeImport &&
+        resolveOnly.length &&
+        !resolveOnly.some((pattern) => pattern.test(id))
+      ) {
         if (input.includes(id)) {
           return null;
         }

--- a/packages/node-resolve/test/fixtures/only-local.js
+++ b/packages/node-resolve/test/fixtures/only-local.js
@@ -1,0 +1,1 @@
+export default 'Resolved local var';

--- a/packages/node-resolve/test/fixtures/only.js
+++ b/packages/node-resolve/test/fixtures/only.js
@@ -2,6 +2,9 @@ import foo from '@scoped/foo';
 import bar from '@scoped/bar';
 import test from 'test';
 
+import local from './only-local';
+
 console.log(foo);
 console.log(bar);
 console.log(test);
+console.log(local);

--- a/packages/node-resolve/test/only.js
+++ b/packages/node-resolve/test/only.js
@@ -1,9 +1,9 @@
-const { join } = require('path');
+const { join, resolve } = require('path');
 
 const test = require('ava');
 const { rollup } = require('rollup');
 
-const { getImports } = require('../../../util/test');
+const { getImports, getResolvedModules } = require('../../../util/test');
 
 const { nodeResolve } = require('..');
 
@@ -21,10 +21,12 @@ test('specify the only packages to resolve', async (t) => {
     ]
   });
   const imports = await getImports(bundle);
+  const modules = await getResolvedModules(bundle);
 
   t.is(warnings.length, 0);
   t.snapshot(warnings);
   t.deepEqual(imports, ['@scoped/foo', '@scoped/bar']);
+  t.assert(Object.keys(modules).includes(resolve('only-local.js')));
 });
 
 test('regex', async (t) => {
@@ -39,10 +41,12 @@ test('regex', async (t) => {
     ]
   });
   const imports = await getImports(bundle);
+  const modules = await getResolvedModules(bundle);
 
   t.is(warnings.length, 0);
   t.snapshot(warnings);
   t.deepEqual(imports, ['test']);
+  t.assert(Object.keys(modules).includes(resolve('only-local.js')));
 });
 
 test('deprecated: specify the only packages to resolve', async (t) => {
@@ -57,10 +61,12 @@ test('deprecated: specify the only packages to resolve', async (t) => {
     ]
   });
   const imports = await getImports(bundle);
+  const modules = await getResolvedModules(bundle);
 
   t.is(warnings.length, 1);
   t.snapshot(warnings);
   t.deepEqual(imports, ['@scoped/foo', '@scoped/bar']);
+  t.assert(Object.keys(modules).includes(resolve('only-local.js')));
 });
 
 test('deprecated: regex', async (t) => {
@@ -75,8 +81,10 @@ test('deprecated: regex', async (t) => {
     ]
   });
   const imports = await getImports(bundle);
+  const modules = await getResolvedModules(bundle);
 
   t.is(warnings.length, 1);
   t.snapshot(warnings);
   t.deepEqual(imports, ['test']);
+  t.assert(Object.keys(modules).includes(resolve('only-local.js')));
 });

--- a/util/test.d.ts
+++ b/util/test.d.ts
@@ -17,6 +17,8 @@ export const getCode: GetCode;
 
 export function getImports(bundle: RollupBuild): Promise<string[]>;
 
+export function getResolvedModules(bundle: RollupBuild): Promise<Record<string, string>>;
+
 export function testBundle(
   t: Assertions,
   bundle: RollupBuild,

--- a/util/test.js
+++ b/util/test.js
@@ -23,6 +23,13 @@ const getImports = async (bundle) => {
   return imports;
 };
 
+const getResolvedModules = async (bundle) => {
+  const {
+    output: [{ modules }]
+  } = await bundle.generate({ format: 'esm' });
+  return modules;
+};
+
 /**
  * @param {import('ava').Assertions} t
  * @param {import('rollup').RollupBuild} bundle
@@ -55,5 +62,6 @@ const testBundle = async (t, bundle, args = {}) => {
 module.exports = {
   getCode,
   getImports,
+  getResolvedModules,
   testBundle
 };


### PR DESCRIPTION
## Rollup Plugin Name: `node-resolve`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

This PR fixes the issue #209, where using the `resolveOnly` option at the `node-resolve` plugin prevented the resolution of local modules.
