### PR TITLE
feat(wasm): Switch to TypeScript & named exports

### DIFF
--- a/packages/wasm/README.md
+++ b/packages/wasm/README.md
@@ -30,7 +30,7 @@ npm install @rollup/plugin-wasm --save-dev
 Create a `rollup.config.js` [configuration file](https://www.rollupjs.org/guide/en/#configuration-files) and import the plugin:
 
 ```js
-import wasm from '@rollup/plugin-wasm';
+import { wasm } from '@rollup/plugin-wasm';
 
 export default {
   input: 'src/index.js',
@@ -66,9 +66,9 @@ int main() {
 Compile the file using `emscripten`, or the online [WasmFiddle](https://wasdk.github.io/WasmFiddle//) tool. Then import and instantiate the resulting file:
 
 ```js
-import wasm from './sample.wasm';
+import sample from './sample.wasm';
 
-wasm({ ...imports }).then(({ instance }) => {
+sample({ ...imports }).then(({ instance }) => {
   console.log(instance.exports.main());
 });
 ```
@@ -90,7 +90,7 @@ wasm({
 This means that the exports can be accessed immediately.
 
 ```js
-import module from './sample.wasm';
+import sample from './sample.wasm';
 
 const instance = sample({ ...imports });
 

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -10,7 +10,7 @@
   "author": "Jamen Marz <jamenmarz+gh@gmail.com>",
   "homepage": "https://github.com/rollup/plugins/tree/master/packages/wasm/#readme",
   "bugs": "https://github.com/rollup/plugins/issues",
-  "main": "dist/index",
+  "main": "dist/index.js",
   "scripts": {
     "build": "rollup -c",
     "ci:coverage": "nyc pnpm run test && nyc report --reporter=text-lcov > coverage.lcov",
@@ -29,6 +29,7 @@
   },
   "files": [
     "dist",
+    "types",
     "README.md",
     "LICENSE"
   ],
@@ -46,6 +47,7 @@
     "rollup": "^1.20.0||^2.0.0"
   },
   "devDependencies": {
+    "@rollup/plugin-typescript": "^4.1.1",
     "del-cli": "^3.0.0",
     "rollup": "^2.0.0",
     "source-map": "^0.7.3"
@@ -61,5 +63,7 @@
   "contributors": [
     "Jamen Marz <jamenmarz+gh@gmail.com>",
     "Colin Eberhardt <colin.eberhardt@gmail.com>"
-  ]
+  ],
+  "module": "dist/index.es.js",
+  "types": "types/index.d.ts"
 }

--- a/packages/wasm/rollup.config.js
+++ b/packages/wasm/rollup.config.js
@@ -1,13 +1,9 @@
-const { builtinModules } = require('module');
+import typescript from '@rollup/plugin-typescript';
+import { createConfig } from '../../shared/rollup.config';
 
-const pkg = require('./package.json');
+import pkg from './package.json';
 
-const dependencies = Object.keys(pkg.dependencies || {});
-
-export default [
-  {
-    input: 'src/index.js',
-    output: { exports: 'named', file: 'dist/index.js', format: 'cjs' },
-    external: [...builtinModules, ...dependencies]
-  }
-];
+export default {
+  ...createConfig(pkg),
+  plugins: [typescript()],
+}

--- a/packages/wasm/src/index.ts
+++ b/packages/wasm/src/index.ts
@@ -1,9 +1,11 @@
 import { readFile } from 'fs';
 import { resolve } from 'path';
 
-export default function wasm(options = {}) {
-  options = Object.assign({}, options); // eslint-disable-line no-param-reassign
+import { Plugin } from 'rollup';
 
+import { RollupWasmOptions } from '../types';
+
+export function wasm(options: RollupWasmOptions = {}): Plugin {
   const syncFiles = (options.sync || []).map((x) => resolve(x));
 
   return {
@@ -49,13 +51,15 @@ export default function wasm(options = {}) {
       }
     `.trim(),
 
-    // eslint-disable-next-line consistent-return
     transform(code, id) {
       if (code && /\.wasm$/.test(id)) {
         const src = Buffer.from(code, 'binary').toString('base64');
         const sync = syncFiles.indexOf(id) !== -1;
         return `export default function(imports){return _loadWasmModule(${+sync}, '${src}', imports)}`;
       }
+      return null;
     }
   };
 }
+
+export default wasm;

--- a/packages/wasm/test/test.js
+++ b/packages/wasm/test/test.js
@@ -1,19 +1,14 @@
 import { rollup } from 'rollup';
 import test from 'ava';
 
-// eslint-disable-next-line no-unused-vars, import/no-unresolved, import/extensions
-import wasm from '../dist/index';
+import { getCode } from '../../../util/test';
+
+import wasm from '../';
 
 const AsyncFunction = Object.getPrototypeOf(async () => {}).constructor;
 
-const generateCode = async (bundle) => {
-  const { output } = await bundle.generate({ format: 'cjs' });
-  const [{ code }] = output;
-  return code;
-};
-
 const testBundle = async (t, bundle) => {
-  const code = await generateCode(bundle);
+  const code = await getCode(bundle);
   const func = new AsyncFunction('t', `let result;\n\n${code}\n\nreturn result;`);
   return func(t);
 };
@@ -75,7 +70,7 @@ try {
       input: 'test/fixtures/worker.js',
       plugins: [wasm()]
     });
-    const code = await generateCode(bundle);
+    const code = await getCode(bundle);
     const executeWorker = () => {
       const worker = new Worker(code, { eval: true });
       return new Promise((resolve, reject) => {

--- a/packages/wasm/types/index.d.ts
+++ b/packages/wasm/types/index.d.ts
@@ -1,0 +1,14 @@
+import { Plugin } from 'rollup';
+
+export interface RollupWasmOptions {
+  /**
+   * Specifies an array of strings that each represent a WebAssembly file to load synchronously.
+   */
+  sync?: readonly string[];
+}
+
+/**
+ * 🍣 A Rollup which allows importing and bundling [WebAssembly modules](http://webassembly.org).
+ */
+export function wasm(options?: RollupWasmOptions): Plugin;
+export default wasm;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -453,10 +453,12 @@ importers:
       rollup: ^2.0.0
   packages/wasm:
     devDependencies:
+      '@rollup/plugin-typescript': 4.1.1_rollup@2.2.0
       del-cli: 3.0.0
       rollup: 2.2.0
       source-map: 0.7.3
     specifiers:
+      '@rollup/plugin-typescript': ^4.1.1
       del-cli: ^3.0.0
       rollup: ^2.0.0
       source-map: ^0.7.3
@@ -2236,6 +2238,20 @@ packages:
       typescript: '>=2.1.0'
     resolution:
       integrity: sha512-O6915Ril3+Q0B4P898PULAcPFZfPuatEB/4nox7bnK48ekGrmamMYhMB5tOqWjihEWrw4oz/NL+c+/kS3Fk95g==
+  /@rollup/plugin-typescript/4.1.1_rollup@2.2.0:
+    dependencies:
+      '@rollup/pluginutils': 3.0.9_rollup@2.2.0
+      resolve: 1.17.0
+      rollup: 2.2.0
+    dev: true
+    engines:
+      node: '>=8.0.0'
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0
+      tslib: '*'
+      typescript: '>=2.1.0'
+    resolution:
+      integrity: sha512-KYZCn1Iw9hZWkeEPqPs5YjlmvSjR7UdezVca8z0e8rm/29wU24UD9Y4IZHhnc9tm749hzsgBTiOUxA85gfShEQ==
   /@rollup/pluginutils/3.0.8:
     dependencies:
       estree-walker: 1.0.1
@@ -2265,6 +2281,19 @@ packages:
       rollup: ^1.20.0
     resolution:
       integrity: sha512-rYGeAc4sxcZ+kPG/Tw4/fwJODC3IXHYDH4qusdN/b6aLw5LPUbzpecYbEJh4sVQGPFJxd2dBU4kc1H3oy9/bnw==
+  /@rollup/pluginutils/3.0.9_rollup@2.2.0:
+    dependencies:
+      '@types/estree': 0.0.39
+      estree-walker: 1.0.1
+      micromatch: 4.0.2
+      rollup: 2.2.0
+    dev: true
+    engines:
+      node: '>= 8.0.0'
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0
+    resolution:
+      integrity: sha512-TLZavlfPAZYI7v33wQh4mTP6zojne14yok3DNSLcjoG/Hirxfkonn6icP5rrNWRn8nZsirJBFFpijVOJzkUHDg==
   /@samverschueren/stream-to-observable/0.3.0:
     dependencies:
       any-observable: 0.3.0

--- a/shared/rollup.config.js
+++ b/shared/rollup.config.js
@@ -1,0 +1,25 @@
+import { builtinModules } from 'module';
+
+/**
+ * Create a base rollup config
+ * @param {*} pkg Imported package.json
+ * @returns {import('rollup').RollupOptions}
+ */
+export function createConfig(pkg) {
+  return {
+    input: 'src/index.ts',
+    external: Object.keys(pkg.dependencies || {}).concat(builtinModules),
+    output: [
+      {
+        format: 'cjs',
+        file: pkg.main,
+        exports: 'named',
+        footer: 'module.exports = Object.assign(exports.default, exports);'
+      },
+      {
+        format: 'esm',
+        file: pkg.module
+      }
+    ]
+  };
+}

--- a/util/test.d.ts
+++ b/util/test.d.ts
@@ -3,8 +3,8 @@ import { RollupBuild, OutputOptions, OutputChunk, OutputAsset } from 'rollup';
 import { Assertions } from 'ava';
 
 interface GetCode {
-  (bundle: RollupBuild, outputOptions: OutputOptions, allFiles?: false): Promise<string>;
-  (bundle: RollupBuild, outputOptions: OutputOptions, allFiles: true): Promise<
+  (bundle: RollupBuild, outputOptions?: OutputOptions | null, allFiles?: false): Promise<string>;
+  (bundle: RollupBuild, outputOptions: OutputOptions | null | undefined, allFiles: true): Promise<
     Array<{
       code: OutputChunk['code'] | undefined;
       fileName: OutputChunk['fileName'] | OutputAsset['fileName'];

--- a/util/test.js
+++ b/util/test.js
@@ -1,6 +1,6 @@
 /**
  * @param {import('rollup').RollupBuild} bundle
- * @param {import('rollup').OutputOptions} outputOptions
+ * @param {import('rollup').OutputOptions} [outputOptions]
  */
 const getCode = async (bundle, outputOptions, allFiles = false) => {
   const { output } = await bundle.generate(outputOptions || { format: 'cjs' });


### PR DESCRIPTION
BREAKING CHANGES: Named exports are used for CJS

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `wasm`

This PR contains:

- [ ] bugfix
- [x] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [x] yes (_breaking changes will not be merged unless absolutely necessary_)
- [ ] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers: #360

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
Switch to Typescript for the wasm plugin. I chose to also switch to named exports here, but that could be pulled out to a separate PR.