### PR TITLE
fix(url): Conform to Rollup type definitions.

### DIFF
--- a/packages/url/src/index.js
+++ b/packages/url/src/index.js
@@ -10,7 +10,7 @@ import { createFilter } from '@rollup/pluginutils';
 const fsStatPromise = util.promisify(fs.stat);
 const fsReadFilePromise = util.promisify(fs.readFile);
 const { posix, sep } = path;
-export const defaultInclude = ['**/*.svg', '**/*.png', '**/*.jpg', '**/*.gif'];
+const defaultInclude = ['**/*.svg', '**/*.png', '**/*.jpg', '**/*.gif'];
 
 export default function url(options = {}) {
   const {

--- a/packages/url/src/index.js
+++ b/packages/url/src/index.js
@@ -10,7 +10,7 @@ import { createFilter } from '@rollup/pluginutils';
 const fsStatPromise = util.promisify(fs.stat);
 const fsReadFilePromise = util.promisify(fs.readFile);
 const { posix, sep } = path;
-const defaultInclude = ['**/*.svg', '**/*.png', '**/*.jpg', '**/*.gif'];
+export const defaultInclude = ['**/*.svg', '**/*.png', '**/*.jpg', '**/*.gif'];
 
 export default function url(options = {}) {
   const {
@@ -26,6 +26,7 @@ export default function url(options = {}) {
   const copies = Object.create(null);
 
   return {
+    name: "url",
     load(id) {
       if (!filter(id)) {
         return null;


### PR DESCRIPTION
## Rollup Plugin Name: `url`

This PR contains:

- [x] bugfix
- [x] other

Are tests included?

- [ ] yes


Breaking Changes?

- [x] no


### Description
Conform to Rollup type definitions to silence compiler errors, as they expect a plugin name and it's [expected/advised](https://rollupjs.org/guide/en/#plugins-overview) on the docs. 

Current workaround is: 
```ts
        {
            name: "url",
            ...url({
                limit: 0,
                include: defaultAssetTypes,
                fileName: '[dirname][name]_[hash][extname]',
                sourceDir: path.join(__dirname, 'src')
            })
        },
```

or more succinct and error prone: 

```ts
        url({
            limit: 0,
            include: defaultAssetTypes,
            fileName: '[dirname][name]_[hash][extname]',
            sourceDir: path.join(__dirname, 'src')
        }) as any,
```



~~Also, exporting defaultInclude as I'd like to extend the defaults instead of redefining them.~~
Edit: Got rid of that, since I guess you don't want to mix default and named export, understandable. 