### PR TITLE
feat(node-resolve): preserve search params and hashes

### DIFF
--- a/packages/node-resolve/test/fixtures/hash.js
+++ b/packages/node-resolve/test/fixtures/hash.js
@@ -1,0 +1,3 @@
+import test from 'test#foo';
+
+export default test;

--- a/packages/node-resolve/test/fixtures/search-params-and-hash.js
+++ b/packages/node-resolve/test/fixtures/search-params-and-hash.js
@@ -1,0 +1,3 @@
+import test from 'test?foo=bar&lorem=ipsum#foo';
+
+export default test;

--- a/packages/node-resolve/test/fixtures/search-params.js
+++ b/packages/node-resolve/test/fixtures/search-params.js
@@ -1,0 +1,3 @@
+import test from 'test?foo=bar&lorem=ipsum';
+
+export default test;

--- a/packages/node-resolve/test/test.js
+++ b/packages/node-resolve/test/test.js
@@ -219,3 +219,78 @@ test('handles package side-effects', async (t) => {
 
   delete global.sideEffects;
 });
+
+test('can resolve imports with hashes', async (t) => {
+  const bundle = await rollup({
+    input: 'hash.js',
+    onwarn: () => t.fail('No warnings were expected'),
+    plugins: [
+      nodeResolve(),
+      {
+        load(id) {
+          if (id === resolve(__dirname, 'fixtures', 'node_modules', 'test', 'index.js#foo')) {
+            return 'export default "resolved with hash"';
+          }
+          return null;
+        }
+      }
+    ]
+  });
+  const { module } = await testBundle(t, bundle);
+
+  t.is(module.exports, 'resolved with hash');
+});
+
+test('can resolve imports with search params', async (t) => {
+  const bundle = await rollup({
+    input: 'search-params.js',
+    onwarn: () => t.fail('No warnings were expected'),
+    plugins: [
+      nodeResolve(),
+      {
+        load(id) {
+          if (
+            id ===
+            resolve(__dirname, 'fixtures', 'node_modules', 'test', 'index.js?foo=bar&lorem=ipsum')
+          ) {
+            return 'export default "resolved with search params"';
+          }
+          return null;
+        }
+      }
+    ]
+  });
+  const { module } = await testBundle(t, bundle);
+
+  t.is(module.exports, 'resolved with search params');
+});
+
+test('can resolve imports with search params and hash', async (t) => {
+  const bundle = await rollup({
+    input: 'search-params-and-hash.js',
+    onwarn: () => t.fail('No warnings were expected'),
+    plugins: [
+      nodeResolve(),
+      {
+        load(id) {
+          if (
+            id ===
+            resolve(
+              __dirname,
+              'fixtures',
+              'node_modules',
+              'test',
+              'index.js?foo=bar&lorem=ipsum#foo'
+            )
+          ) {
+            return 'export default "resolved with search params and hash"';
+          }
+          return null;
+        }
+      }
+    ]
+  });
+  const { module } = await testBundle(t, bundle);
+
+  t.is(module.exports, 'resolved with search params and hash');
+});


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `@rollup/plugin-node-resolve`

This PR contains:

- [ ] bugfix
- [X] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [X] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [X] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers: Fixes https://github.com/rollup/plugins/issues/486

### Description

This makes node-resolve preserve any search params or hashes if they were in the import path.

Code:

```js
import foo from 'my-package?foo=bar';
```

Before this change it would throw, saying it can't find `my-package?foo=bar'`.

After this change, it gets resolved to something like:

```js
import foo from '/absolute/file/system/path/to/my-package?foo=bar';
```

This would still throw as rollup tries to find this file, but a rollup plugin can set up a special load for a module with this parameter.