### PR TITLE
Support TypeScript `.js` imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "write-pkg": "^4.0.0"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^2.14.0",
-    "@typescript-eslint/parser": "^2.14.0",
+    "@typescript-eslint/eslint-plugin": "^3.5.0",
+    "@typescript-eslint/parser": "^3.5.0",
     "ava": "^2.4.0",
     "chalk": "^2.4.2",
     "codecov-lite": "^0.3.1",
@@ -38,7 +38,6 @@
     "pnpm": "^4.13.0",
     "prettier": "^1.19.1",
     "prettier-plugin-package": "^0.3.1",
-    "rollup": "^2.0.0",
     "ts-node": "^8.5.4",
     "tsconfig-paths": "^3.9.0",
     "tslib": "^1.10.0",

--- a/packages/node-resolve/package.json
+++ b/packages/node-resolve/package.json
@@ -48,22 +48,23 @@
     "rollup": "^1.20.0||^2.0.0"
   },
   "dependencies": {
-    "@rollup/pluginutils": "^3.0.8",
-    "@types/resolve": "0.0.8",
+    "@rollup/pluginutils": "^3.1.0",
+    "@types/resolve": "1.17.1",
     "builtin-modules": "^3.1.0",
     "deep-freeze": "^0.0.1",
     "deepmerge": "^4.2.2",
     "is-module": "^1.0.0",
-    "resolve": "^1.14.2"
+    "resolve": "^1.17.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.9.0",
-    "@babel/preset-env": "^7.9.0",
-    "@rollup/plugin-json": "^4.0.1",
+    "@babel/core": "^7.10.4",
+    "@babel/plugin-transform-typescript": "^7.10.4",
+    "@babel/preset-env": "^7.10.4",
+    "@rollup/plugin-babel": "^5.0.4",
+    "@rollup/plugin-commonjs": "^13.0.0",
+    "@rollup/plugin-json": "^4.1.0",
     "es5-ext": "^0.10.53",
     "rollup": "^2.12.0",
-    "rollup-plugin-babel": "^4.3.3",
-    "rollup-plugin-commonjs": "^10.1.0",
     "source-map": "^0.7.3",
     "string-capitalize": "^1.0.1"
   },

--- a/packages/node-resolve/src/index.js
+++ b/packages/node-resolve/src/index.js
@@ -191,6 +191,15 @@ export function nodeResolve(opts = {}) {
         importSpecifierList.push(`${importee}/`);
       }
 
+      // TypeScript files may import '.js' to refer to either '.ts' or '.tsx'
+      if (importer && importee.endsWith('.js')) {
+        for (const ext of ['.ts', '.tsx']) {
+          if (importer.endsWith(ext) && extensions.includes(ext)) {
+            importSpecifierList.push(importee.replace(/.js$/, ext));
+          }
+        }
+      }
+
       importSpecifierList.push(importee);
       resolveOptions = Object.assign(resolveOptions, customResolveOptions);
 

--- a/packages/node-resolve/test/browser.js
+++ b/packages/node-resolve/test/browser.js
@@ -2,7 +2,7 @@ const { join } = require('path');
 
 const test = require('ava');
 const { rollup } = require('rollup');
-const commonjs = require('rollup-plugin-commonjs');
+const commonjs = require('@rollup/plugin-commonjs');
 
 const { testBundle } = require('../../../util/test');
 

--- a/packages/node-resolve/test/fixtures/ts-import-js-extension/import-ts-with-js-extension.ts
+++ b/packages/node-resolve/test/fixtures/ts-import-js-extension/import-ts-with-js-extension.ts
@@ -1,0 +1,4 @@
+import { main } from './main.js';
+// This resolves as main.ts and _not_ main.js, despite the extension
+const mainResult = main();
+export default mainResult;

--- a/packages/node-resolve/test/fixtures/ts-import-js-extension/main.ts
+++ b/packages/node-resolve/test/fixtures/ts-import-js-extension/main.ts
@@ -1,0 +1,11 @@
+// To make this very clearly TypeScript and not just JS with a TS extension
+type TestType = string | string[];
+interface Main {
+  (): string;
+  propertyCall(input?: TestType): TestType;
+}
+
+const main: Main = () => 'It works!';
+main.propertyCall = () => '';
+
+export { main };

--- a/packages/node-resolve/test/test.js
+++ b/packages/node-resolve/test/test.js
@@ -1,13 +1,13 @@
-const { join, resolve } = require('path');
+import { join, resolve } from 'path';
 
-const test = require('ava');
-const { rollup } = require('rollup');
-const babel = require('rollup-plugin-babel');
-const commonjs = require('rollup-plugin-commonjs');
+import test from 'ava';
+import { rollup } from 'rollup';
+import babel from '@rollup/plugin-babel';
+import commonjs from '@rollup/plugin-commonjs';
 
-const { getCode, getImports, testBundle } = require('../../../util/test');
+import { getCode, getImports, testBundle } from '../../../util/test';
 
-const { nodeResolve } = require('..');
+import { nodeResolve } from '..';
 
 process.chdir(join(__dirname, 'fixtures'));
 
