### PR TITLE
feat(node-resolve): Add default export

### DIFF
--- a/packages/node-resolve/src/index.js
+++ b/packages/node-resolve/src/index.js
@@ -29,7 +29,7 @@ const defaults = {
 };
 export const DEFAULTS = deepFreeze(deepMerge({}, defaults));
 
-export const nodeResolve = (opts = {}) => {
+export function nodeResolve(opts = {}) {
   const options = Object.assign({}, defaults, opts);
   const { customResolveOptions, extensions, jail } = options;
   const warnings = [];
@@ -258,4 +258,6 @@ export const nodeResolve = (opts = {}) => {
       return idToPackageInfo.get(id);
     }
   };
-};
+}
+
+export default nodeResolve;

--- a/packages/node-resolve/types/index.d.ts
+++ b/packages/node-resolve/types/index.d.ts
@@ -8,7 +8,7 @@ export const DEFAULTS: {
   resolveOnly: [];
 };
 
-export interface Options {
+export interface RollupNodeResolveOptions {
   /**
    * If `true`, instructs the plugin to use the `"browser"` property in `package.json`
    * files to specify alternative files to load for bundling. This is useful when
@@ -88,4 +88,5 @@ export interface Options {
 /**
  * Locate modules using the Node resolution algorithm, for using third party modules in node_modules
  */
-export const nodeResolve: (options?: Options) => Plugin;
+export function nodeResolve(options?: RollupNodeResolveOptions): Plugin;
+export default nodeResolve;


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `node-resolve`

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no *(this is a pretty straightforward change)*

Breaking Changes?

- [x] yes (_breaking changes will not be merged unless absolutely necessary_) Since we're including breaking changes anyways, I'm going to fix the Typescript interface name so it matches other plugins.
- [ ] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
Building on #301, this updates the documentation but also re-adds a default export. When the plugin is used with ES modules, the previous change is no longer a breaking change. However, CommonJS modules still must switch to named exports.

For consistency we should always used named exports in the documentation, but this helps users migrate to the new format.