### PR TITLE
feat(dynamic-import-vars): add support for dynamic expressions with concat

### DIFF
--- a/packages/dynamic-import-vars/README.md
+++ b/packages/dynamic-import-vars/README.md
@@ -106,6 +106,14 @@ Some example patterns and the glob they produce:
 './locales/' + `${foo + bar}.js` -> './locales/*.js'
 ```
 
+```js
+'./locales/'.concat(locale, '.js') -> './locales/*.js'
+```
+
+```js
+'./'.concat(folder, '/').concat(name, '.js') -> './*/*.js'
+```
+
 Code that looks like this:
 
 ```js

--- a/packages/dynamic-import-vars/src/dynamic-import-to-glob.js
+++ b/packages/dynamic-import-vars/src/dynamic-import-to-glob.js
@@ -25,6 +25,14 @@ function templateLiteralToGlob(node) {
   return glob;
 }
 
+function callExpressionToGlob(node) {
+  const callee = node.callee;
+  if (callee.type === 'MemberExpression' && callee.property.type === 'Identifier' && callee.property.name === 'concat') {
+    return `${expressionToGlob(callee.object)}${node.arguments.map(expressionToGlob).join('')}`;
+  }
+  return '*';
+}
+
 function binaryExpressionToGlob(node) {
   if (node.operator !== '+') {
     throw new VariableDynamicImportError(`${node.operator} operator is not supported.`);
@@ -37,6 +45,8 @@ function expressionToGlob(node) {
   switch (node.type) {
     case 'TemplateLiteral':
       return templateLiteralToGlob(node);
+    case 'CallExpression':
+      return callExpressionToGlob(node);
     case 'BinaryExpression':
       return binaryExpressionToGlob(node);
     case 'Literal': {

--- a/packages/dynamic-import-vars/test/src/dynamic-import-to-glob.test.js
+++ b/packages/dynamic-import-vars/test/src/dynamic-import-to-glob.test.js
@@ -35,6 +35,33 @@ test('template literal with multiple variables', (t) => {
   t.is(glob, './*/*.js');
 });
 
+test('dynamic expression with variable filename', (t) => {
+  const ast = CustomParser.parse('import("./foo/".concat(bar,".js"));', {
+    sourceType: 'module',
+  });
+
+  const glob = dynamicImportToGlob(ast.body[0].expression.arguments[0]);
+  t.is(glob, './foo/*.js');
+});
+
+test('dynamic expression with variable directory', (t) => {
+  const ast = CustomParser.parse('import("./foo/".concat(bar, "/x.js"));', {
+    sourceType: 'module',
+  });
+
+  const glob = dynamicImportToGlob(ast.body[0].expression.arguments[0]);
+  t.is(glob, './foo/*/x.js');
+});
+
+test('dynamic expression with multiple variables', (t) => {
+  const ast = CustomParser.parse('import("./".concat(foo, "/").concat(bar,".js"));', {
+    sourceType: 'module',
+  });
+
+  const glob = dynamicImportToGlob(ast.body[0].expression.arguments[0]);
+  t.is(glob, './*/*.js');
+});
+
 test('string concatenation', (t) => {
   const ast = CustomParser.parse('import("./foo/" + bar + ".js");', {
     sourceType: 'module'


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `@rollup/dynamic-import-vars`

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
no issue was specifically created for this, we had one in the original repo: https://github.com/LarsDenBakker/rollup-plugin-dynamic-import-variables/issues/1

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

This PR enhances the `@rollup/dynamic-import-vars` plugin with support for some extra patterns for the vars.  
In some cases, during a Rollup build, it is needed to do a Babel transformation to support older browsers. When transofrming template literals, this means this type of code ``import(`./translations/${foo}.js`)`` becomes ``import('./translations/'.concat(foo, '.js'))``. If this happens before the `@rollup/dynamic-import-vars` plugin, the plugin won't be able to expand the code anymore. This PR adds the required code to support this type of code as well.
