### PR TITLE
feat(pluginutils): add native node es modules support

### DIFF
--- a/packages/pluginutils/package.json
+++ b/packages/pluginutils/package.json
@@ -12,7 +12,7 @@
   "bugs": {
     "url": "https://github.com/rollup/plugins/issues"
   },
-  "main": "dist/index.js",
+  "main": "./dist/cjs/index.js",
   "engines": {
     "node": ">= 8.0.0"
   },
@@ -75,12 +75,17 @@
       "!**/types.ts"
     ]
   },
-  "module": "dist/index.es.js",
+  "exports": {
+    "require": "./dist/cjs/index.js",
+    "import": "./dist/es/index.js"
+  },
+  "module": "./dist/es/index.js",
   "nyc": {
     "extension": [
       ".js",
       ".ts"
     ]
   },
+  "type": "commonjs",
   "types": "types/index.d.ts"
 }

--- a/packages/pluginutils/rollup.config.js
+++ b/packages/pluginutils/rollup.config.js
@@ -2,20 +2,9 @@ import commonjs from '@rollup/plugin-commonjs';
 import resolve from '@rollup/plugin-node-resolve';
 import typescript from '@rollup/plugin-typescript';
 
-import pkg from './package.json';
+import { emitModulePackageFile } from '../../shared/rollup.config';
 
-function emitModulePackageFile() {
-  return {
-    name: 'emit-module-package-file',
-    generateBundle() {
-      this.emitFile({
-        type: 'asset',
-        fileName: 'package.json',
-        source: `{"type":"module"}`
-      });
-    }
-  };
-}
+import pkg from './package.json';
 
 export default {
   input: 'src/index.ts',

--- a/packages/pluginutils/rollup.config.js
+++ b/packages/pluginutils/rollup.config.js
@@ -17,7 +17,7 @@ export default {
   ],
   external: [...builtinModules, 'picomatch'],
   output: [
-    { format: 'cjs', file: pkg.main, exports: 'named' },
+    { file: pkg.main, format: 'cjs', exports: 'named' },
     { file: pkg.module, format: 'es', plugins: [emitModulePackageFile()] }
   ]
 };

--- a/packages/pluginutils/rollup.config.js
+++ b/packages/pluginutils/rollup.config.js
@@ -1,3 +1,5 @@
+import { builtinModules } from 'module';
+
 import commonjs from '@rollup/plugin-commonjs';
 import resolve from '@rollup/plugin-node-resolve';
 import typescript from '@rollup/plugin-typescript';
@@ -13,7 +15,7 @@ export default {
     commonjs({ include: '../../node_modules/.pnpm/registry.npmjs.org/**' }),
     typescript({ include: '**/*.{ts,js}', module: 'esnext' })
   ],
-  external: Object.keys(pkg.dependencies).concat('path', 'util'),
+  external: [...builtinModules, 'picomatch'],
   output: [
     { format: 'cjs', file: pkg.main, exports: 'named' },
     { file: pkg.module, format: 'es', plugins: [emitModulePackageFile()] }

--- a/packages/pluginutils/rollup.config.js
+++ b/packages/pluginutils/rollup.config.js
@@ -4,6 +4,19 @@ import typescript from '@rollup/plugin-typescript';
 
 import pkg from './package.json';
 
+function emitModulePackageFile() {
+  return {
+    name: 'emit-module-package-file',
+    generateBundle() {
+      this.emitFile({
+        type: 'asset',
+        fileName: 'package.json',
+        source: `{"type":"module"}`
+      });
+    }
+  };
+}
+
 export default {
   input: 'src/index.ts',
   plugins: [
@@ -13,14 +26,7 @@ export default {
   ],
   external: Object.keys(pkg.dependencies).concat('path', 'util'),
   output: [
-    {
-      format: 'cjs',
-      file: pkg.main,
-      exports: 'named'
-    },
-    {
-      format: 'es',
-      file: pkg.module
-    }
+    { format: 'cjs', file: pkg.main, exports: 'named' },
+    { file: pkg.module, format: 'es', plugins: [emitModulePackageFile()] }
   ]
 };

--- a/shared/rollup.config.js
+++ b/shared/rollup.config.js
@@ -23,3 +23,16 @@ export function createConfig(pkg) {
     ]
   };
 }
+
+export function emitModulePackageFile() {
+  return {
+    name: 'emit-module-package-file',
+    generateBundle() {
+      this.emitFile({
+        type: 'asset',
+        fileName: 'package.json',
+        source: `{"type":"module"}`
+      });
+    }
+  };
+}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `pluginutils`

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:
- https://github.com/rollup/plugins/issues/412
- https://github.com/rollup/plugins/pull/413

### Description

Enable native node es modules via "exports" field in package.json.
Added custom plugin to generate nested package.json with `{"type": "module"}`
as an alternative to mjs extension usage. This works similar to rollup distribution.
https://unpkg.com/browse/rollup@2.10.9/dist/es/

This change is necessary before migrating all other plugins.
