### PR TITLE
docs(replace): clarify options for allowed replacement values

### DIFF
--- a/packages/replace/README.md
+++ b/packages/replace/README.md
@@ -36,13 +36,17 @@ export default {
     dir: 'output',
     format: 'cjs'
   },
-  plugins: [replace({ __buildEnv__: 'production' })]
+  plugins: [replace({ 
+    __buildEnv__: 'production',
+    __buildDate__: () => new Date(),
+    __buildVersion: 15
+  })]
 };
 ```
 
 Then call `rollup` either via the [CLI](https://www.rollupjs.org/guide/en/#command-line-reference) or the [API](https://www.rollupjs.org/guide/en/#javascript-api).
 
-The configuration above will replace every instance of `__buildEnv__` with `'production'` in any file included in the build. _Note: Values should always be strings. For complex values, use `JSON.stringify`._
+The configuration above will replace every instance of `__buildEnv__` with `'production'` and `__buildDate__` with the result of the given function in any file included in the build. _Note: Values have to be either primitives or functions that return a string. For complex values, use `JSON.stringify`._
 
 Typically, `@rollup/plugin-replace` should be placed in `plugins` _before_ other plugins so that they may apply optimizations, such as dead code removal.
 


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `replace`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

#399 

### Description

This PR updates the documentation as stated in #399 to clarify that functions can be used as replacement options using the replace plugin.  Testing revealed that replacing with numbers also works, so I changed the wording _strings_ into _primitives_ (unsure if that's a good term ?)