### PR TITLE
feat(json): log the filename when JSON.parse fails

### DIFF
--- a/packages/json/src/index.js
+++ b/packages/json/src/index.js
@@ -11,15 +11,23 @@ export default function json(options = {}) {
     transform(json, id) {
       if (id.slice(-5) !== '.json' || !filter(id)) return null;
 
-      return {
-        code: dataToEsm(JSON.parse(json), {
-          preferConst: options.preferConst,
-          compact: options.compact,
-          namedExports: options.namedExports,
-          indent
-        }),
-        map: { mappings: '' }
-      };
+      try {
+        const parsed = JSON.parse(json);
+        return {
+          code: dataToEsm(parsed, {
+            preferConst: options.preferConst,
+            compact: options.compact,
+            namedExports: options.namedExports,
+            indent
+          }),
+          map: { mappings: '' }
+        };
+      } catch (err) {
+        const message = 'Could not parse JSON file';
+        const position = parseInt(/[\d]/.exec(err.message)[0], 10);
+        this.warn({ message, id, position });
+        return null;
+      }
     }
   };
 }

--- a/packages/json/test/test.js
+++ b/packages/json/test/test.js
@@ -73,14 +73,21 @@ test('handles JSON objects with no valid keys (#19)', async (t) => {
 });
 
 test('handles garbage', async (t) => {
-  const bundle = async () =>
-    rollup({
-      input: 'fixtures/garbage/main.js',
-      plugins: [json()]
-    });
+  const warns = [];
 
-  const error = await t.throwsAsync(bundle);
-  t.is(error.message.indexOf('Unexpected token o'), 0);
+  await rollup({
+    input: 'fixtures/garbage/main.js',
+    plugins: [json()],
+    onwarn: (warning) => warns.push(warning)
+  }).catch(() => {});
+
+  const [{ message, id, position, plugin }] = warns;
+
+  t.is(warns.length, 1);
+  t.is(plugin, 'json');
+  t.is(position, 1);
+  t.is(message, 'Could not parse JSON file');
+  t.regex(id, /(.*)bad.json$/);
 });
 
 test('does not generate an AST', async (t) => {


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `json`

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description
Helpful when debugging
Sometimes in a large codebase, a single comma buried in a gigantic json file can halt the entire build. This change ensures that users will more easily be able to find and fix those errors.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
