### PR TITLE
feat(html): Allow adding arbitrary HTML to body and head

### DIFF
--- a/packages/html/README.md
+++ b/packages/html/README.md
@@ -92,7 +92,7 @@ const template = ({ attributes, bundle, files, publicPath, title }) => { ... }
 
 - `attributes`: Corresponds to the `attributes` option passed to the plugin
 - `bundle`: An `Object` containing key-value pairs of [`AssetInfo` or `ChunkInfo`](https://rollupjs.org/guide/en/#generatebundle)
-- `files`: An `Array` of `AssetInfo` or `ChunkInfo` containing any entry (`isEntry: true`) files, and any asset (`isAsset: true`) files in the bundle that will be emitted
+- `files`: An `Object` mapping file types to `Array`s of `AssetInfo` or `ChunkInfo` of entry (`isEntry: true`) files, and asset (`isAsset: true`) files in the bundle that will be emitted
 - `publicPath`: Corresponds to the `publicPath` option passed to the plugin
 - `title`: Corresponds to the `title` option passed to the plugin
 
@@ -134,7 +134,7 @@ Consumes an object with key-value pairs that represent an HTML element attribute
 const { makeHtmlAttributes } = require('@rollup/plugin-html');
 
 makeHtmlAttributes({ lang: 'en', 'data-batcave': 'secret' });
-// -> 'lang="en" data-batcave="secret"'
+// -> ' lang="en" data-batcave="secret"'
 ```
 
 ## Supported Output Formats

--- a/packages/html/README.md
+++ b/packages/html/README.md
@@ -57,12 +57,26 @@ Specifies additional attributes for `html`, `link`, and `script` elements. For e
 
 _Note: If using the `es` / `esm` output format, `{ type: 'module'}` is automatically added to `attributes.script`._
 
+### `body`
+
+Type: `String`<br>
+Default: `''`
+
+Specifies any extra HTML to insert into the `<body>` tag.
+
 ### `fileName`
 
 Type: `String`<br>
 Default: `'index.html'`
 
 Specifies the name of the HTML to emit.
+
+### `head`
+
+Type: `String`<br>
+Default: `''`
+
+Specifies any extra HTML to insert into the `<head>` tag.
 
 ### `meta`
 
@@ -91,7 +105,9 @@ const template = ({ attributes, bundle, files, publicPath, title }) => { ... }
 ```
 
 - `attributes`: Corresponds to the `attributes` option passed to the plugin
+- `body`: Corresponds to the `body` option passed to the plugin
 - `bundle`: An `Object` containing key-value pairs of [`AssetInfo` or `ChunkInfo`](https://rollupjs.org/guide/en/#generatebundle)
+- `head`: Corresponds to the `head` option passed to the plugin
 - `files`: An `Object` mapping file types to `Array`s of `AssetInfo` or `ChunkInfo` of entry (`isEntry: true`) files, and asset (`isAsset: true`) files in the bundle that will be emitted
 - `publicPath`: Corresponds to the `publicPath` option passed to the plugin
 - `title`: Corresponds to the `title` option passed to the plugin
@@ -104,10 +120,10 @@ By default this is handled internally and produces HTML in the following format:
   <head>
     ${metas}
     <title>${title}</title>
-    ${links}
+    ${links}${head}
   </head>
   <body>
-    ${scripts}
+    ${scripts}${body}
   </body>
 </html>
 ```

--- a/packages/html/README.md
+++ b/packages/html/README.md
@@ -62,14 +62,14 @@ _Note: If using the `es` / `esm` output format, `{ type: 'module'}` is automatic
 Type: `String`<br>
 Default: `'index.html'`
 
+Specifies the name of the HTML to emit.
+
 ### `meta`
 
 Type: `Array[...object]`<br>
 Default: `[{ charset: 'utf-8' }]`
 
 Specifies attributes used to create `<meta>` elements. For each array item, provide an object with key-value pairs that represent `<meta>` element attribute names and values.
-
-Specifies the name of the HTML to emit.
 
 ### `publicPath`
 

--- a/packages/html/lib/index.js
+++ b/packages/html/lib/index.js
@@ -19,9 +19,9 @@ const makeHtmlAttributes = (attributes) => {
     return '';
   }
 
-  const keys = Object.keys(attributes);
-  // eslint-disable-next-line no-param-reassign
-  return keys.reduce((result, key) => (result += ` ${key}="${attributes[key]}"`), '');
+  return Object.entries(attributes)
+    .map(([key, value]) => ` ${key}="${value}"`)
+    .join('');
 };
 
 const defaultTemplate = async ({ attributes, files, meta, publicPath, title }) => {

--- a/packages/html/lib/index.js
+++ b/packages/html/lib/index.js
@@ -24,7 +24,7 @@ const makeHtmlAttributes = (attributes) => {
     .join('');
 };
 
-const defaultTemplate = async ({ attributes, files, meta, publicPath, title }) => {
+const defaultTemplate = async ({ attributes, body, files, head, meta, publicPath, title }) => {
   const scripts = (files.js || [])
     .map(({ fileName }) => {
       const attrs = makeHtmlAttributes(attributes.script);
@@ -52,10 +52,10 @@ const defaultTemplate = async ({ attributes, files, meta, publicPath, title }) =
   <head>
     ${metas}
     <title>${title}</title>
-    ${links}
+    ${links}${head}
   </head>
   <body>
-    ${scripts}
+    ${scripts}${body}
   </body>
 </html>`;
 };
@@ -68,7 +68,9 @@ const defaults = {
     html: { lang: 'en' },
     script: null
   },
+  body: '',
   fileName: 'index.html',
+  head: '',
   meta: [{ charset: 'utf-8' }],
   publicPath: '',
   template: defaultTemplate,
@@ -76,7 +78,7 @@ const defaults = {
 };
 
 const html = (opts = {}) => {
-  const { attributes, fileName, meta, publicPath, template, title } = Object.assign(
+  const { attributes, body, fileName, head, meta, publicPath, template, title } = Object.assign(
     {},
     defaults,
     opts
@@ -101,7 +103,16 @@ const html = (opts = {}) => {
       }
 
       const files = getFiles(bundle);
-      const source = await template({ attributes, bundle, files, meta, publicPath, title });
+      const source = await template({
+        attributes,
+        body,
+        bundle,
+        files,
+        head,
+        meta,
+        publicPath,
+        title
+      });
 
       const htmlFile = {
         type: 'asset',

--- a/packages/html/test/test.js
+++ b/packages/html/test/test.js
@@ -34,7 +34,9 @@ test.serial('options', async (t) => {
         meta: [
           { charset: 'utf-8' },
           { name: 'viewport', content: 'minimum-scale=1, initial-scale=1, width=device-width' }
-        ]
+        ],
+        head: '<link rel="icon" href="favicon.ico" type="image/x-icon">',
+        body: '<script type="application/json">{}</script>'
       })
     ]
   });


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `{html}`

This PR contains:

- [ ] bugfix
- [x] feature
- [x] refactor
- [x] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers: n/a

### Description

I recently started using this plugin and discovered the just merged #308, which allows adding additional `<meta>` tags to the HTML `<head>`. This will nearly allow me to get rid of a custom template function for adding a `viewport` meta tag. However, I'd still need a custom template function to add a `<link>` for a favicon or a link to a webmanifest.

This PR adds two more options to add arbitrary strings at the end of the head and body tag respectively in the template function. This might be considered bloat of the options of this plugin, but I'd consider them generic and useful enough to be worth the addition.

Also, the first three commits contain a minor refactor to get rid of an eslint-disable and fix up some minor mistakes in the README.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