@@ -51,6 +51,7 @@ test('finds a file inside a package directory', async (t) => {
     plugins: [
       nodeResolve(),
       babel({
+        babelHelpers: 'bundled',
         presets: [
           [
             '@babel/preset-env',
@@ -102,6 +103,25 @@ test('supports non-standard extensions', async (t) => {
     ]
   });
   await testBundle(t, bundle);
+});
+
+test('supports JS extensions in TS when referring to TS imports', async (t) => {
+  const bundle = await rollup({
+    input: 'ts-import-js-extension/import-ts-with-js-extension.ts',
+    onwarn: () => t.fail('No warnings were expected'),
+    plugins: [
+      nodeResolve({
+        extensions: ['.js', '.ts']
+      }),
+      babel({
+        babelHelpers: 'bundled',
+        plugins: ['@babel/plugin-transform-typescript'],
+        extensions: ['.js', '.ts']
+      })
+    ]
+  });
+  const { module } = await testBundle(t, bundle);
+  t.is(module.exports, 'It works!');
 });
 
 test('ignores IDs with null character', async (t) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,8 @@ importers:
       semver: 7.3.2
       write-pkg: 4.0.0
     devDependencies:
-      '@typescript-eslint/eslint-plugin': 2.29.0_78834e48aafc7e2cd4306b1d6b447263
-      '@typescript-eslint/parser': 2.29.0_typescript@3.8.3
+      '@typescript-eslint/eslint-plugin': 3.6.0_1cd0d21f7cfbad5ac6106263f5332fb7
+      '@typescript-eslint/parser': 3.6.0_typescript@3.8.3
       ava: 2.4.0
       chalk: 2.4.2
       codecov-lite: 0.3.1
@@ -20,15 +20,14 @@ importers:
       pnpm: 4.14.0
       prettier: 1.19.1
       prettier-plugin-package: 0.3.1_prettier@1.19.1
-      rollup: 2.7.2
       ts-node: 8.9.1_typescript@3.8.3
       tsconfig-paths: 3.9.0
       tslib: 1.11.1
       typescript: 3.8.3
       yaml: 1.9.2
     specifiers:
-      '@typescript-eslint/eslint-plugin': ^2.14.0
-      '@typescript-eslint/parser': ^2.14.0
+      '@typescript-eslint/eslint-plugin': ^3.5.0
+      '@typescript-eslint/parser': ^3.5.0
       ava: ^2.4.0
       chalk: ^2.4.2
       codecov-lite: ^0.3.1
@@ -43,7 +42,6 @@ importers:
       pnpm: ^4.13.0
       prettier: ^1.19.1
       prettier-plugin-package: ^0.3.1
-      rollup: ^2.0.0
       semver: ^7.1.1
       ts-node: ^8.5.4
       tsconfig-paths: ^3.9.0
@@ -304,38 +302,40 @@ importers:
       rollup-plugin-babel: ^4.4.0
   packages/node-resolve:
     dependencies:
-      '@rollup/pluginutils': 3.0.10_rollup@2.12.0
-      '@types/resolve': 0.0.8
+      '@rollup/pluginutils': 3.1.0_rollup@2.12.0
+      '@types/resolve': 1.17.1
       builtin-modules: 3.1.0
       deep-freeze: 0.0.1
       deepmerge: 4.2.2
       is-module: 1.0.0
-      resolve: 1.15.0
+      resolve: 1.17.0
     devDependencies:
-      '@babel/core': 7.9.0
-      '@babel/preset-env': 7.9.5_@babel+core@7.9.0
-      '@rollup/plugin-json': 4.0.3_rollup@2.12.0
+      '@babel/core': 7.10.4
+      '@babel/plugin-transform-typescript': 7.10.4_@babel+core@7.10.4
+      '@babel/preset-env': 7.10.4_@babel+core@7.10.4
+      '@rollup/plugin-babel': 5.0.4_@babel+core@7.10.4+rollup@2.12.0
+      '@rollup/plugin-commonjs': 13.0.0_rollup@2.12.0
+      '@rollup/plugin-json': 4.1.0_rollup@2.12.0
       es5-ext: 0.10.53
       rollup: 2.12.0
-      rollup-plugin-babel: 4.3.3_@babel+core@7.9.0+rollup@2.12.0
-      rollup-plugin-commonjs: 10.1.0_rollup@2.12.0
       source-map: 0.7.3
       string-capitalize: 1.0.1
     specifiers:
-      '@babel/core': ^7.9.0
-      '@babel/preset-env': ^7.9.0
-      '@rollup/plugin-json': ^4.0.1
-      '@rollup/pluginutils': ^3.0.8
-      '@types/resolve': 0.0.8
+      '@babel/core': ^7.10.4
+      '@babel/plugin-transform-typescript': ^7.10.4
+      '@babel/preset-env': ^7.10.4
+      '@rollup/plugin-babel': ^5.0.4
+      '@rollup/plugin-commonjs': ^13.0.0
+      '@rollup/plugin-json': ^4.1.0
+      '@rollup/pluginutils': ^3.1.0
+      '@types/resolve': 1.17.1
       builtin-modules: ^3.1.0
       deep-freeze: ^0.0.1
       deepmerge: ^4.2.2
       es5-ext: ^0.10.53
       is-module: ^1.0.0
-      resolve: ^1.14.2
+      resolve: ^1.17.0
       rollup: ^2.12.0
-      rollup-plugin-babel: ^4.3.3
-      rollup-plugin-commonjs: ^10.1.0
       source-map: ^0.7.3
       string-capitalize: ^1.0.1
   packages/pluginutils:
@@ -541,11 +541,25 @@ packages:
       node: '>=8.9.4 <9 || >=10.0.0 <11 || >=12.0.0'
     resolution:
       integrity: sha512-8eKhFzZp7Qcq1VLfoC75ggGT8nQs9q8fIxltU47yCB7Wi7Y8Qf6oqY1Bm0z04fIec24vEgr0ENhDHEOUGVDqnA==
+  /@babel/code-frame/7.10.4:
+    dependencies:
+      '@babel/highlight': 7.10.4
+    dev: true
+    resolution:
+      integrity: sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==
   /@babel/code-frame/7.8.3:
     dependencies:
       '@babel/highlight': 7.9.0
     resolution:
       integrity: sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==
+  /@babel/compat-data/7.10.4:
+    dependencies:
+      browserslist: 4.12.0
+      invariant: 2.2.4
+      semver: 5.7.1
+    dev: true
+    resolution:
+      integrity: sha512-t+rjExOrSVvjQQXNp5zAIYDp00KjdvGl/TpDX5REPr0S9IAIPQMTilcfG6q8c0QFmj9lSTVySV2VTsyggvtNIw==
   /@babel/compat-data/7.9.0:
     dependencies:
       browserslist: 4.12.0
@@ -554,6 +568,29 @@ packages:
     dev: true
     resolution:
       integrity: sha512-zeFQrr+284Ekvd9e7KAX954LkapWiOmQtsfHirhxqfdlX6MEC32iRE+pqUGlYIBchdevaCwvzxWGSy/YBNI85g==
+  /@babel/core/7.10.4:
+    dependencies:
+      '@babel/code-frame': 7.10.4
+      '@babel/generator': 7.10.4
+      '@babel/helper-module-transforms': 7.10.4
+      '@babel/helpers': 7.10.4
+      '@babel/parser': 7.10.4
+      '@babel/template': 7.10.4
+      '@babel/traverse': 7.10.4
+      '@babel/types': 7.10.4
+      convert-source-map: 1.7.0
+      debug: 4.1.1
+      gensync: 1.0.0-beta.1
+      json5: 2.1.3
+      lodash: 4.17.15
+      resolve: 1.17.0
+      semver: 5.7.1
+      source-map: 0.5.7
+    dev: true
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-3A0tS0HWpy4XujGc7QtOIHTeNwUgWaZc/WuS5YQrfhU67jnVmsD6OGPc1AKHH0LJHQICGncy3+YUjIhVlfDdcA==
   /@babel/core/7.8.3:
     dependencies:
       '@babel/code-frame': 7.8.3
@@ -599,6 +636,15 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==
+  /@babel/generator/7.10.4:
+    dependencies:
+      '@babel/types': 7.10.4
+      jsesc: 2.5.2
+      lodash: 4.17.15
+      source-map: 0.5.7
+    dev: true
+    resolution:
+      integrity: sha512-toLIHUIAgcQygFZRAQcsLQV3CBuX6yOIru1kJk/qqqvcRmZrYe6WavZTSG+bB8MxhnL9YPf+pKQfuiP161q7ng==
   /@babel/generator/7.9.5:
     dependencies:
       '@babel/types': 7.9.5
@@ -608,12 +654,25 @@ packages:
     dev: true
     resolution:
       integrity: sha512-GbNIxVB3ZJe3tLeDm1HSn2AhuD/mVcyLDpgtLXa5tplmWrJdF/elxB56XNqCuD6szyNkDi6wuoKXln3QeBmCHQ==
+  /@babel/helper-annotate-as-pure/7.10.4:
+    dependencies:
+      '@babel/types': 7.10.4
+    dev: true
+    resolution:
+      integrity: sha512-XQlqKQP4vXFB7BN8fEEerrmYvHp3fK/rBkRFz9jaJbzK0B1DSfej9Kc7ZzE8Z/OnId1jpJdNAZ3BFQjWG68rcA==
   /@babel/helper-annotate-as-pure/7.8.3:
     dependencies:
       '@babel/types': 7.9.5
     dev: true
     resolution:
       integrity: sha512-6o+mJrZBxOoEX77Ezv9zwW7WV8DdluouRKNY/IR5u/YTMuKHgugHOzYWlYvYLpLA9nPsQCAAASpCIbjI9Mv+Uw==
+  /@babel/helper-builder-binary-assignment-operator-visitor/7.10.4:
+    dependencies:
+      '@babel/helper-explode-assignable-expression': 7.10.4
+      '@babel/types': 7.10.4
+    dev: true
+    resolution:
+      integrity: sha512-L0zGlFrGWZK4PbT8AszSfLTM5sDU1+Az/En9VrdT8/LmEiJt4zXt+Jve9DCAnQcbqDhCI+29y/L93mrDzddCcg==
   /@babel/helper-builder-binary-assignment-operator-visitor/7.8.3:
     dependencies:
       '@babel/helper-explode-assignable-expression': 7.8.3
@@ -621,6 +680,19 @@ packages:
     dev: true
     resolution:
       integrity: sha512-5eFOm2SyFPK4Rh3XMMRDjN7lBH0orh3ss0g3rTYZnBQ+r6YPj7lgDyCvPphynHvUrobJmeMignBr6Acw9mAPlw==
+  /@babel/helper-compilation-targets/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/compat-data': 7.10.4
+      '@babel/core': 7.10.4
+      browserslist: 4.12.0
+      invariant: 2.2.4
+      levenary: 1.1.1
+      semver: 5.7.1
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    resolution:
+      integrity: sha512-a3rYhlsGV0UHNDvrtOXBg8/OpfV0OKTkxKPzIplS1zpx7CygDcWWxckxZeDd3gzPzC4kUT0A4nVFDK0wGMh4MQ==
   /@babel/helper-compilation-targets/7.8.7_@babel+core@7.8.3:
     dependencies:
       '@babel/compat-data': 7.9.0
@@ -647,6 +719,20 @@ packages:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-4mWm8DCK2LugIS+p1yArqvG1Pf162upsIsjE7cNBjez+NjliQpVhj20obE520nao0o14DaTnFJv+Fw5a0JpoUw==
+  /@babel/helper-create-class-features-plugin/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-function-name': 7.10.4
+      '@babel/helper-member-expression-to-functions': 7.10.4
+      '@babel/helper-optimise-call-expression': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-replace-supers': 7.10.4
+      '@babel/helper-split-export-declaration': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    resolution:
+      integrity: sha512-9raUiOsXPxzzLjCXeosApJItoMnX3uyT4QdM2UldffuGApNrF8e938MwNpDCK9CPoyxrEoCgT+hObJc3mZa6lQ==
   /@babel/helper-create-class-features-plugin/7.9.5_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -661,6 +747,39 @@ packages:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-IipaxGaQmW4TfWoXdqjY0TzoXQ1HRS0kPpEgvjosb3u7Uedcq297xFqDQiCcQtRRwzIMif+N1MLVI8C5a4/PAA==
+  /@babel/helper-create-regexp-features-plugin/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-annotate-as-pure': 7.10.4
+      '@babel/helper-regex': 7.10.4
+      regexpu-core: 4.7.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    resolution:
+      integrity: sha512-2/hu58IEPKeoLF45DBwx3XFqsbCXmkdAay4spVr2x0jYgRxrSNp+ePwvSsy9g6YSaNDcKIQVPXk1Ov8S2edk2g==
+  /@babel/helper-create-regexp-features-plugin/7.10.4_@babel+core@7.8.3:
+    dependencies:
+      '@babel/core': 7.8.3
+      '@babel/helper-annotate-as-pure': 7.10.4
+      '@babel/helper-regex': 7.10.4
+      regexpu-core: 4.7.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    resolution:
+      integrity: sha512-2/hu58IEPKeoLF45DBwx3XFqsbCXmkdAay4spVr2x0jYgRxrSNp+ePwvSsy9g6YSaNDcKIQVPXk1Ov8S2edk2g==
+  /@babel/helper-create-regexp-features-plugin/7.10.4_@babel+core@7.9.0:
+    dependencies:
+      '@babel/core': 7.9.0
+      '@babel/helper-annotate-as-pure': 7.10.4
+      '@babel/helper-regex': 7.10.4
+      regexpu-core: 4.7.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    resolution:
+      integrity: sha512-2/hu58IEPKeoLF45DBwx3XFqsbCXmkdAay4spVr2x0jYgRxrSNp+ePwvSsy9g6YSaNDcKIQVPXk1Ov8S2edk2g==
   /@babel/helper-create-regexp-features-plugin/7.8.8_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -683,6 +802,14 @@ packages:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-LYVPdwkrQEiX9+1R29Ld/wTrmQu1SSKYnuOk3g0CkcZMA1p0gsNxJFj/3gBdaJ7Cg0Fnek5z0DsMULePP7Lrqg==
+  /@babel/helper-define-map/7.10.4:
+    dependencies:
+      '@babel/helper-function-name': 7.10.4
+      '@babel/types': 7.10.4
+      lodash: 4.17.15
+    dev: true
+    resolution:
+      integrity: sha512-nIij0oKErfCnLUCWaCaHW0Bmtl2RO9cN7+u2QT8yqTywgALKlyUVOvHDElh+b5DwVC6YB1FOYFOTWcN/+41EDA==
   /@babel/helper-define-map/7.8.3:
     dependencies:
       '@babel/helper-function-name': 7.9.5
@@ -691,6 +818,13 @@ packages:
     dev: true
     resolution:
       integrity: sha512-PoeBYtxoZGtct3md6xZOCWPcKuMuk3IHhgxsRRNtnNShebf4C8YonTSblsK4tvDbm+eJAw2HAPOfCr+Q/YRG/g==
+  /@babel/helper-explode-assignable-expression/7.10.4:
+    dependencies:
+      '@babel/traverse': 7.10.4
+      '@babel/types': 7.10.4
+    dev: true
+    resolution:
+      integrity: sha512-4K71RyRQNPRrR85sr5QY4X3VwG4wtVoXZB9+L3r1Gp38DhELyHCtovqydRi7c1Ovb17eRGiQ/FD5s8JdU0Uy5A==
   /@babel/helper-explode-assignable-expression/7.8.3:
     dependencies:
       '@babel/traverse': 7.9.5
@@ -698,6 +832,14 @@ packages:
     dev: true
     resolution:
       integrity: sha512-N+8eW86/Kj147bO9G2uclsg5pwfs/fqqY5rwgIL7eTBklgXjcOJ3btzS5iM6AitJcftnY7pm2lGsrJVYLGjzIw==
+  /@babel/helper-function-name/7.10.4:
+    dependencies:
+      '@babel/helper-get-function-arity': 7.10.4
+      '@babel/template': 7.10.4
+      '@babel/types': 7.10.4
+    dev: true
+    resolution:
+      integrity: sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==
   /@babel/helper-function-name/7.9.5:
     dependencies:
       '@babel/helper-get-function-arity': 7.8.3
@@ -706,29 +848,65 @@ packages:
     dev: true
     resolution:
       integrity: sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==
+  /@babel/helper-get-function-arity/7.10.4:
+    dependencies:
+      '@babel/types': 7.10.4
+    dev: true
+    resolution:
+      integrity: sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==
   /@babel/helper-get-function-arity/7.8.3:
     dependencies:
       '@babel/types': 7.9.5
     dev: true
     resolution:
       integrity: sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==
+  /@babel/helper-hoist-variables/7.10.4:
+    dependencies:
+      '@babel/types': 7.10.4
+    dev: true
+    resolution:
+      integrity: sha512-wljroF5PgCk2juF69kanHVs6vrLwIPNp6DLD+Lrl3hoQ3PpPPikaDRNFA+0t81NOoMt2DL6WW/mdU8k4k6ZzuA==
   /@babel/helper-hoist-variables/7.8.3:
     dependencies:
       '@babel/types': 7.9.5
     dev: true
     resolution:
       integrity: sha512-ky1JLOjcDUtSc+xkt0xhYff7Z6ILTAHKmZLHPxAhOP0Nd77O+3nCsd6uSVYur6nJnCI029CrNbYlc0LoPfAPQg==
+  /@babel/helper-member-expression-to-functions/7.10.4:
+    dependencies:
+      '@babel/types': 7.10.4
+    dev: true
+    resolution:
+      integrity: sha512-m5j85pK/KZhuSdM/8cHUABQTAslV47OjfIB9Cc7P+PvlAoBzdb79BGNfw8RhT5Mq3p+xGd0ZfAKixbrUZx0C7A==
   /@babel/helper-member-expression-to-functions/7.8.3:
     dependencies:
       '@babel/types': 7.9.5
     dev: true
     resolution:
       integrity: sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==
+  /@babel/helper-module-imports/7.10.4:
+    dependencies:
+      '@babel/types': 7.10.4
+    dev: true
+    resolution:
+      integrity: sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==
   /@babel/helper-module-imports/7.8.3:
     dependencies:
       '@babel/types': 7.9.5
     resolution:
       integrity: sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==
+  /@babel/helper-module-transforms/7.10.4:
+    dependencies:
+      '@babel/helper-module-imports': 7.10.4
+      '@babel/helper-replace-supers': 7.10.4
+      '@babel/helper-simple-access': 7.10.4
+      '@babel/helper-split-export-declaration': 7.10.4
+      '@babel/template': 7.10.4
+      '@babel/types': 7.10.4
+      lodash: 4.17.15
+    dev: true
+    resolution:
+      integrity: sha512-Er2FQX0oa3nV7eM1o0tNCTx7izmQtwAQsIiaLRWtavAAEcskb0XJ5OjJbVrYXWOTr8om921Scabn4/tzlx7j1Q==
   /@babel/helper-module-transforms/7.9.0:
     dependencies:
       '@babel/helper-module-imports': 7.8.3
@@ -741,22 +919,48 @@ packages:
     dev: true
     resolution:
       integrity: sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==
+  /@babel/helper-optimise-call-expression/7.10.4:
+    dependencies:
+      '@babel/types': 7.10.4
+    dev: true
+    resolution:
+      integrity: sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==
   /@babel/helper-optimise-call-expression/7.8.3:
     dependencies:
       '@babel/types': 7.9.5
     dev: true
     resolution:
       integrity: sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==
+  /@babel/helper-plugin-utils/7.10.4:
+    dev: true
+    resolution:
+      integrity: sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==
   /@babel/helper-plugin-utils/7.8.3:
     dev: true
     resolution:
       integrity: sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==
+  /@babel/helper-regex/7.10.4:
+    dependencies:
+      lodash: 4.17.15
+    dev: true
+    resolution:
+      integrity: sha512-inWpnHGgtg5NOF0eyHlC0/74/VkdRITY9dtTpB2PrxKKn+AkVMRiZz/Adrx+Ssg+MLDesi2zohBW6MVq6b4pOQ==
   /@babel/helper-regex/7.8.3:
     dependencies:
       lodash: 4.17.15
     dev: true
     resolution:
       integrity: sha512-BWt0QtYv/cg/NecOAZMdcn/waj/5P26DR4mVLXfFtDokSR6fyuG0Pj+e2FqtSME+MqED1khnSMulkmGl8qWiUQ==
+  /@babel/helper-remap-async-to-generator/7.10.4:
+    dependencies:
+      '@babel/helper-annotate-as-pure': 7.10.4
+      '@babel/helper-wrap-function': 7.10.4
+      '@babel/template': 7.10.4
+      '@babel/traverse': 7.10.4
+      '@babel/types': 7.10.4
+    dev: true
+    resolution:
+      integrity: sha512-86Lsr6NNw3qTNl+TBcF1oRZMaVzJtbWTyTko+CQL/tvNvcGYEFKbLXDPxtW0HKk3McNOk4KzY55itGWCAGK5tg==
   /@babel/helper-remap-async-to-generator/7.8.3:
     dependencies:
       '@babel/helper-annotate-as-pure': 7.8.3
@@ -767,6 +971,15 @@ packages:
     dev: true
     resolution:
       integrity: sha512-kgwDmw4fCg7AVgS4DukQR/roGp+jP+XluJE5hsRZwxCYGg+Rv9wSGErDWhlI90FODdYfd4xG4AQRiMDjjN0GzA==
+  /@babel/helper-replace-supers/7.10.4:
+    dependencies:
+      '@babel/helper-member-expression-to-functions': 7.10.4
+      '@babel/helper-optimise-call-expression': 7.10.4
+      '@babel/traverse': 7.10.4
+      '@babel/types': 7.10.4
+    dev: true
+    resolution:
+      integrity: sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==
   /@babel/helper-replace-supers/7.8.6:
     dependencies:
       '@babel/helper-member-expression-to-functions': 7.8.3
@@ -776,6 +989,13 @@ packages:
     dev: true
     resolution:
       integrity: sha512-PeMArdA4Sv/Wf4zXwBKPqVj7n9UF/xg6slNRtZW84FM7JpE1CbG8B612FyM4cxrf4fMAMGO0kR7voy1ForHHFA==
+  /@babel/helper-simple-access/7.10.4:
+    dependencies:
+      '@babel/template': 7.10.4
+      '@babel/types': 7.10.4
+    dev: true
+    resolution:
+      integrity: sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==
   /@babel/helper-simple-access/7.8.3:
     dependencies:
       '@babel/template': 7.8.6
@@ -783,15 +1003,34 @@ packages:
     dev: true
     resolution:
       integrity: sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==
+  /@babel/helper-split-export-declaration/7.10.4:
+    dependencies:
+      '@babel/types': 7.10.4
+    dev: true
+    resolution:
+      integrity: sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==
   /@babel/helper-split-export-declaration/7.8.3:
     dependencies:
       '@babel/types': 7.9.5
     dev: true
     resolution:
       integrity: sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==
+  /@babel/helper-validator-identifier/7.10.4:
+    dev: true
+    resolution:
+      integrity: sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==
   /@babel/helper-validator-identifier/7.9.5:
     resolution:
       integrity: sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==
+  /@babel/helper-wrap-function/7.10.4:
+    dependencies:
+      '@babel/helper-function-name': 7.10.4
+      '@babel/template': 7.10.4
+      '@babel/traverse': 7.10.4
+      '@babel/types': 7.10.4
+    dev: true
+    resolution:
+      integrity: sha512-6py45WvEF0MhiLrdxtRjKjufwLL1/ob2qDJgg5JgNdojBAZSAKnAjkyOCNug6n+OBl4VW76XjvgSFTdaMcW0Ug==
   /@babel/helper-wrap-function/7.8.3:
     dependencies:
       '@babel/helper-function-name': 7.9.5
@@ -801,6 +1040,14 @@ packages:
     dev: true
     resolution:
       integrity: sha512-LACJrbUET9cQDzb6kG7EeD7+7doC3JNvUgTEQOx2qaO1fKlzE/Bf05qs9w1oXQMmXlPO65lC3Tq9S6gZpTErEQ==
+  /@babel/helpers/7.10.4:
+    dependencies:
+      '@babel/template': 7.10.4
+      '@babel/traverse': 7.10.4
+      '@babel/types': 7.10.4
+    dev: true
+    resolution:
+      integrity: sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==
   /@babel/helpers/7.9.2:
     dependencies:
       '@babel/template': 7.8.6
@@ -809,6 +1056,14 @@ packages:
     dev: true
     resolution:
       integrity: sha512-JwLvzlXVPjO8eU9c/wF9/zOIN7X6h8DYf7mG4CiFRZRvZNKEF5dQ3H3V+ASkHoIB3mWhatgl5ONhyqHRI6MppA==
+  /@babel/highlight/7.10.4:
+    dependencies:
+      '@babel/helper-validator-identifier': 7.10.4
+      chalk: 2.4.2
+      js-tokens: 4.0.0
+    dev: true
+    resolution:
+      integrity: sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==
   /@babel/highlight/7.9.0:
     dependencies:
       '@babel/helper-validator-identifier': 7.9.5
@@ -816,6 +1071,13 @@ packages:
       js-tokens: 4.0.0
     resolution:
       integrity: sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==
+  /@babel/parser/7.10.4:
+    dev: true
+    engines:
+      node: '>=6.0.0'
+    hasBin: true
+    resolution:
+      integrity: sha512-8jHII4hf+YVDsskTF6WuMB3X4Eh+PsUkC2ljq22so5rHvH+T8BzyL94VOdyFLNR8tBSVXOTbNHOKpR4TfRxVtA==
   /@babel/parser/7.9.4:
     dev: true
     engines:
@@ -832,6 +1094,17 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-mx0WXDDiIl5DwzMtzWGRSPugXi9BxROS05GQrhLNbEamhBiicgn994ibwkyiBH+6png7bm/yA7AUsvHyCXi4Vw==
+  /@babel/plugin-proposal-async-generator-functions/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-remap-async-to-generator': 7.10.4
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-MJbxGSmejEFVOANAezdO39SObkURO5o/8b6fSH6D1pi9RZQt+ldppKPXfqgUWpSQ9asM6xaSaSJIaeWMDRP0Zg==
   /@babel/plugin-proposal-async-generator-functions/7.8.3_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -854,6 +1127,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-NZ9zLv848JsV3hs8ryEh7Uaz/0KsmPLqv0+PdkDJL1cJy0K4kOCFa8zc1E3mp+RHPQcpdfb/6GovEsW4VDrOMw==
+  /@babel/plugin-proposal-class-properties/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-create-class-features-plugin': 7.10.4_@babel+core@7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-vhwkEROxzcHGNu2mzUC0OFFNXdZ4M23ib8aRRcJSsW8BZK9pQMD7QB7csl97NBbgGZO7ZyHUyKDnxzOaP4IrCg==
   /@babel/plugin-proposal-decorators/7.8.3_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -865,6 +1148,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-e3RvdvS4qPJVTe288DlXjwKflpfy1hr0j5dz5WpIYYeP7vQZg2WfAEIp8k5/Lwis/m5REXEteIz6rrcDtXXG7w==
+  /@babel/plugin-proposal-dynamic-import/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-up6oID1LeidOOASNXgv/CFbgBqTuKJ0cJjz6An5tWD+NVBNlp3VNSBxv2ZdU7SYl3NxJC7agAQDApZusV6uFwQ==
   /@babel/plugin-proposal-dynamic-import/7.8.3_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -885,6 +1178,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-NyaBbyLFXFLT9FP+zk0kYlUlA8XtCUbehs67F0nnEg7KICgMc2mNkIeu9TYhKzyXMkrapZFwAhXLdnt4IYHy1w==
+  /@babel/plugin-proposal-json-strings/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-fCL7QF0Jo83uy1K0P2YXrfX11tj3lkpN7l4dMv9Y9VkowkhkQDwFHFd8IiwyK5MZjE8UpbgokkgtcReH88Abaw==
   /@babel/plugin-proposal-json-strings/7.8.3_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -905,6 +1208,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-KGhQNZ3TVCQG/MjRbAUwuH+14y9q0tpxs1nWWs3pbSleRdDro9SAMMDyye8HhY1gqZ7/NqIc8SKhya0wRDgP1Q==
+  /@babel/plugin-proposal-nullish-coalescing-operator/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-wq5n1M3ZUlHl9sqT2ok1T2/MTt6AXE0e1Lz4WzWBr95LsAZ5qDXe4KnFuauYyEyLiohvXFMdbsOTMyLZs91Zlw==
   /@babel/plugin-proposal-nullish-coalescing-operator/7.8.3_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -925,6 +1238,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-TS9MlfzXpXKt6YYomudb/KU7nQI6/xnapG6in1uZxoxDghuSMZsPb6D2fyUwNYSAp4l1iR7QtFOjkqcRYcUsfw==
+  /@babel/plugin-proposal-numeric-separator/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-73/G7QoRoeNkLZFxsoCCvlg4ezE4eM+57PnOqgaPOozd5myfj7p0muD1mRVJvbUWbOzD+q3No2bWbaKy+DJ8DA==
   /@babel/plugin-proposal-numeric-separator/7.8.3_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -945,6 +1268,17 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-jWioO1s6R/R+wEHizfaScNsAx+xKgwTLNXSh7tTC4Usj3ItsPEhYkEpU4h+lpnBwq7NBVOJXfO6cRFYcX69JUQ==
+  /@babel/plugin-proposal-object-rest-spread/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.10.4
+      '@babel/plugin-transform-parameters': 7.10.4_@babel+core@7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-6vh4SqRuLLarjgeOf4EaROJAHjvu9Gl+/346PbDH9yWbJyfnJ/ah3jmYKYtswEyCoWZiidvVHjHshd4WgjB9BA==
   /@babel/plugin-proposal-object-rest-spread/7.9.5_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -967,6 +1301,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-VP2oXvAf7KCYTthbUHwBlewbl1Iq059f6seJGsxMizaCdgHIeczOr7FBqELhSqfkIl04Fi8okzWzl63UKbQmmg==
+  /@babel/plugin-proposal-optional-catch-binding/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-LflT6nPh+GK2MnFiKDyLiqSqVHkQnVf7hdoAvyTnnKj9xB3docGRsdPuxp6qqqW19ifK3xgc9U5/FwrSaCNX5g==
   /@babel/plugin-proposal-optional-catch-binding/7.8.3_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -987,6 +1331,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-0gkX7J7E+AtAw9fcwlVQj8peP61qhdg/89D5swOkjYbkboA2CVckn3kiyum1DE0wskGb7KJJxBdyEBApDLLVdw==
+  /@babel/plugin-proposal-optional-chaining/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-ZIhQIEeavTgouyMSdZRap4VPPHqJJ3NEs2cuHs5p0erH+iz6khB0qfgU8g7UuJkG88+fBMy23ZiU+nuHvekJeQ==
   /@babel/plugin-proposal-optional-chaining/7.9.0_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -1007,6 +1361,52 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-NDn5tu3tcv4W30jNhmc2hyD5c56G6cXx4TesJubhxrJeCvuuMpttxr0OnNCqbZGhFjLrg+NIhxxC+BK5F6yS3w==
+  /@babel/plugin-proposal-private-methods/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-create-class-features-plugin': 7.10.4_@babel+core@7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-wh5GJleuI8k3emgTg5KkJK6kHNsGEr0uBTDBuQUBJwckk9xs1ez79ioheEVVxMLyPscB0LfkbVHslQqIzWV6Bw==
+  /@babel/plugin-proposal-unicode-property-regex/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-create-regexp-features-plugin': 7.10.4_@babel+core@7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    engines:
+      node: '>=4'
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-H+3fOgPnEXFL9zGYtKQe4IDOPKYlZdF1kqFDQRRb8PK4B8af1vAGK04tF5iQAAsui+mHNBQSAtd2/ndEDe9wuA==
+  /@babel/plugin-proposal-unicode-property-regex/7.10.4_@babel+core@7.8.3:
+    dependencies:
+      '@babel/core': 7.8.3
+      '@babel/helper-create-regexp-features-plugin': 7.10.4_@babel+core@7.8.3
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    engines:
+      node: '>=4'
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-H+3fOgPnEXFL9zGYtKQe4IDOPKYlZdF1kqFDQRRb8PK4B8af1vAGK04tF5iQAAsui+mHNBQSAtd2/ndEDe9wuA==
+  /@babel/plugin-proposal-unicode-property-regex/7.10.4_@babel+core@7.9.0:
+    dependencies:
+      '@babel/core': 7.9.0
+      '@babel/helper-create-regexp-features-plugin': 7.10.4_@babel+core@7.9.0
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    engines:
+      node: '>=4'
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-H+3fOgPnEXFL9zGYtKQe4IDOPKYlZdF1kqFDQRRb8PK4B8af1vAGK04tF5iQAAsui+mHNBQSAtd2/ndEDe9wuA==
   /@babel/plugin-proposal-unicode-property-regex/7.8.8_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -1031,10 +1431,19 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-EVhjVsMpbhLw9ZfHWSx2iy13Q8Z/eg8e8ccVWt23sWQK5l1UdkoLJPN5w69UA4uITGBnEZD2JOe4QOHycYKv8A==
+  /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==
   /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
-      '@babel/helper-plugin-utils': 7.8.3
+      '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1043,12 +1452,21 @@ packages:
   /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.8.3
+      '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==
+  /@babel/plugin-syntax-class-properties/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-GCSBF7iUle6rNugfURwNmCGG3Z/2+opxAMLs1nND4bhEG5PuxTIggDBoeYYSujAlLtsupzOHYJQgPS3pivwXIA==
   /@babel/plugin-syntax-decorators/7.8.3_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -1058,6 +1476,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-8Hg4dNNT9/LcA1zQlfwuKR8BUc/if7Q7NkTam9sGTcJphLwpf2g4S42uhspQrIrR+dpzE0dtTqBVFoHl8GtnnQ==
+  /@babel/plugin-syntax-dynamic-import/7.8.3_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-plugin-utils': 7.8.3
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==
   /@babel/plugin-syntax-dynamic-import/7.8.3_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -1076,10 +1503,19 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==
+  /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==
   /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
-      '@babel/helper-plugin-utils': 7.8.3
+      '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1088,16 +1524,25 @@ packages:
   /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.8.3
+      '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==
+  /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==
   /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
-      '@babel/helper-plugin-utils': 7.8.3
+      '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1106,12 +1551,21 @@ packages:
   /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.8.3
+      '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==
+  /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==
   /@babel/plugin-syntax-numeric-separator/7.8.3_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -1130,10 +1584,19 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-H7dCMAdN83PcCmqmkHB5dtp+Xa9a6LKSvA2hiFBC/5alSHxM5VgWZXFqDi0YFe8XNGT6iCa+z4V4zSt/PdZ7Dw==
+  /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==
   /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
-      '@babel/helper-plugin-utils': 7.8.3
+      '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1142,16 +1605,25 @@ packages:
   /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.8.3
+      '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==
+  /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==
   /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
-      '@babel/helper-plugin-utils': 7.8.3
+      '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1160,16 +1632,25 @@ packages:
   /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.8.3
+      '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==
+  /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==
   /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
-      '@babel/helper-plugin-utils': 7.8.3
+      '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1178,12 +1659,21 @@ packages:
   /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.8.3
+      '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==
+  /@babel/plugin-syntax-top-level-await/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-ni1brg4lXEmWyafKr0ccFWkJG0CeMt4WV1oyeBW6EFObF4oOHclbkj5cARxAPQyAQ2UTuplJyK4nfkXIMMFvsQ==
   /@babel/plugin-syntax-top-level-await/7.8.3_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -1202,6 +1692,24 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-kwj1j9lL/6Wd0hROD3b/OZZ7MSrZLqqn9RAZ5+cYYsflQ9HZBIKCUkr3+uL1MEJ1NePiUbf98jjiMQSv0NMR9g==
+  /@babel/plugin-syntax-typescript/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-oSAEz1YkBCAKr5Yiq8/BNtvSAPwkp/IyUnwZogd8p+F0RuYQQrLeRUzIQhueQTTBy/F+a40uS7OFKxnkRvmvFQ==
+  /@babel/plugin-transform-arrow-functions/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-9J/oD1jV0ZCBcgnoFWFq1vJd4msoKb/TCpGNFyyLt0zABdcvgK3aYikZ8HjzB14c26bc7E3Q1yugpwGy2aTPNA==
   /@babel/plugin-transform-arrow-functions/7.8.3_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -1220,6 +1728,17 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-0MRF+KC8EqH4dbuITCWwPSzsyO3HIWWlm30v8BbbpOrS1B++isGxPnnuq/IZvOX5J2D/p7DQalQm+/2PnlKGxg==
+  /@babel/plugin-transform-async-to-generator/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-module-imports': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-remap-async-to-generator': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-F6nREOan7J5UXTLsDsZG3DXmZSVofr2tGNwfdrVwkDWHfQckbQXnXSPfD7iO+c/2HGqycwyLST3DnZ16n+cBJQ==
   /@babel/plugin-transform-async-to-generator/7.8.3_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -1242,6 +1761,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-imt9tFLD9ogt56Dd5CI/6XgpukMwd/fLGSrix2httihVe7LOGVPhyhMh1BU5kDM7iHD08i8uUtmV2sWaBFlHVQ==
+  /@babel/plugin-transform-block-scoped-functions/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-WzXDarQXYYfjaV1szJvN3AD7rZgZzC1JtjJZ8dMHUyiK8mxPRahynp14zzNjU3VkPqPsO38CzxiWO1c9ARZ8JA==
   /@babel/plugin-transform-block-scoped-functions/7.8.3_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -1260,6 +1788,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-vo4F2OewqjbB1+yaJ7k2EJFHlTP3jR634Z9Cj9itpqNjuLXvhlVxgnjsHsdRgASR8xYDrx6onw4vW5H6We0Jmg==
+  /@babel/plugin-transform-block-scoping/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+      lodash: 4.17.15
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-J3b5CluMg3hPUii2onJDRiaVbPtKFPLEaV5dOPY5OeAbDi1iU/UbbFFTgwb7WnanaDy7bjU35kc26W3eM5Qa0A==
   /@babel/plugin-transform-block-scoping/7.8.3_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -1280,6 +1818,22 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-pGnYfm7RNRgYRi7bids5bHluENHqJhrV4bCZRwc5GamaWIIs07N4rZECcmJL6ZClwjDz1GbdMZFtPs27hTB06w==
+  /@babel/plugin-transform-classes/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-annotate-as-pure': 7.10.4
+      '@babel/helper-define-map': 7.10.4
+      '@babel/helper-function-name': 7.10.4
+      '@babel/helper-optimise-call-expression': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-replace-supers': 7.10.4
+      '@babel/helper-split-export-declaration': 7.10.4
+      globals: 11.12.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-2oZ9qLjt161dn1ZE0Ms66xBncQH4In8Sqw1YWgBUZuGVJJS5c0OFZXL6dP2MRHrkU/eKhWg8CzFJhRQl50rQxA==
   /@babel/plugin-transform-classes/7.9.5_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -1312,6 +1866,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-x2kZoIuLC//O5iA7PEvecB105o7TLzZo8ofBVhP79N+DO3jaX+KYfww9TQcfBEZD0nikNyYcGB1IKtRq36rdmg==
+  /@babel/plugin-transform-computed-properties/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-JFwVDXcP/hM/TbyzGq3l/XWGut7p46Z3QvqFMXTfk6/09m7xZHJUN9xHfsv7vqqD4YnfI5ueYdSJtXqqBLyjBw==
   /@babel/plugin-transform-computed-properties/7.8.3_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -1330,6 +1893,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-O5hiIpSyOGdrQZRQ2ccwtTVkgUDBBiCuK//4RJ6UfePllUTCENOzKxfh6ulckXKc0DixTFLCfb2HVkNA7aDpzA==
+  /@babel/plugin-transform-destructuring/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-+WmfvyfsyF603iPa6825mq6Qrb7uLjTOsa3XOFzlYcYDHSS4QmpOWOL0NNBY5qMbvrcf3tq0Cw+v4lxswOBpgA==
   /@babel/plugin-transform-destructuring/7.9.5_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -1348,6 +1920,36 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-j3OEsGel8nHL/iusv/mRd5fYZ3DrOxWC82x0ogmdN/vHfAP4MYw+AFKYanzWlktNwikKvlzUV//afBW5FTp17Q==
+  /@babel/plugin-transform-dotall-regex/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-create-regexp-features-plugin': 7.10.4_@babel+core@7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-ZEAVvUTCMlMFAbASYSVQoxIbHm2OkG2MseW6bV2JjIygOjdVv8tuxrCTzj1+Rynh7ODb8GivUy7dzEXzEhuPaA==
+  /@babel/plugin-transform-dotall-regex/7.10.4_@babel+core@7.8.3:
+    dependencies:
+      '@babel/core': 7.8.3
+      '@babel/helper-create-regexp-features-plugin': 7.10.4_@babel+core@7.8.3
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-ZEAVvUTCMlMFAbASYSVQoxIbHm2OkG2MseW6bV2JjIygOjdVv8tuxrCTzj1+Rynh7ODb8GivUy7dzEXzEhuPaA==
+  /@babel/plugin-transform-dotall-regex/7.10.4_@babel+core@7.9.0:
+    dependencies:
+      '@babel/core': 7.9.0
+      '@babel/helper-create-regexp-features-plugin': 7.10.4_@babel+core@7.9.0
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-ZEAVvUTCMlMFAbASYSVQoxIbHm2OkG2MseW6bV2JjIygOjdVv8tuxrCTzj1+Rynh7ODb8GivUy7dzEXzEhuPaA==
   /@babel/plugin-transform-dotall-regex/7.8.3_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -1368,6 +1970,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-kLs1j9Nn4MQoBYdRXH6AeaXMbEJFaFu/v1nQkvib6QzTj8MZI5OQzqmD83/2jEM1z0DLilra5aWO5YpyC0ALIw==
+  /@babel/plugin-transform-duplicate-keys/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-GL0/fJnmgMclHiBTTWXNlYjYsA7rDrtsazHG6mglaGSTh0KsrW04qml+Bbz9FL0LcJIRwBWL5ZqlNHKTkU3xAA==
   /@babel/plugin-transform-duplicate-keys/7.8.3_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -1386,6 +1997,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-s8dHiBUbcbSgipS4SMFuWGqCvyge5V2ZeAWzR6INTVC3Ltjig/Vw1G2Gztv0vU/hRG9X8IvKvYdoksnUfgXOEQ==
+  /@babel/plugin-transform-exponentiation-operator/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-builder-binary-assignment-operator-visitor': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-S5HgLVgkBcRdyQAHbKj+7KyuWx8C6t5oETmUuwz1pt3WTWJhsUV0WIIXuVvfXMxl/QQyHKlSCNNtaIamG8fysw==
   /@babel/plugin-transform-exponentiation-operator/7.8.3_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -1406,6 +2027,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-zwIpuIymb3ACcInbksHaNcR12S++0MDLKkiqXHl3AzpgdKlFNhog+z/K0+TGW+b0w5pgTq4H6IwV/WhxbGYSjQ==
+  /@babel/plugin-transform-for-of/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-ItdQfAzu9AlEqmusA/65TqJ79eRcgGmpPPFvBnGILXZH975G0LNjP1yjHvGgfuCxqrPPueXOPe+FsvxmxKiHHQ==
   /@babel/plugin-transform-for-of/7.9.0_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -1424,6 +2054,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-lTAnWOpMwOXpyDx06N+ywmF3jNbafZEqZ96CGYabxHrxNX8l5ny7dt4bK/rGwAh9utyP2b2Hv7PlZh1AAS54FQ==
+  /@babel/plugin-transform-function-name/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-function-name': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-OcDCq2y5+E0dVD5MagT5X+yTRbcvFjDI2ZVAottGH6tzqjx/LKpgkUepu3hp/u4tZBzxxpNGwLsAvGBvQ2mJzg==
   /@babel/plugin-transform-function-name/7.8.3_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -1444,6 +2084,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-rO/OnDS78Eifbjn5Py9v8y0aR+aSYhDhqAwVfsTl0ERuMZyr05L1aFSCJnbv2mmsLkit/4ReeQ9N2BgLnOcPCQ==
+  /@babel/plugin-transform-literals/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-Xd/dFSTEVuUWnyZiMu76/InZxLTYilOSr1UlHV+p115Z/Le2Fi1KXkJUYz0b42DfndostYlPub3m8ZTQlMaiqQ==
   /@babel/plugin-transform-literals/7.8.3_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -1462,6 +2111,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-3Tqf8JJ/qB7TeldGl+TT55+uQei9JfYaregDcEAyBZ7akutriFrt6C/wLYIer6OYhleVQvH/ntEhjE/xMmy10A==
+  /@babel/plugin-transform-member-expression-literals/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-0bFOvPyAoTBhtcJLr9VcwZqKmSjFml1iVxvPL0ReomGU53CX53HsM4h2SzckNdkQcHox1bpAqzxBI1Y09LlBSw==
   /@babel/plugin-transform-member-expression-literals/7.8.3_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -1480,6 +2138,17 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-3Wk2EXhnw+rP+IDkK6BdtPKsUE5IeZ6QOGrPYvw52NwBStw9V1ZVzxgK6fSKSxqUvH9eQPR3tm3cOq79HlsKYA==
+  /@babel/plugin-transform-modules-amd/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-module-transforms': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+      babel-plugin-dynamic-import-node: 2.3.3
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-3Fw+H3WLUrTlzi3zMiZWp3AR4xadAEMv6XRCYnd5jAlLM61Rn+CRJaZMaNvIpcJpQ3vs1kyifYvEVPFfoSkKOA==
   /@babel/plugin-transform-modules-amd/7.9.0_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -1502,6 +2171,18 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-vZgDDF003B14O8zJy0XXLnPH4sg+9X5hFBBGN1V+B2rgrB+J2xIypSN6Rk9imB2hSTHQi5OHLrFWsZab1GMk+Q==
+  /@babel/plugin-transform-modules-commonjs/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-module-transforms': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-simple-access': 7.10.4
+      babel-plugin-dynamic-import-node: 2.3.3
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-Xj7Uq5o80HDLlW64rVfDBhao6OX89HKUmb+9vWYaLXBZOma4gA6tw4Ni1O5qVDoZWUV0fxMYA0aYzOawz0l+1w==
   /@babel/plugin-transform-modules-commonjs/7.9.0_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -1526,6 +2207,18 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-qzlCrLnKqio4SlgJ6FMMLBe4bySNis8DFn1VkGmOcxG9gqEyPIOzeQrA//u0HAKrWpJlpZbZMPB1n/OPa4+n8g==
+  /@babel/plugin-transform-modules-systemjs/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-hoist-variables': 7.10.4
+      '@babel/helper-module-transforms': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+      babel-plugin-dynamic-import-node: 2.3.3
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-Tb28LlfxrTiOTGtZFsvkjpyjCl9IoaRI52AEU/VIwOwvDQWtbNJsAqTXzh+5R7i74e/OZHH2c2w2fsOqAfnQYQ==
   /@babel/plugin-transform-modules-systemjs/7.9.0_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -1550,6 +2243,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-FsiAv/nao/ud2ZWy4wFacoLOm5uxl0ExSQ7ErvP7jpoihLR6Cq90ilOFyX9UXct3rbtKsAiZ9kFt5XGfPe/5SQ==
+  /@babel/plugin-transform-modules-umd/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-module-transforms': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-mohW5q3uAEt8T45YT7Qc5ws6mWgJAaL/8BfWD9Dodo1A3RKWli8wTS+WiQ/knF+tXlPirW/1/MqzzGfCExKECA==
   /@babel/plugin-transform-modules-umd/7.9.0_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -1570,6 +2273,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-uTWkXkIVtg/JGRSIABdBoMsoIeoHQHPTL0Y2E7xf5Oj7sLqwVsNXOkNk0VJc7vF0IMBsPeikHxFjGe+qmwPtTQ==
+  /@babel/plugin-transform-named-capturing-groups-regex/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-create-regexp-features-plugin': 7.10.4_@babel+core@7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    resolution:
+      integrity: sha512-V6LuOnD31kTkxQPhKiVYzYC/Jgdq53irJC/xBSmqcNcqFGV+PER4l6rU5SH2Vl7bH9mLDHcc0+l9HUOe4RNGKA==
   /@babel/plugin-transform-named-capturing-groups-regex/7.8.3_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -1588,6 +2300,15 @@ packages:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-f+tF/8UVPU86TrCb06JoPWIdDpTNSGGcAtaD9mLP0aYGA0OS0j7j7DHJR0GTFrUZPUU6loZhbsVZgTh0N+Qdnw==
+  /@babel/plugin-transform-new-target/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-YXwWUDAH/J6dlfwqlWsztI2Puz1NtUAubXhOPLQ5gjR/qmQ5U96DY4FQO8At33JN4XPBhrjB8I4eMmLROjjLjw==
   /@babel/plugin-transform-new-target/7.8.3_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -1606,6 +2327,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-QuSGysibQpyxexRyui2vca+Cmbljo8bcRckgzYV4kRIsHpVeyeC3JDO63pY+xFZ6bWOBn7pfKZTqV4o/ix9sFw==
+  /@babel/plugin-transform-object-super/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-replace-supers': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-5iTw0JkdRdJvr7sY0vHqTpnruUpTea32JHmq/atIWqsnNussbRzjEDyWep8UNztt1B5IusBYg8Irb0bLbiEBCQ==
   /@babel/plugin-transform-object-super/7.8.3_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -1626,6 +2357,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-57FXk+gItG/GejofIyLIgBKTas4+pEU47IXKDBWFTxdPd7F80H8zybyAY7UoblVfBhBGs2EKM+bJUu2+iUYPDQ==
+  /@babel/plugin-transform-parameters/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-get-function-arity': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-RurVtZ/D5nYfEg0iVERXYKEgDFeesHrHfx8RT05Sq57ucj2eOYAP6eu5fynL4Adju4I/mP/I6SO0DqNWAXjfLQ==
   /@babel/plugin-transform-parameters/7.9.5_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -1646,6 +2387,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-0+1FhHnMfj6lIIhVvS4KGQJeuhe1GI//h5uptK4PvLt+BGBxsoUJbd3/IW002yk//6sZPlFgsG1hY6OHLcy6kA==
+  /@babel/plugin-transform-property-literals/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-ofsAcKiUxQ8TY4sScgsGeR2vJIsfrzqvFb9GvJ5UdXDzl+MyYCaBj/FGzXuv7qE0aJcjWMILny1epqelnFlz8g==
   /@babel/plugin-transform-property-literals/7.8.3_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -1664,6 +2414,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-uGiiXAZMqEoQhRWMK17VospMZh5sXWg+dlh2soffpkAl96KAm+WZuJfa6lcELotSRmooLqg0MWdH6UUq85nmmg==
+  /@babel/plugin-transform-regenerator/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      regenerator-transform: 0.14.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-3thAHwtor39A7C04XucbMg17RcZ3Qppfxr22wYzZNcVIkPHfpM9J0SO8zuCV6SZa265kxBJSrfKTvDCYqBFXGw==
   /@babel/plugin-transform-regenerator/7.8.7_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -1682,6 +2441,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-TIg+gAl4Z0a3WmD3mbYSk+J9ZUH6n/Yc57rtKRnlA/7rcCvpekHXe0CMZHP1gYp7/KLe9GHTuIba0vXmls6drA==
+  /@babel/plugin-transform-reserved-words/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-hGsw1O6Rew1fkFbDImZIEqA8GoidwTAilwCyWqLBM9f+e/u/sQMQu7uX6dyokfOayRuuVfKOW4O7HvaBWM+JlQ==
   /@babel/plugin-transform-reserved-words/7.8.3_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -1712,6 +2480,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-pUu9VSf3kI1OqbWINQ7MaugnitRss1z533436waNXp+0N3ur3zfut37sXiQMxkuCF4VUjwZucen/quskCh7NHw==
+  /@babel/plugin-transform-shorthand-properties/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-AC2K/t7o07KeTIxMoHneyX90v3zkm5cjHJEokrPEAGEy3UCp8sLKfnfOIGdZ194fyN4wfX/zZUWT9trJZ0qc+Q==
   /@babel/plugin-transform-shorthand-properties/7.8.3_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -1730,6 +2507,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-I9DI6Odg0JJwxCHzbzW08ggMdCezoWcuQRz3ptdudgwaHxTjxw5HgdFJmZIkIMlRymL6YiZcped4TTCB0JcC8w==
+  /@babel/plugin-transform-spread/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-1e/51G/Ni+7uH5gktbWv+eCED9pP8ZpRhZB3jOaI3mmzfvJTWHkuyYTv0Z5PYtyM+Tr2Ccr9kUdQxn60fI5WuQ==
   /@babel/plugin-transform-spread/7.8.3_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -1748,6 +2534,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-CkuTU9mbmAoFOI1tklFWYYbzX5qCIZVXPVy0jpXgGwkplCndQAa58s2jr66fTeQnA64bDox0HL4U56CFYoyC7g==
+  /@babel/plugin-transform-sticky-regex/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-regex': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-Ddy3QZfIbEV0VYcVtFDCjeE4xwVTJWTmUtorAJkn6u/92Z/nWJNV+mILyqHKrUxXYKA2EoCilgoPePymKL4DvQ==
   /@babel/plugin-transform-sticky-regex/7.8.3_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -1768,6 +2564,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-9Spq0vGCD5Bb4Z/ZXXSK5wbbLFMG085qd2vhL1JYu1WcQ5bXqZBAYRzU1d+p79GcHs2szYv5pVQCX13QgldaWw==
+  /@babel/plugin-transform-template-literals/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-annotate-as-pure': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-4NErciJkAYe+xI5cqfS8pV/0ntlY5N5Ske/4ImxAVX7mk9Rxt2bwDTGv1Msc2BRJvWQcmYEC+yoMLdX22aE4VQ==
   /@babel/plugin-transform-template-literals/7.8.3_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -1788,6 +2594,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-820QBtykIQOLFT8NZOcTRJ1UNuztIELe4p9DCgvj4NK+PwluSJ49we7s9FB1HIGNIYT7wFUJ0ar2QpCDj0escQ==
+  /@babel/plugin-transform-typeof-symbol/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-QqNgYwuuW0y0H+kUE/GWSR45t/ccRhe14Fs/4ZRouNNQsyd4o3PG4OtHiIrepbM2WKUBDAXKCAK/Lk4VhzTaGA==
   /@babel/plugin-transform-typeof-symbol/7.8.4_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -1806,6 +2621,36 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-2QKyfjGdvuNfHsb7qnBBlKclbD4CfshH2KvDabiijLMGXPHJXGxtDzwIF7bQP+T0ysw8fYTtxPafgfs/c1Lrqg==
+  /@babel/plugin-transform-typescript/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-create-class-features-plugin': 7.10.4_@babel+core@7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-typescript': 7.10.4_@babel+core@7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-3WpXIKDJl/MHoAN0fNkSr7iHdUMHZoppXjf2HJ9/ed5Xht5wNIsXllJXdityKOxeA3Z8heYRb1D3p2H5rfCdPw==
+  /@babel/plugin-transform-unicode-escapes/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-y5XJ9waMti2J+e7ij20e+aH+fho7Wb7W8rNuu72aKRwCHFqQdhkdU2lo3uZ9tQuboEJcUFayXdARhcxLQ3+6Fg==
+  /@babel/plugin-transform-unicode-regex/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-create-regexp-features-plugin': 7.10.4_@babel+core@7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-wNfsc4s8N2qnIwpO/WP2ZiSyjfpTamT2C9V9FDH/Ljub9zw6P3SjkXcFmc0RQUt96k2fmIvtla2MMjgTwIAC+A==
   /@babel/plugin-transform-unicode-regex/7.8.3_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
@@ -1826,6 +2671,78 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-+ufgJjYdmWfSQ+6NS9VGUR2ns8cjJjYbrbi11mZBTaWm+Fui/ncTLFF28Ei1okavY+xkojGr1eJxNsWYeA5aZw==
+  /@babel/preset-env/7.10.4_@babel+core@7.10.4:
+    dependencies:
+      '@babel/compat-data': 7.10.4
+      '@babel/core': 7.10.4
+      '@babel/helper-compilation-targets': 7.10.4_@babel+core@7.10.4
+      '@babel/helper-module-imports': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-proposal-async-generator-functions': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-proposal-class-properties': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-proposal-dynamic-import': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-proposal-json-strings': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-proposal-numeric-separator': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-proposal-object-rest-spread': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-proposal-optional-catch-binding': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-proposal-optional-chaining': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-proposal-private-methods': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-proposal-unicode-property-regex': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.10.4
+      '@babel/plugin-syntax-class-properties': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.10.4
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.10.4
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.10.4
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.10.4
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.10.4
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.10.4
+      '@babel/plugin-syntax-top-level-await': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-transform-arrow-functions': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-transform-async-to-generator': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-transform-block-scoped-functions': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-transform-block-scoping': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-transform-classes': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-transform-computed-properties': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-transform-destructuring': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-transform-dotall-regex': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-transform-duplicate-keys': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-transform-exponentiation-operator': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-transform-for-of': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-transform-function-name': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-transform-literals': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-transform-member-expression-literals': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-transform-modules-amd': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-transform-modules-commonjs': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-transform-modules-systemjs': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-transform-modules-umd': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-transform-new-target': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-transform-object-super': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-transform-parameters': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-transform-property-literals': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-transform-regenerator': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-transform-reserved-words': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-transform-shorthand-properties': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-transform-spread': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-transform-sticky-regex': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-transform-template-literals': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-transform-typeof-symbol': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-transform-unicode-escapes': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-transform-unicode-regex': 7.10.4_@babel+core@7.10.4
+      '@babel/preset-modules': 0.1.3_@babel+core@7.10.4
+      '@babel/types': 7.10.4
+      browserslist: 4.12.0
+      core-js-compat: 3.6.5
+      invariant: 2.2.4
+      levenary: 1.1.1
+      semver: 5.7.1
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-tcmuQ6vupfMZPrLrc38d0sF2OjLT3/bZ0dry5HchNCQbrokoQi4reXqclvkkAT5b+gWc23meVWpve5P/7+w/zw==
   /@babel/preset-env/7.9.5_@babel+core@7.8.3:
     dependencies:
       '@babel/compat-data': 7.9.0
@@ -1962,13 +2879,26 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-eWGYeADTlPJH+wq1F0wNfPbVS1w1wtmMJiYk55Td5Yu28AsdR9AsC97sZ0Qq8fHqQuslVSIYSGJMcblr345GfQ==
+  /@babel/preset-modules/0.1.3_@babel+core@7.10.4:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-proposal-unicode-property-regex': 7.10.4_@babel+core@7.10.4
+      '@babel/plugin-transform-dotall-regex': 7.10.4_@babel+core@7.10.4
+      '@babel/types': 7.10.4
+      esutils: 2.0.3
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-Ra3JXOHBq2xd56xSF7lMKXdjBn3T772Y1Wet3yWnkDly9zHvJki029tAFzvAAK5cf4YV3yoxuP61crYRol6SVg==
   /@babel/preset-modules/0.1.3_@babel+core@7.8.3:
     dependencies:
       '@babel/core': 7.8.3
-      '@babel/helper-plugin-utils': 7.8.3
-      '@babel/plugin-proposal-unicode-property-regex': 7.8.8_@babel+core@7.8.3
-      '@babel/plugin-transform-dotall-regex': 7.8.3_@babel+core@7.8.3
-      '@babel/types': 7.9.5
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-proposal-unicode-property-regex': 7.10.4_@babel+core@7.8.3
+      '@babel/plugin-transform-dotall-regex': 7.10.4_@babel+core@7.8.3
+      '@babel/types': 7.10.4
       esutils: 2.0.3
     dev: true
     peerDependencies:
@@ -1978,10 +2908,10 @@ packages:
   /@babel/preset-modules/0.1.3_@babel+core@7.9.0:
     dependencies:
       '@babel/core': 7.9.0
-      '@babel/helper-plugin-utils': 7.8.3
-      '@babel/plugin-proposal-unicode-property-regex': 7.8.8_@babel+core@7.9.0
-      '@babel/plugin-transform-dotall-regex': 7.8.3_@babel+core@7.9.0
-      '@babel/types': 7.9.5
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-proposal-unicode-property-regex': 7.10.4_@babel+core@7.9.0
+      '@babel/plugin-transform-dotall-regex': 7.10.4_@babel+core@7.9.0
+      '@babel/types': 7.10.4
       esutils: 2.0.3
     dev: true
     peerDependencies:
@@ -2007,6 +2937,14 @@ packages:
     dev: true
     resolution:
       integrity: sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==
+  /@babel/template/7.10.4:
+    dependencies:
+      '@babel/code-frame': 7.10.4
+      '@babel/parser': 7.10.4
+      '@babel/types': 7.10.4
+    dev: true
+    resolution:
+      integrity: sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==
   /@babel/template/7.8.6:
     dependencies:
       '@babel/code-frame': 7.8.3
@@ -2015,6 +2953,20 @@ packages:
     dev: true
     resolution:
       integrity: sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==
+  /@babel/traverse/7.10.4:
+    dependencies:
+      '@babel/code-frame': 7.10.4
+      '@babel/generator': 7.10.4
+      '@babel/helper-function-name': 7.10.4
+      '@babel/helper-split-export-declaration': 7.10.4
+      '@babel/parser': 7.10.4
+      '@babel/types': 7.10.4
+      debug: 4.1.1
+      globals: 11.12.0
+      lodash: 4.17.15
+    dev: true
+    resolution:
+      integrity: sha512-aSy7p5THgSYm4YyxNGz6jZpXf+Ok40QF3aA2LyIONkDHpAcJzDUqlCKXv6peqYUs2gmic849C/t2HKw2a2K20Q==
   /@babel/traverse/7.9.5:
     dependencies:
       '@babel/code-frame': 7.8.3
@@ -2029,6 +2981,14 @@ packages:
     dev: true
     resolution:
       integrity: sha512-c4gH3jsvSuGUezlP6rzSJ6jf8fYjLj3hsMZRx/nX0h+fmHN0w+ekubRrHPqnMec0meycA2nwCsJ7dC8IPem2FQ==
+  /@babel/types/7.10.4:
+    dependencies:
+      '@babel/helper-validator-identifier': 7.10.4
+      lodash: 4.17.15
+      to-fast-properties: 2.0.0
+    dev: true
+    resolution:
+      integrity: sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==
   /@babel/types/7.9.5:
     dependencies:
       '@babel/helper-validator-identifier': 7.9.5
@@ -2086,6 +3046,20 @@ packages:
       rollup: ^1.20.0||^2.0.0
     resolution:
       integrity: sha512-IzoejtAqdfwAvx4D0bztAJFoL5Js36kJgnbO00zfI1B9jf9G80vWysyG0C4+E6w5uG5hz0EeetPpoBWKdNktCQ==
+  /@rollup/plugin-babel/5.0.4_@babel+core@7.10.4+rollup@2.12.0:
+    dependencies:
+      '@babel/core': 7.10.4
+      '@babel/helper-module-imports': 7.8.3
+      '@rollup/pluginutils': 3.1.0_rollup@2.12.0
+      rollup: 2.12.0
+    dev: true
+    engines:
+      node: '>= 10.0.0'
+    peerDependencies:
+      '@babel/core': ^7.0.0
+      rollup: ^1.20.0||^2.0.0
+    resolution:
+      integrity: sha512-MBtNoi5gqBEbqy1gE9jZBfPsi10kbuK2CEu9bx53nk1Z3ATRvBOoZ/GsbhXOeVbS76xXi/DeYM+vYX6EGIDv9A==
   /@rollup/plugin-buble/0.20.0_rollup@2.2.0:
     dependencies:
       buble: 0.19.8
@@ -2158,15 +3132,23 @@ packages:
       rollup: ^1.20.0
     resolution:
       integrity: sha512-MPYGZr0qdbV5zZj8/2AuomVpnRVXRU5XKXb3HVniwRoRCreGlf5kOE081isNWeiLIi6IYkwTX9zE0/c7V8g81g==
-  /@rollup/plugin-json/4.0.3_rollup@2.12.0:
+  /@rollup/plugin-commonjs/13.0.0_rollup@2.12.0:
     dependencies:
-      '@rollup/pluginutils': 3.0.10_rollup@2.12.0
+      '@rollup/pluginutils': 3.1.0_rollup@2.12.0
+      commondir: 1.0.1
+      estree-walker: 1.0.1
+      glob: 7.1.6
+      is-reference: 1.1.4
+      magic-string: 0.25.7
+      resolve: 1.17.0
       rollup: 2.12.0
     dev: true
+    engines:
+      node: '>= 8.0.0'
     peerDependencies:
-      rollup: ^1.20.0 || ^2.0.0
+      rollup: ^2.3.4
     resolution:
-      integrity: sha512-QMUT0HZNf4CX17LMdwaslzlYHUKTYGuuk34yYIgZrNdu+pMEfqMS55gck7HEeHBKXHM4cz5Dg1OVwythDdbbuQ==
+      integrity: sha512-Anxc3qgkAi7peAyesTqGYidG5GRim9jtg8xhmykNaZkImtvjA7Wsqep08D2mYsqw1IF7rA3lYfciLgzUSgRoqw==
   /@rollup/plugin-json/4.0.3_rollup@2.2.0:
     dependencies:
       '@rollup/pluginutils': 3.0.10_rollup@2.2.0
@@ -2185,6 +3167,15 @@ packages:
       rollup: ^1.20.0 || ^2.0.0
     resolution:
       integrity: sha512-QMUT0HZNf4CX17LMdwaslzlYHUKTYGuuk34yYIgZrNdu+pMEfqMS55gck7HEeHBKXHM4cz5Dg1OVwythDdbbuQ==
+  /@rollup/plugin-json/4.1.0_rollup@2.12.0:
+    dependencies:
+      '@rollup/pluginutils': 3.1.0_rollup@2.12.0
+      rollup: 2.12.0
+    dev: true
+    peerDependencies:
+      rollup: ^1.20.0 || ^2.0.0
+    resolution:
+      integrity: sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==
   /@rollup/plugin-node-resolve/7.1.1:
     dependencies:
       '@rollup/pluginutils': 3.0.8
@@ -2314,18 +3305,6 @@ packages:
       rollup: ^1.20.0||^2.0.0
     resolution:
       integrity: sha512-d44M7t+PjmMrASHbhgpSbVgtL6EFyX7J4mYxwQ/c5eoaE6N2VgCgEcWVzNnwycIloti+/MpwFr8qfw+nRw00sw==
-  /@rollup/pluginutils/3.0.10_rollup@2.12.0:
-    dependencies:
-      '@types/estree': 0.0.39
-      estree-walker: 1.0.1
-      picomatch: 2.2.2
-      rollup: 2.12.0
-    engines:
-      node: '>= 8.0.0'
-    peerDependencies:
-      rollup: ^1.20.0||^2.0.0
-    resolution:
-      integrity: sha512-d44M7t+PjmMrASHbhgpSbVgtL6EFyX7J4mYxwQ/c5eoaE6N2VgCgEcWVzNnwycIloti+/MpwFr8qfw+nRw00sw==
   /@rollup/pluginutils/3.0.10_rollup@2.16.1:
     dependencies:
       '@types/estree': 0.0.39
@@ -2406,6 +3385,18 @@ packages:
       rollup: ^1.20.0
     resolution:
       integrity: sha512-rYGeAc4sxcZ+kPG/Tw4/fwJODC3IXHYDH4qusdN/b6aLw5LPUbzpecYbEJh4sVQGPFJxd2dBU4kc1H3oy9/bnw==
+  /@rollup/pluginutils/3.1.0_rollup@2.12.0:
+    dependencies:
+      '@types/estree': 0.0.39
+      estree-walker: 1.0.1
+      picomatch: 2.2.2
+      rollup: 2.12.0
+    engines:
+      node: '>= 8.0.0'
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0
+    resolution:
+      integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==
   /@samverschueren/stream-to-observable/0.3.0:
     dependencies:
       any-observable: 0.3.0
@@ -2529,10 +3520,10 @@ packages:
     resolution:
       integrity: sha512-Jg1F+bmxcpENHP23sVKkNuU3uaxPnsBMW0cLjleiikFKomJQbsn0Cqk2yDvQArqzZN6ABfBkZ0To7pQ8sLdWDg==
   /@types/node/13.1.8:
+    dev: true
     resolution:
       integrity: sha512-6XzyyNM9EKQW4HKuzbo/CkOIjn/evtCmsU+MUM1xDfJ+3/rNjBttM1NgN7AOQvN6tP1Sl1D1PIKMreTArnxM9A==
   /@types/node/13.13.4:
-    dev: true
     resolution:
       integrity: sha512-x26ur3dSXgv5AwKS0lNfbjpCakGIduWU1DU91Zz58ONRWrIKGunmZBNv4P7N+e27sJkiGDsw/3fT4AtsqQBrBA==
   /@types/normalize-package-data/2.4.0:
@@ -2549,8 +3540,15 @@ packages:
   /@types/resolve/0.0.8:
     dependencies:
       '@types/node': 13.1.8
+    dev: true
     resolution:
       integrity: sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
+  /@types/resolve/1.17.1:
+    dependencies:
+      '@types/node': 13.13.4
+    dev: false
+    resolution:
+      integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==
   /@types/yargs-parser/15.0.0:
     dev: true
     resolution:
@@ -2561,78 +3559,97 @@ packages:
     dev: true
     resolution:
       integrity: sha512-CF/+sxTO7FOwbIRL4wMv0ZYLCRfMid2HQpzDRyViH7kSpfoAFiMdGqKIxb1PxWfjtQXQhnQuD33lvRHNwr809Q==
-  /@typescript-eslint/eslint-plugin/2.29.0_78834e48aafc7e2cd4306b1d6b447263:
+  /@typescript-eslint/eslint-plugin/3.6.0_1cd0d21f7cfbad5ac6106263f5332fb7:
     dependencies:
-      '@typescript-eslint/experimental-utils': 2.29.0_typescript@3.8.3
-      '@typescript-eslint/parser': 2.29.0_typescript@3.8.3
+      '@typescript-eslint/experimental-utils': 3.6.0_typescript@3.8.3
+      '@typescript-eslint/parser': 3.6.0_typescript@3.8.3
+      debug: 4.1.1
       functional-red-black-tree: 1.0.1
       regexpp: 3.1.0
+      semver: 7.3.2
       tsutils: 3.17.1_typescript@3.8.3
       typescript: 3.8.3
     dev: true
     engines:
-      node: ^8.10.0 || ^10.13.0 || >=11.10.1
+      node: ^10.12.0 || >=12.0.0
     peerDependencies:
-      '@typescript-eslint/parser': ^2.0.0
-      eslint: ^5.0.0 || ^6.0.0
+      '@typescript-eslint/parser': ^3.0.0
+      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
     resolution:
-      integrity: sha512-X/YAY7azKirENm4QRpT7OVmzok02cSkqeIcLmdz6gXUQG4Hk0Fi9oBAynSAyNXeGdMRuZvjBa0c1Lu0dn/u6VA==
-  /@typescript-eslint/experimental-utils/2.29.0_typescript@3.8.3:
+      integrity: sha512-ubHlHVt1lsPQB/CZdEov9XuOFhNG9YRC//kuiS1cMQI6Bs1SsqKrEmZnpgRwthGR09/kEDtr9MywlqXyyYd8GA==
+  /@typescript-eslint/experimental-utils/3.6.0_typescript@3.8.3:
     dependencies:
       '@types/json-schema': 7.0.4
-      '@typescript-eslint/typescript-estree': 2.29.0_typescript@3.8.3
+      '@typescript-eslint/types': 3.6.0
+      '@typescript-eslint/typescript-estree': 3.6.0_typescript@3.8.3
       eslint-scope: 5.0.0
       eslint-utils: 2.0.0
     dev: true
     engines:
-      node: ^8.10.0 || ^10.13.0 || >=11.10.1
+      node: ^10.12.0 || >=12.0.0
     peerDependencies:
       eslint: '*'
       typescript: '*'
     resolution:
-      integrity: sha512-H/6VJr6eWYstyqjWXBP2Nn1hQJyvJoFdDtsHxGiD+lEP7piGnGpb/ZQd+z1ZSB1F7dN+WsxUDh8+S4LwI+f3jw==
-  /@typescript-eslint/parser/2.29.0_typescript@3.8.3:
+      integrity: sha512-4Vdf2hvYMUnTdkCNZu+yYlFtL2v+N2R7JOynIOkFbPjf9o9wQvRwRkzUdWlFd2YiiUwJLbuuLnl5civNg5ykOQ==
+  /@typescript-eslint/parser/3.6.0_typescript@3.8.3:
     dependencies:
       '@types/eslint-visitor-keys': 1.0.0
-      '@typescript-eslint/experimental-utils': 2.29.0_typescript@3.8.3
-      '@typescript-eslint/typescript-estree': 2.29.0_typescript@3.8.3
+      '@typescript-eslint/experimental-utils': 3.6.0_typescript@3.8.3
+      '@typescript-eslint/types': 3.6.0
+      '@typescript-eslint/typescript-estree': 3.6.0_typescript@3.8.3
       eslint-visitor-keys: 1.1.0
       typescript: 3.8.3
     dev: true
     engines:
-      node: ^8.10.0 || ^10.13.0 || >=11.10.1
+      node: ^10.12.0 || >=12.0.0
     peerDependencies:
-      eslint: ^5.0.0 || ^6.0.0
+      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
     resolution:
-      integrity: sha512-H78M+jcu5Tf6m/5N8iiFblUUv+HJDguMSdFfzwa6vSg9lKR8Mk9BsgeSjO8l2EshKnJKcbv0e8IDDOvSNjl0EA==
-  /@typescript-eslint/typescript-estree/2.29.0_typescript@3.8.3:
+      integrity: sha512-taghDxuLhbDAD1U5Fk8vF+MnR0yiFE9Z3v2/bYScFb0N1I9SK8eKHkdJl1DAD48OGFDMFTeOTX0z7g0W6SYUXw==
+  /@typescript-eslint/types/3.6.0:
+    dev: true
+    engines:
+      node: ^8.10.0 || ^10.13.0 || >=11.10.1
+    resolution:
+      integrity: sha512-JwVj74ohUSt0ZPG+LZ7hb95fW8DFOqBuR6gE7qzq55KDI3BepqsCtHfBIoa0+Xi1AI7fq5nCu2VQL8z4eYftqg==
+  /@typescript-eslint/typescript-estree/3.6.0_typescript@3.8.3:
     dependencies:
+      '@typescript-eslint/types': 3.6.0
+      '@typescript-eslint/visitor-keys': 3.6.0
       debug: 4.1.1
-      eslint-visitor-keys: 1.1.0
       glob: 7.1.6
       is-glob: 4.0.1
       lodash: 4.17.15
-      semver: 6.3.0
+      semver: 7.3.2
       tsutils: 3.17.1_typescript@3.8.3
       typescript: 3.8.3
     dev: true
     engines:
-      node: ^8.10.0 || ^10.13.0 || >=11.10.1
+      node: ^10.12.0 || >=12.0.0
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
     resolution:
-      integrity: sha512-3YGbtnWy4az16Egy5Fj5CckkVlpIh0MADtAQza+jiMADRSKkjdpzZp/5WuvwK/Qib3Z0HtzrDFeWanS99dNhnA==
+      integrity: sha512-G57NDSABHjvob7zVV09ehWyD1K6/YUKjz5+AufObFyjNO4DVmKejj47MHjVHHlZZKgmpJD2yyH9lfCXHrPITFg==
+  /@typescript-eslint/visitor-keys/3.6.0:
+    dependencies:
+      eslint-visitor-keys: 1.1.0
+    dev: true
+    engines:
+      node: ^8.10.0 || ^10.13.0 || >=11.10.1
+    resolution:
+      integrity: sha512-p1izllL2Ubwunite0ITjubuMQRBGgjdVYwyG7lXPX8GbrA6qF0uwSRz9MnXZaHMxID4948gX0Ez8v9tUDi/KfQ==
   /JSONStream/1.3.5:
     dependencies:
       jsonparse: 1.3.1
@@ -7642,18 +8659,6 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==
-  /rollup-plugin-babel/4.3.3_@babel+core@7.9.0+rollup@2.12.0:
-    dependencies:
-      '@babel/core': 7.9.0
-      '@babel/helper-module-imports': 7.8.3
-      rollup: 2.12.0
-      rollup-pluginutils: 2.8.2
-    dev: true
-    peerDependencies:
-      '@babel/core': 7 || ^7.0.0-rc.2
-      rollup: '>=0.60.0 <2'
-    resolution:
-      integrity: sha512-tKzWOCmIJD/6aKNz0H1GMM+lW1q9KyFubbWzGiOG540zxPPifnEAHTZwjo0g991Y+DyOZcLqBgqOdqazYE5fkw==
   /rollup-plugin-babel/4.3.3_@babel+core@7.9.0+rollup@2.2.0:
     dependencies:
       '@babel/core': 7.9.0
@@ -7690,20 +8695,6 @@ packages:
       rollup: '>=0.60.0 <3'
     resolution:
       integrity: sha512-Lek/TYp1+7g7I+uMfJnnSJ7YWoD58ajo6Oarhlex7lvUce+RCKRuGRSgztDO3/MF/PuGKmUL5iTHKf208UNszw==
-  /rollup-plugin-commonjs/10.1.0_rollup@2.12.0:
-    dependencies:
-      estree-walker: 0.6.1
-      is-reference: 1.1.4
-      magic-string: 0.25.7
-      resolve: 1.15.0
-      rollup: 2.12.0
-      rollup-pluginutils: 2.8.2
-    deprecated: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-commonjs.
-    dev: true
-    peerDependencies:
-      rollup: '>=1.12.0'
-    resolution:
-      integrity: sha512-jlXbjZSQg8EIeAAvepNwhJj++qJWNJw1Cl0YnOqKtP5Djx+fFGkp3WRh+W0ASCaFG5w1jhmzDxgu3SJuVxPF4Q==
   /rollup-plugin-postcss/2.0.3:
     dependencies:
       chalk: 2.4.2
@@ -7837,7 +8828,6 @@ packages:
     resolution:
       integrity: sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
   /semver/7.3.2:
-    dev: false
     engines:
       node: '>=10'
     hasBin: true


### PR DESCRIPTION
Closes https://github.com/rollup/plugins/issues/479

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `node-resolve`

This PR contains:

- [x] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

https://github.com/rollup/plugins/issues/479

### Description

As described in #479 it's common for a TS project to use '.js' to refer to local '.ts' or '.tsx' files. This adds support for that.

Previously/Currently you need to import as either `'./file'` (see quote in #479 :wink:) or `'./file.ts'`. Both don't really work:

![image](https://user-images.githubusercontent.com/44614862/86153531-b0b9c400-bab6-11ea-8d23-fcbafcb983d4.png)

![image](https://user-images.githubusercontent.com/44614862/86153702-e78fda00-bab6-11ea-8b41-529a86839b16.png)

The fix:

![image](https://user-images.githubusercontent.com/44614862/86154016-5a995080-bab7-11ea-9641-fd0eff48faa3.png)

I haven't added tests because it's only 5 lines of code and the "algorithm" is just "Is a TS/TSX file importing a JS file and `{ extensions: [] }` has TS and/or TSX in it? Then add to `importSpecifierList` as a potential resolution".

Note that `@rollup/plugin-typescript` works out of the box for this already, but I think it'd be good to not _need_ to require the full TS compiler just to support this - VSCode already lints the whole project, I don't need a compile, I just need types removed via Babel (so so much faster)

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
