### PR TITLE
fix(alias): properly initialize custom resolvers

### DIFF
--- a/packages/alias/src/index.ts
+++ b/packages/alias/src/index.ts
@@ -8,8 +8,8 @@ import { Alias, ResolverFunction, RollupAliasOptions } from '../types';
 const VOLUME = /^([A-Z]:)/i;
 const IS_WINDOWS = platform() === 'win32';
 
-// Helper functions
 const noop = () => null;
+
 function matches(pattern: string | RegExp, importee: string) {
   if (pattern instanceof RegExp) {
     return pattern.test(importee);
@@ -48,10 +48,28 @@ function getEntries({ entries }: RollupAliasOptions): Alias[] {
   });
 }
 
+function getCustomResolver(
+  { customResolver }: Alias,
+  options: RollupAliasOptions
+): ResolverFunction | null {
+  if (typeof customResolver === 'function') {
+    return customResolver;
+  }
+  if (customResolver && typeof customResolver.resolveId === 'function') {
+    return customResolver.resolveId;
+  }
+  if (typeof options.customResolver === 'function') {
+    return options.customResolver;
+  }
+  if (options.customResolver && typeof options.customResolver.resolveId === 'function') {
+    return options.customResolver.resolveId;
+  }
+  return null;
+}
+
 export default function alias(options: RollupAliasOptions = {}): Plugin {
   const entries = getEntries(options);
 
-  // No aliases?
   if (entries.length === 0) {
     return {
       name: 'alias',
@@ -61,6 +79,17 @@ export default function alias(options: RollupAliasOptions = {}): Plugin {
 
   return {
     name: 'alias',
+    buildStart(inputOptions) {
+      return Promise.all(
+        [...entries, options].map(
+          ({ customResolver }) =>
+            customResolver &&
+            typeof customResolver === 'object' &&
+            typeof customResolver.buildStart === 'function' &&
+            customResolver.buildStart.call(this, inputOptions)
+        )
+      ).then(() => {});
+    },
     resolveId(importee, importer) {
       const importeeId = normalizeId(importee);
       const importerId = normalizeId(importer);
@@ -75,25 +104,9 @@ export default function alias(options: RollupAliasOptions = {}): Plugin {
         importeeId.replace(matchedEntry.find, matchedEntry.replacement)
       );
 
-      let customResolver: ResolverFunction | null = null;
-      if (typeof matchedEntry.customResolver === 'function') {
-        ({ customResolver } = matchedEntry);
-      } else if (
-        typeof matchedEntry.customResolver === 'object' &&
-        typeof matchedEntry.customResolver!.resolveId === 'function'
-      ) {
-        customResolver = matchedEntry.customResolver!.resolveId;
-      } else if (typeof options.customResolver === 'function') {
-        ({ customResolver } = options);
-      } else if (
-        typeof options.customResolver === 'object' &&
-        typeof options.customResolver!.resolveId === 'function'
-      ) {
-        customResolver = options.customResolver!.resolveId;
-      }
-
+      const customResolver = getCustomResolver(matchedEntry, options);
       if (customResolver) {
-        return customResolver(updatedId, importerId);
+        return customResolver.call(this, updatedId, importerId);
       }
 
       return this.resolve(updatedId, importer, { skipSelf: true }).then((resolved) => {

--- a/packages/alias/src/index.ts
+++ b/packages/alias/src/index.ts
@@ -88,7 +88,9 @@ export default function alias(options: RollupAliasOptions = {}): Plugin {
             typeof customResolver.buildStart === 'function' &&
             customResolver.buildStart.call(this, inputOptions)
         )
-      ).then(() => {});
+      ).then(() => {
+        // enforce void return value
+      });
     },
     resolveId(importee, importer) {
       const importeeId = normalizeId(importee);

--- a/packages/alias/test/test.js
+++ b/packages/alias/test/test.js
@@ -311,9 +311,33 @@ test('Local customResolver plugin-like object', (t) => {
   ).then((result) => t.deepEqual(result, [localCustomResult]));
 });
 
-/** @TODO
- *  Needs to be modified after rollup-plugin-node-resolve would became a part of rollup-plugins monorepo
- */
+test('supports node-resolve as a custom resolver', (t) =>
+  resolveAliasWithRollup(
+    {
+      entries: [
+        {
+          find: 'local-resolver',
+          replacement: path.resolve(DIRNAME, 'fixtures'),
+          customResolver: nodeResolvePlugin()
+        },
+        {
+          find: 'global-resolver',
+          replacement: path.resolve(DIRNAME, 'fixtures', 'folder')
+        }
+      ],
+      customResolver: nodeResolvePlugin()
+    },
+    [
+      { source: 'local-resolver', importer: posix.resolve(DIRNAME, './files/index.js') },
+      { source: 'global-resolver', importer: posix.resolve(DIRNAME, './files/index.js') }
+    ]
+  ).then((result) =>
+    t.deepEqual(result, [
+      path.resolve(DIRNAME, 'fixtures', 'index.js'),
+      path.resolve(DIRNAME, 'fixtures', 'folder', 'index.js')
+    ])
+  ));
+
 test('Alias + rollup-plugin-node-resolve', (t) =>
   rollup({
     input: './test/fixtures/index.js',

--- a/packages/alias/types/index.d.ts
+++ b/packages/alias/types/index.d.ts
@@ -1,4 +1,4 @@
-import { Plugin, ResolveIdResult } from 'rollup';
+import { Plugin, PluginHooks } from 'rollup';
 
 export interface Alias {
   find: string | RegExp;
@@ -6,12 +6,10 @@ export interface Alias {
   customResolver?: ResolverFunction | ResolverObject | null;
 }
 
-export type ResolverFunction = (
-  source: string,
-  importer: string | undefined
-) => Promise<ResolveIdResult> | ResolveIdResult;
+export type ResolverFunction = PluginHooks['resolveId'];
 
 export interface ResolverObject {
+  buildStart?: PluginHooks['buildStart'];
   resolveId: ResolverFunction;
 }
 


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `alias`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:
Resolves #203 

### Description
This will make sure that for all custom resolvers
- the `buildStart` hooks are run if present during `buildStart`
- the `resolveId` hook is run with correct `this` context