### PR TITLE
fix(typescript): load empty emitted files

### DIFF
--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -93,11 +93,11 @@ export default function typescript(options: RollupTypescriptOptions = {}): Plugi
     async load(id) {
       if (!filter(id)) return null;
 
-      await watchProgramHelper.wait()
+      await watchProgramHelper.wait();
 
       const output = findTypescriptOutput(ts, parsedOptions, id, emittedFiles);
 
-      return output.code ? (output as SourceDescription) : null;
+      return output.code != null ? (output as SourceDescription) : null;
     },
 
     generateBundle(outputOptions) {

--- a/packages/typescript/test/fixtures/reexport-type/Baz.ts
+++ b/packages/typescript/test/fixtures/reexport-type/Baz.ts
@@ -1,0 +1,1 @@
+export type Baz = unknown;

--- a/packages/typescript/test/fixtures/reexport-type/main.ts
+++ b/packages/typescript/test/fixtures/reexport-type/main.ts
@@ -2,3 +2,5 @@ import { Foo } from './Foo';
 
 export { Foo };
 export { Bar } from './Bar';
+
+export * from './Baz';

--- a/packages/typescript/test/test.js
+++ b/packages/typescript/test/test.js
@@ -641,7 +641,14 @@ test('creates _tslib.js file when preserveModules is used', async (t) => {
 test('should handle re-exporting types', async (t) => {
   const bundle = await rollup({
     input: 'fixtures/reexport-type/main.ts',
-    plugins: [typescript({ tsconfig: 'fixtures/reexport-type/tsconfig.json' })],
+    plugins: [
+      typescript({
+        tsconfig: 'fixtures/reexport-type/tsconfig.json',
+        // Make sure the transpiled files are empty
+        inlineSourceMap: false,
+        sourceMap: false
+      })
+    ],
     onwarn
   });
   await t.notThrowsAsync(getCode(bundle, outputOptions));


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `typescript`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
The plugin ignores files which are emitted empty. In this cases Rollup deals with original source code and may fail with SyntaxError.

My case:
- `export *` from file with types only (that file has empty emit output)
- TS 3.9 (`export *` is always retained)

I used type-reexporting test case to reproduce. The existing version passes because sourceMap is enabled. TS emits single sourceMappingURL comment and plugin accepts it. Test fails when sourceMap is disabled.

I've also extended test case with `export *` declaration.

