### PR TITLE
feat(commonjs): add kill-switch for mixed es-cjs modules

### DIFF
--- a/packages/commonjs/README.md
+++ b/packages/commonjs/README.md
@@ -111,7 +111,7 @@ If false, skips source map generation for CommonJS modules.
 Type: `Boolean`<br>
 Default: `false`
 
-In case of modules that contain commonjs code you can enable/disable the transformer. Set it to `true` if you know that `require` calls should be transformed, or `false` if you know that the code contains env detection and the `require` should survive the transform.
+Instructs the plugin whether or not to enable mixed module transformations. This is useful in scenarios with mixed ES and CommonJS modules. Set to `true` if it's known that `require` calls should be transformed, or `false` if the code contains env detection and the `require` should survive a transformation.
 
 ### `ignore`
 

--- a/packages/commonjs/README.md
+++ b/packages/commonjs/README.md
@@ -106,6 +106,13 @@ Default: `true`
 
 If false, skips source map generation for CommonJS modules.
 
+### `transformMixedEsModules`
+
+Type: `Boolean`<br>
+Default: `false`
+
+In case of modules that contain commonjs code you can enable/disable the transformer. Set it to `true` if you know that `require` calls should be transformed, or `false` if you know that the code contains env detection and the `require` should survive the transform.
+
 ### `ignore`
 
 Type: `Array[...String | (String) => Boolean]`<br>

--- a/packages/commonjs/src/index.js
+++ b/packages/commonjs/src/index.js
@@ -66,10 +66,14 @@ export default function commonjs(options = {}) {
 
     const isDynamicRequireModule = dynamicRequireModuleSet.has(normalizePathSlashes(id));
 
-    if (isEsModule && !isDynamicRequireModule) {
+    if (isEsModule && (!isDynamicRequireModule || !options.transformMixedEsModules)) {
       (hasDefaultExport ? esModulesWithDefaultExport : esModulesWithoutDefaultExport).add(id);
+      if (!options.transformMixedEsModules) {
+        setIsCjsPromise(id, false);
+        return null;
+      }
     }
-    // it is not an ES module but it does not have CJS-specific elements.
+    // it is not an ES module AND it does not have CJS-specific elements.
     else if (!hasCjsKeywords(code, ignoreGlobal)) {
       esModulesWithoutDefaultExport.add(id);
       setIsCjsPromise(id, false);

--- a/packages/commonjs/test/fixtures/form/unambiguous-with-default-export/_config.js
+++ b/packages/commonjs/test/fixtures/form/unambiguous-with-default-export/_config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  options: {
+    transformMixedEsModules: true
+  }
+};

--- a/packages/commonjs/test/fixtures/form/unambiguous-with-import/_config.js
+++ b/packages/commonjs/test/fixtures/form/unambiguous-with-import/_config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  options: {
+    transformMixedEsModules: true
+  }
+};

--- a/packages/commonjs/test/fixtures/form/unambiguous-with-named-export/_config.js
+++ b/packages/commonjs/test/fixtures/form/unambiguous-with-named-export/_config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  options: {
+    transformMixedEsModules: true
+  }
+};

--- a/packages/commonjs/test/fixtures/function/dynamic-require-code-splitting/_config.js
+++ b/packages/commonjs/test/fixtures/function/dynamic-require-code-splitting/_config.js
@@ -7,6 +7,7 @@ module.exports = {
     ]
   },
   pluginOptions: {
-    dynamicRequireTargets: ['fixtures/function/dynamic-require-code-splitting/target?.js']
+    dynamicRequireTargets: ['fixtures/function/dynamic-require-code-splitting/target?.js'],
+    transformMixedEsModules: true
   }
 };

--- a/packages/commonjs/test/fixtures/function/dynamic-require-es-entry/_config.js
+++ b/packages/commonjs/test/fixtures/function/dynamic-require-es-entry/_config.js
@@ -1,6 +1,7 @@
 module.exports = {
   description: 'works when the entry point is an es module',
   pluginOptions: {
-    dynamicRequireTargets: ['fixtures/function/dynamic-require-es-entry/submodule.js']
+    dynamicRequireTargets: ['fixtures/function/dynamic-require-es-entry/submodule.js'],
+    transformMixedEsModules: true
   }
 };

--- a/packages/commonjs/test/fixtures/function/es6-export-with-global-sniffing/_config.js
+++ b/packages/commonjs/test/fixtures/function/es6-export-with-global-sniffing/_config.js
@@ -4,5 +4,7 @@ module.exports = {
   options: {
     plugins: [nodeResolve()]
   },
-  pluginOptions: {}
+  pluginOptions: {
+    transformMixedEsModules: true
+  }
 };

--- a/packages/commonjs/test/types.ts
+++ b/packages/commonjs/test/types.ts
@@ -13,6 +13,7 @@ const config: import('rollup').RollupOptions = {
       extensions: ['.js', '.coffee'],
       ignoreGlobal: false,
       sourceMap: false,
+      transformMixedEsModules: false,
       ignore: ['conditional-runtime-dependency'],
       dynamicRequireTargets: ['node_modules/logform/*.js']
     })

--- a/packages/commonjs/types/index.d.ts
+++ b/packages/commonjs/types/index.d.ts
@@ -31,6 +31,11 @@ interface RollupCommonJSOptions {
    */
   sourceMap?: boolean;
   /**
+   * In case of modules that contain commonjs code you can enable/disable the transformer. Set it to `true` if you know that `require` calls should be transformed, or `false` if you know that the code contains env detection and the `require` should survive the transform.
+   * @default false
+   */
+  transformMixedEsModules?: boolean;
+  /**
    * explicitly specify unresolvable named exports
    * ([see below for more details](https://github.com/rollup/plugins/tree/master/packages/commonjs#named-exports))
    * @default undefined

--- a/packages/commonjs/types/index.d.ts
+++ b/packages/commonjs/types/index.d.ts
@@ -31,7 +31,7 @@ interface RollupCommonJSOptions {
    */
   sourceMap?: boolean;
   /**
-   * In case of modules that contain commonjs code you can enable/disable the transformer. Set it to `true` if you know that `require` calls should be transformed, or `false` if you know that the code contains env detection and the `require` should survive the transform.
+   * Instructs the plugin whether or not to enable mixed module transformations. This is useful in scenarios with mixed ES and CommonJS modules. Set to `true` if it's known that `require` calls should be transformed, or `false` if the code contains env detection and the `require` should survive a transformation.
    * @default false
    */
   transformMixedEsModules?: boolean;


### PR DESCRIPTION
## Rollup Plugin Name: `commonjs`

This PR contains:

- [x] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [x] yes (_breaking changes will not be merged unless absolutely necessary_)
- [ ] no

List any relevant issue numbers: #348, #342

### Description

Reverts default behavior of mixed es and cjs modules.  
I have marked this as a  "breaking change", but the PR that raised this need was a actually a breaking change for people who did not utilize `include`/`exclude` correctly and have garbage of mixed UMD mechanisms.


