### PR TITLE
fix(typescript): utilize 'this.meta.watchMode'

### DIFF
--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -44,7 +44,7 @@
     "es2015"
   ],
   "peerDependencies": {
-    "rollup": "^1.20.0||^2.0.0",
+    "rollup": "^2.14.0",
     "tslib": "*",
     "typescript": ">=3.4.0"
   },
@@ -57,7 +57,7 @@
     "@rollup/plugin-commonjs": "^11.0.1",
     "@rollup/plugin-typescript": "^3.0.0",
     "buble": "^0.19.8",
-    "rollup": "^2.0.0",
+    "rollup": "^2.14.0",
     "tslib": "^1.10.0",
     "typescript": "^3.7.4"
   },

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -58,7 +58,7 @@ export default function typescript(options: RollupTypescriptOptions = {}): Plugi
     },
 
     buildEnd() {
-      if (process.env.ROLLUP_WATCH !== 'true') {
+      if (this.meta.watchMode !== true) {
         // ESLint doesn't understand optional chaining
         // eslint-disable-next-line
         program?.close();

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -93,7 +93,7 @@ export default function typescript(options: RollupTypescriptOptions = {}): Plugi
     async load(id) {
       if (!filter(id)) return null;
 
-      await watchProgramHelper.wait()
+      await watchProgramHelper.wait();
 
       const output = findTypescriptOutput(ts, parsedOptions, id, emittedFiles);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,7 +81,7 @@ importers:
   packages/babel:
     dependencies:
       '@babel/helper-module-imports': 7.8.3
-      '@rollup/pluginutils': 3.0.8_rollup@2.2.0
+      '@rollup/pluginutils': 3.0.10_rollup@2.2.0
     devDependencies:
       '@babel/core': 7.8.3
       '@babel/plugin-external-helpers': 7.8.3_@babel+core@7.8.3
@@ -89,7 +89,7 @@ importers:
       '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.8.3
       '@babel/plugin-transform-runtime': 7.9.0_@babel+core@7.8.3
       '@babel/preset-env': 7.9.5_@babel+core@7.8.3
-      '@rollup/plugin-json': 4.0.1_rollup@2.2.0
+      '@rollup/plugin-json': 4.0.3_rollup@2.2.0
       rollup: 2.2.0
       source-map: 0.6.1
     specifiers:
@@ -113,7 +113,7 @@ importers:
       strip-ansi: ^5.2.0
   packages/buble:
     dependencies:
-      '@rollup/pluginutils': 3.0.8_rollup@2.2.0
+      '@rollup/pluginutils': 3.0.10_rollup@2.2.0
       '@types/buble': 0.19.2
       buble: 0.20.0
     devDependencies:
@@ -133,7 +133,7 @@ importers:
       typescript: ^3.7.4
   packages/commonjs:
     dependencies:
-      '@rollup/pluginutils': 3.0.8_rollup@2.7.2
+      '@rollup/pluginutils': 3.0.10_rollup@2.7.2
       commondir: 1.0.1
       estree-walker: 1.0.1
       glob: 7.1.6
@@ -144,7 +144,7 @@ importers:
       '@babel/core': 7.9.0
       '@babel/preset-env': 7.9.5_@babel+core@7.9.0
       '@babel/register': 7.9.0_@babel+core@7.9.0
-      '@rollup/plugin-json': 4.0.1_rollup@2.7.2
+      '@rollup/plugin-json': 4.0.3_rollup@2.7.2
       '@rollup/plugin-node-resolve': 7.1.1_rollup@2.7.2
       acorn: 7.1.1
       locate-character: 2.0.5
@@ -182,7 +182,7 @@ importers:
   packages/data-uri:
     devDependencies:
       '@rollup/plugin-typescript': 3.0.0_rollup@2.2.0+typescript@3.7.5
-      '@rollup/pluginutils': 3.0.8_rollup@2.2.0
+      '@rollup/pluginutils': 3.0.10_rollup@2.2.0
       rollup: 2.2.0
       typescript: 3.7.5
     specifiers:
@@ -192,7 +192,7 @@ importers:
       typescript: ^3.7.4
   packages/dsv:
     dependencies:
-      '@rollup/pluginutils': 3.0.8_rollup@2.2.0
+      '@rollup/pluginutils': 3.0.10_rollup@2.2.0
       d3-dsv: 1.2.0
       tosource: 1.0.0
     devDependencies:
@@ -213,7 +213,7 @@ importers:
       rollup-plugin-postcss: ^2.0.3
   packages/image:
     dependencies:
-      '@rollup/pluginutils': 3.0.8_rollup@2.2.0
+      '@rollup/pluginutils': 3.0.10_rollup@2.2.0
       mini-svg-data-uri: 1.1.3
     devDependencies:
       '@rollup/plugin-buble': 0.21.0_rollup@2.2.0
@@ -225,7 +225,7 @@ importers:
       rollup: ^2.0.0
   packages/inject:
     dependencies:
-      '@rollup/pluginutils': 3.0.8_rollup@2.2.0
+      '@rollup/pluginutils': 3.0.10_rollup@2.2.0
       estree-walker: 1.0.1
       magic-string: 0.25.6
     devDependencies:
@@ -247,7 +247,7 @@ importers:
       typescript: ^3.7.4
   packages/json:
     dependencies:
-      '@rollup/pluginutils': 3.0.8
+      '@rollup/pluginutils': 3.0.10
     devDependencies:
       '@rollup/plugin-buble': 0.21.0
       '@rollup/plugin-node-resolve': 7.1.1
@@ -342,7 +342,7 @@ importers:
       typescript: ^3.7.5
   packages/replace:
     dependencies:
-      '@rollup/pluginutils': 3.0.8_rollup@2.2.0
+      '@rollup/pluginutils': 3.0.10_rollup@2.2.0
       magic-string: 0.25.6
     devDependencies:
       '@rollup/plugin-buble': 0.21.0_rollup@2.2.0
@@ -376,7 +376,7 @@ importers:
       sinon: 8.0.4
   packages/strip:
     dependencies:
-      '@rollup/pluginutils': 3.0.8_rollup@2.2.0
+      '@rollup/pluginutils': 3.0.10_rollup@2.2.0
       estree-walker: 1.0.1
       magic-string: 0.25.6
     devDependencies:
@@ -402,14 +402,14 @@ importers:
       sucrase: ^3.10.1
   packages/typescript:
     dependencies:
-      '@rollup/pluginutils': 3.0.8_rollup@2.2.0
+      '@rollup/pluginutils': 3.0.10_rollup@2.16.1
       resolve: 1.15.0
     devDependencies:
-      '@rollup/plugin-buble': 0.21.0_rollup@2.2.0
-      '@rollup/plugin-commonjs': 11.0.2_rollup@2.2.0
-      '@rollup/plugin-typescript': 3.0.0_b32f28c91b7d5afb3a4e5593fb670831
+      '@rollup/plugin-buble': 0.21.0_rollup@2.16.1
+      '@rollup/plugin-commonjs': 11.0.2_rollup@2.16.1
+      '@rollup/plugin-typescript': 3.0.0_b7ed8cf084a78b83114da7b845e0a30a
       buble: 0.19.8
-      rollup: 2.2.0
+      rollup: 2.16.1
       tslib: 1.10.0
       typescript: 3.7.5
     specifiers:
@@ -419,12 +419,12 @@ importers:
       '@rollup/pluginutils': ^3.0.1
       buble: ^0.19.8
       resolve: ^1.14.1
-      rollup: ^2.0.0
+      rollup: ^2.14.0
       tslib: ^1.10.0
       typescript: ^3.7.4
   packages/url:
     dependencies:
-      '@rollup/pluginutils': 3.0.8_rollup@2.2.0
+      '@rollup/pluginutils': 3.0.10_rollup@2.2.0
       make-dir: 3.0.0
       mime: 2.4.4
     devDependencies:
@@ -466,7 +466,7 @@ importers:
       source-map: ^0.7.3
   packages/yaml:
     dependencies:
-      '@rollup/pluginutils': 3.0.8_rollup@2.2.0
+      '@rollup/pluginutils': 3.0.10_rollup@2.2.0
       js-yaml: 3.13.1
       tosource: 1.0.0
     devDependencies:
@@ -2088,6 +2088,17 @@ packages:
       rollup: ^1.20.0
     resolution:
       integrity: sha512-n6N311RCrVvnsWGyo/if6K2kFoDW+x9r+/hkp+fI73MryLFGxN50Y3zJDg3k0ZTDjRHmveVzM6Nzwv9+plWiLA==
+  /@rollup/plugin-buble/0.21.0_rollup@2.16.1:
+    dependencies:
+      '@types/buble': 0.19.2
+      buble: 0.19.8
+      rollup: 2.16.1
+      rollup-pluginutils: 2.8.2
+    dev: true
+    peerDependencies:
+      rollup: ^1.20.0
+    resolution:
+      integrity: sha512-n6N311RCrVvnsWGyo/if6K2kFoDW+x9r+/hkp+fI73MryLFGxN50Y3zJDg3k0ZTDjRHmveVzM6Nzwv9+plWiLA==
   /@rollup/plugin-buble/0.21.0_rollup@2.2.0:
     dependencies:
       '@types/buble': 0.19.2
@@ -2113,14 +2124,14 @@ packages:
       rollup: ^1.20.0
     resolution:
       integrity: sha512-MPYGZr0qdbV5zZj8/2AuomVpnRVXRU5XKXb3HVniwRoRCreGlf5kOE081isNWeiLIi6IYkwTX9zE0/c7V8g81g==
-  /@rollup/plugin-commonjs/11.0.2_rollup@2.2.0:
+  /@rollup/plugin-commonjs/11.0.2_rollup@2.16.1:
     dependencies:
-      '@rollup/pluginutils': 3.0.8_rollup@2.2.0
+      '@rollup/pluginutils': 3.0.8_rollup@2.16.1
       estree-walker: 1.0.1
       is-reference: 1.1.4
       magic-string: 0.25.7
       resolve: 1.15.0
-      rollup: 2.2.0
+      rollup: 2.16.1
     dev: true
     engines:
       node: '>= 8.0.0'
@@ -2128,28 +2139,28 @@ packages:
       rollup: ^1.20.0
     resolution:
       integrity: sha512-MPYGZr0qdbV5zZj8/2AuomVpnRVXRU5XKXb3HVniwRoRCreGlf5kOE081isNWeiLIi6IYkwTX9zE0/c7V8g81g==
-  /@rollup/plugin-json/4.0.1_rollup@2.2.0:
-    dependencies:
-      rollup: 2.2.0
-      rollup-pluginutils: 2.8.2
-    dev: true
-    peerDependencies:
-      rollup: ^1.20.0
-    resolution:
-      integrity: sha512-soxllkhOGgchswBAAaTe7X9G80U2tjjHvXv0sBrriLJcC/89PkP59iTrKPOfbz3SjX088mKDmMhAscuyLz8ZSg==
-  /@rollup/plugin-json/4.0.1_rollup@2.7.2:
-    dependencies:
-      rollup: 2.7.2
-      rollup-pluginutils: 2.8.2
-    dev: true
-    peerDependencies:
-      rollup: ^1.20.0
-    resolution:
-      integrity: sha512-soxllkhOGgchswBAAaTe7X9G80U2tjjHvXv0sBrriLJcC/89PkP59iTrKPOfbz3SjX088mKDmMhAscuyLz8ZSg==
   /@rollup/plugin-json/4.0.3_rollup@2.12.0:
     dependencies:
       '@rollup/pluginutils': 3.0.10_rollup@2.12.0
       rollup: 2.12.0
+    dev: true
+    peerDependencies:
+      rollup: ^1.20.0 || ^2.0.0
+    resolution:
+      integrity: sha512-QMUT0HZNf4CX17LMdwaslzlYHUKTYGuuk34yYIgZrNdu+pMEfqMS55gck7HEeHBKXHM4cz5Dg1OVwythDdbbuQ==
+  /@rollup/plugin-json/4.0.3_rollup@2.2.0:
+    dependencies:
+      '@rollup/pluginutils': 3.0.10_rollup@2.2.0
+      rollup: 2.2.0
+    dev: true
+    peerDependencies:
+      rollup: ^1.20.0 || ^2.0.0
+    resolution:
+      integrity: sha512-QMUT0HZNf4CX17LMdwaslzlYHUKTYGuuk34yYIgZrNdu+pMEfqMS55gck7HEeHBKXHM4cz5Dg1OVwythDdbbuQ==
+  /@rollup/plugin-json/4.0.3_rollup@2.7.2:
+    dependencies:
+      '@rollup/pluginutils': 3.0.10_rollup@2.7.2
+      rollup: 2.7.2
     dev: true
     peerDependencies:
       rollup: ^1.20.0 || ^2.0.0
@@ -2199,11 +2210,11 @@ packages:
       rollup: ^1.20.0
     resolution:
       integrity: sha512-14ddhD7TnemeHE97a4rLOhobfYvUVcaYuqTnL8Ti7Jxi9V9Jr5LY7Gko4HZ5k4h4vqQM0gBQt6tsp9xXW94WPA==
-  /@rollup/plugin-typescript/3.0.0_b32f28c91b7d5afb3a4e5593fb670831:
+  /@rollup/plugin-typescript/3.0.0_b7ed8cf084a78b83114da7b845e0a30a:
     dependencies:
-      '@rollup/pluginutils': 3.0.8_rollup@2.2.0
+      '@rollup/pluginutils': 3.0.8_rollup@2.16.1
       resolve: 1.15.0
-      rollup: 2.2.0
+      rollup: 2.16.1
       tslib: 1.10.0
       typescript: 3.7.5
     dev: true
@@ -2272,12 +2283,37 @@ packages:
       typescript: '>=2.1.0'
     resolution:
       integrity: sha512-KYZCn1Iw9hZWkeEPqPs5YjlmvSjR7UdezVca8z0e8rm/29wU24UD9Y4IZHhnc9tm749hzsgBTiOUxA85gfShEQ==
+  /@rollup/pluginutils/3.0.10:
+    dependencies:
+      '@types/estree': 0.0.39
+      estree-walker: 1.0.1
+      picomatch: 2.2.2
+    dev: false
+    engines:
+      node: '>= 8.0.0'
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0
+    resolution:
+      integrity: sha512-d44M7t+PjmMrASHbhgpSbVgtL6EFyX7J4mYxwQ/c5eoaE6N2VgCgEcWVzNnwycIloti+/MpwFr8qfw+nRw00sw==
   /@rollup/pluginutils/3.0.10_rollup@2.12.0:
     dependencies:
       '@types/estree': 0.0.39
       estree-walker: 1.0.1
       picomatch: 2.2.2
       rollup: 2.12.0
+    engines:
+      node: '>= 8.0.0'
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0
+    resolution:
+      integrity: sha512-d44M7t+PjmMrASHbhgpSbVgtL6EFyX7J4mYxwQ/c5eoaE6N2VgCgEcWVzNnwycIloti+/MpwFr8qfw+nRw00sw==
+  /@rollup/pluginutils/3.0.10_rollup@2.16.1:
+    dependencies:
+      '@types/estree': 0.0.39
+      estree-walker: 1.0.1
+      picomatch: 2.2.2
+      rollup: 2.16.1
+    dev: false
     engines:
       node: '>= 8.0.0'
     peerDependencies:
@@ -2296,9 +2332,33 @@ packages:
       rollup: ^1.20.0||^2.0.0
     resolution:
       integrity: sha512-d44M7t+PjmMrASHbhgpSbVgtL6EFyX7J4mYxwQ/c5eoaE6N2VgCgEcWVzNnwycIloti+/MpwFr8qfw+nRw00sw==
+  /@rollup/pluginutils/3.0.10_rollup@2.7.2:
+    dependencies:
+      '@types/estree': 0.0.39
+      estree-walker: 1.0.1
+      picomatch: 2.2.2
+      rollup: 2.7.2
+    engines:
+      node: '>= 8.0.0'
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0
+    resolution:
+      integrity: sha512-d44M7t+PjmMrASHbhgpSbVgtL6EFyX7J4mYxwQ/c5eoaE6N2VgCgEcWVzNnwycIloti+/MpwFr8qfw+nRw00sw==
   /@rollup/pluginutils/3.0.8:
     dependencies:
       estree-walker: 1.0.1
+    dev: true
+    engines:
+      node: '>= 8.0.0'
+    peerDependencies:
+      rollup: ^1.20.0
+    resolution:
+      integrity: sha512-rYGeAc4sxcZ+kPG/Tw4/fwJODC3IXHYDH4qusdN/b6aLw5LPUbzpecYbEJh4sVQGPFJxd2dBU4kc1H3oy9/bnw==
+  /@rollup/pluginutils/3.0.8_rollup@2.16.1:
+    dependencies:
+      estree-walker: 1.0.1
+      rollup: 2.16.1
+    dev: true
     engines:
       node: '>= 8.0.0'
     peerDependencies:
@@ -2309,6 +2369,7 @@ packages:
     dependencies:
       estree-walker: 1.0.1
       rollup: 2.2.0
+    dev: true
     engines:
       node: '>= 8.0.0'
     peerDependencies:
@@ -2319,6 +2380,7 @@ packages:
     dependencies:
       estree-walker: 1.0.1
       rollup: 2.7.2
+    dev: true
     engines:
       node: '>= 8.0.0'
     peerDependencies:
@@ -7641,6 +7703,14 @@ packages:
       fsevents: 2.1.3
     resolution:
       integrity: sha512-vKwc/xFkZGM9DRai3Eztpr/4g0yYDgNKVq8tLXhq/aSLbR+/EVL6rTjEW9bgWgeYEIKoN66/5w2Bjv1gzyHR/w==
+  /rollup/2.16.1:
+    engines:
+      node: '>=10.0.0'
+    hasBin: true
+    optionalDependencies:
+      fsevents: 2.1.3
+    resolution:
+      integrity: sha512-UYupMcbFtoWLB6ZtL4hPZNUTlkXjJfGT33Mmhz3hYLNmRj/cOvX2B26ZxDQuEpwtLdcyyyraBGQ7EfzmMJnXXg==
   /rollup/2.2.0:
     engines:
       node: '>=10.0.0'


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `typescript`

This PR contains:

- [x] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [x] yes (_breaking changes will not be merged unless absolutely necessary_)
- [ ] no

BREAKING CHANGES: Changed `rollup` peer dependency to `rollup@^2.14.0`

List any relevant issue numbers:
https://github.com/rollup/rollup/issues/3608
#418
Fix: #478

### Description

I applied `prettier` and added the new `this.meta.watchMode` (see https://github.com/rollup/rollup/pull/3616). Checking `process.env.ROLLUP_WATCH` will only work in `rollup -w` context. Checking for `this.meta.watchMode` will also work in `rollup.watch` context. In the future plugins should preferable utilize `this.meta.watchMode`.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
