### PR TITLE
docs(babel): update babelHelpers default description

### DIFF
--- a/packages/babel/README.md
+++ b/packages/babel/README.md
@@ -93,9 +93,9 @@ It is recommended to configure this option explicitly (even if with its default 
 We recommend to follow those guidelines for each possible value:
 
 - `'runtime'` - you should use it especially when building libraries with rollup. It has to be used in combination with `@babel/plugin-transform-runtime` and you should also specify `@babel/runtime` as dependency of your package (don't forget to tell rollup to treat it as your external dependency when bundling for `cjs` & `es` formats).
-- `'bundled'` - you should use it if you want your resulting bundle to contain those helpers (at most one copy of each). Useful especially if you bundle an application code **(this is the default Babel behaviour)**.
+- `'bundled'` - you should use it if you want your resulting bundle to contain those helpers (at most one copy of each). Useful especially if you bundle an application code.
 - `'external'` - use it only if you know what you are doing. It will reference helpers on **global** `babelHelpers` object. Used in combination with `@babel/plugin-external-helpers`.
-- `'inline'` - this is not recommended. Helpers will be inserted in each file using them. This can cause serious code duplication.
+- `'inline'` - this is not recommended. Helpers will be inserted in each file using them. This can cause serious code duplication. **(for reference, this is the default behaviour of Babel, but it is overridden by the `babelHelpers` value of this plugin: to either your own explicit selection, otherwise the default value of `'bundled'` will be used)**
 
 ### `skipPreflightCheck`
 

--- a/packages/babel/README.md
+++ b/packages/babel/README.md
@@ -93,9 +93,9 @@ It is recommended to configure this option explicitly (even if with its default 
 We recommend to follow those guidelines for each possible value:
 
 - `'runtime'` - you should use it especially when building libraries with rollup. It has to be used in combination with `@babel/plugin-transform-runtime` and you should also specify `@babel/runtime` as dependency of your package (don't forget to tell rollup to treat it as your external dependency when bundling for `cjs` & `es` formats).
-- `'bundled'` - you should use it if you want your resulting bundle to contain those helpers (at most one copy of each). Useful especially if you bundle an application code.
+- `'bundled'` - you should use it if you want your resulting bundle to contain those helpers (at most one copy of each). Useful especially if you bundle an application code **(this is the default Babel behaviour)**.
 - `'external'` - use it only if you know what you are doing. It will reference helpers on **global** `babelHelpers` object. Used in combination with `@babel/plugin-external-helpers`.
-- `'inline'` - this is not recommended. Helpers will be inserted in each file using them. This can cause serious code duplication (this is the default Babel behaviour).
+- `'inline'` - this is not recommended. Helpers will be inserted in each file using them. This can cause serious code duplication.
 
 ### `skipPreflightCheck`
 

--- a/packages/babel/README.md
+++ b/packages/babel/README.md
@@ -90,12 +90,12 @@ Default: `'bundled'`
 
 It is recommended to configure this option explicitly (even if with its default value) so an informed decision is taken on how those babel helpers are inserted into the code.
 
-We recommend to follow those guidelines for each possible value:
+We recommend to follow these guidelines to determine the most appropriate value for your project:
 
-- `'runtime'` - you should use it especially when building libraries with rollup. It has to be used in combination with `@babel/plugin-transform-runtime` and you should also specify `@babel/runtime` as dependency of your package (don't forget to tell rollup to treat it as your external dependency when bundling for `cjs` & `es` formats).
-- `'bundled'` - you should use it if you want your resulting bundle to contain those helpers (at most one copy of each). Useful especially if you bundle an application code.
-- `'external'` - use it only if you know what you are doing. It will reference helpers on **global** `babelHelpers` object. Used in combination with `@babel/plugin-external-helpers`.
-- `'inline'` - this is not recommended. Helpers will be inserted in each file using them. This can cause serious code duplication. **(for reference, this is the default behaviour of Babel, but it is overridden by the `babelHelpers` value of this plugin: to either your own explicit selection, otherwise the default value of `'bundled'` will be used)**
+- `'runtime'` - you should use this especially when building libraries with Rollup. It has to be used in combination with `@babel/plugin-transform-runtime` and you should also specify `@babel/runtime` as dependency of your package (don't forget to tell Rollup to treat it as your external dependency when bundling for `cjs` & `es` formats).
+- `'bundled'` - you should use this if you want your resulting bundle to contain those helpers (at most one copy of each). Useful especially if you bundle an application code.
+- `'external'` - use this only if you know what you are doing. It will reference helpers on **global** `babelHelpers` object. Used in combination with `@babel/plugin-external-helpers`.
+- `'inline'` - this is not recommended. Helpers will be inserted in each file using this option. This can cause serious code duplication. This is the default Babel behavior as Babel operates on isolated files - however, as Rollup is a bundler and is project-aware (and therefore likely operating across multiple input files), the default of this plugin is `"bundled"`.
 
 ### `skipPreflightCheck`
 


### PR DESCRIPTION
Update `babelHelpers` options documentation, which was confusing (and likely incorrect): it reported that `babelHelpers: 'inline'` is the default, when the header of the section says that the default is `'bundled'`.

Please verify that this documentation change reflects the actual behavior.

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `{name}`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
