### PR TITLE
fix(babel): use loadPartialConfigAsync when it is available

### DIFF
--- a/packages/babel/src/transformCode.js
+++ b/packages/babel/src/transformCode.js
@@ -8,7 +8,8 @@ export default async function transformCode(
   ctx,
   finalizeOptions
 ) {
-  const config = babel.loadPartialConfig(babelOptions);
+  // loadPartialConfigAsync has become available in @babel/core@7.8.0
+  const config = await (babel.loadPartialConfigAsync || babel.loadPartialConfig)(babelOptions);
 
   // file is ignored by babel
   if (!config) {


### PR DESCRIPTION
## Rollup Plugin Name: `babel`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

fixes #345

### Description

It got missed when `transform` has been migrated to `transformAsync`.

I don't think this change is worth testing now because it can only be tested on node@13+.