### PR TITLE
feat(node-resolve): add native node es modules support

### DIFF
--- a/packages/node-resolve/package.json
+++ b/packages/node-resolve/package.json
@@ -10,7 +10,7 @@
   "author": "Rich Harris <richard.a.harris@gmail.com>",
   "homepage": "https://github.com/rollup/plugins/tree/master/packages/node-resolve/#readme",
   "bugs": "https://github.com/rollup/plugins/issues",
-  "main": "dist/index.js",
+  "main": "./dist/cjs/index.js",
   "engines": {
     "node": ">= 8.0.0"
   },
@@ -75,6 +75,11 @@
       "!**/types.ts"
     ]
   },
-  "module": "dist/index.es.js",
+  "exports": {
+    "require": "./dist/cjs/index.js",
+    "import": "./dist/es/index.js"
+  },
+  "module": "./dist/es/index.js",
+  "type": "commonjs",
   "types": "types/index.d.ts"
 }

--- a/packages/node-resolve/rollup.config.js
+++ b/packages/node-resolve/rollup.config.js
@@ -1,6 +1,8 @@
 import babel from 'rollup-plugin-babel';
 import json from '@rollup/plugin-json';
 
+import { emitModulePackageFile } from '../../shared/rollup.config';
+
 import pkg from './package.json';
 
 export default {
@@ -22,7 +24,7 @@ export default {
   ],
   external: Object.keys(pkg.dependencies).concat(['fs', 'path', 'os', 'util']),
   output: [
-    { file: pkg.main, format: 'cjs' },
-    { file: pkg.module, format: 'es' }
+    { file: pkg.main, format: 'cjs', exports: 'named' },
+    { file: pkg.module, format: 'es', plugins: [emitModulePackageFile()] }
   ]
 };


### PR DESCRIPTION

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `node-resolve`

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

- https://github.com/rollup/plugins/issues/412

### Description

Wrapper module is the simplest solution. I used it in terser plugin
which cannot resolve worker without commonjs for now.
