### PR TITLE
`namedExports` is now deprecated

### DIFF
--- a/packages/commonjs/types/index.d.ts
+++ b/packages/commonjs/types/index.d.ts
@@ -36,12 +36,6 @@ interface RollupCommonJSOptions {
    */
   transformMixedEsModules?: boolean;
   /**
-   * explicitly specify unresolvable named exports
-   * ([see below for more details](https://github.com/rollup/plugins/tree/master/packages/commonjs#named-exports))
-   * @default undefined
-   */
-  namedExports?: { [package: string]: ReadonlyArray<string> };
-  /**
    * sometimes you have to leave require statements
    * unconverted. Pass an array containing the IDs
    * or a `id => boolean` function. Only use this


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `commonjs`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
As the commit message, `namedExports` option of `@rollup/plugin-commonjs` is deprecated, so remove it from related types.