### PR TITLE
Fix using colon in the filename on Windows

### DIFF
--- a/packages/multi-entry/package.json
+++ b/packages/multi-entry/package.json
@@ -51,6 +51,7 @@
     "matched": "^5.0.0"
   },
   "devDependencies": {
+    "del": "^5.1.0",
     "rollup": "^2.23.0"
   },
   "ava": {

--- a/packages/multi-entry/src/index.js
+++ b/packages/multi-entry/src/index.js
@@ -2,7 +2,13 @@
 
 import matched from 'matched';
 
-const entry = '\0rollup:plugin-multi-entry:entry-point';
+let entry;
+if (process.platform === "win32") {
+  // the colon is different
+	entry = '\0rollup꞉plugin-multi-entry꞉entry-point';
+} else {
+	entry = '\0rollup:plugin-multi-entry:entry-point';
+}
 
 export default function multiEntry(conf) {
   let include = [];

--- a/packages/multi-entry/test/test.js
+++ b/packages/multi-entry/test/test.js
@@ -3,6 +3,8 @@
 import fs from 'fs';
 import path from 'path';
 
+import del from 'del';
+
 import test from 'ava';
 import { rollup } from 'rollup';
 
@@ -98,6 +100,6 @@ test('allows to prevent exporting', async (t) => {
 async function isBundleWritten(bundle, outputOptions, outputPath) {
   await bundle.write(outputOptions);
   const iswritten = fs.existsSync(outputPath);
-  fs.rmdirSync(testDistDir, { recursive: true });
+  del.sync([testDistDir], { force: true, onlyFiles: true });
   return iswritten;
 }

--- a/packages/multi-entry/test/test.js
+++ b/packages/multi-entry/test/test.js
@@ -1,5 +1,8 @@
 /* eslint-disable no-bitwise */
 
+import fs from 'fs';
+import path from 'path';
+
 import test from 'ava';
 import { rollup } from 'rollup';
 
@@ -7,8 +10,21 @@ import { getCode } from '../../../util/test';
 
 import multiEntry from '../';
 
+const testDistDir = path.join(__dirname, 'dist');
+const outputOptions = { format: 'cjs', output: { dir: testDistDir } };
+
+let outFile;
+if (process.platform === 'win32') {
+  // the colon is different
+  outFile = '_rollup꞉plugin-multi-entry꞉entry-point.js';
+} else {
+  outFile = '_rollup:plugin-multi-entry:entry-point.js';
+}
+const outputPath = path.join(testDistDir, outFile);
+
 test('takes a single file as input', async (t) => {
   const bundle = await rollup({ input: 'test/fixtures/0.js', plugins: [multiEntry()] });
+  t.truthy(await isBundleWritten(bundle, outputOptions, outputPath, testDistDir));
   const code = await getCode(bundle);
   t.truthy(code.includes('exports.zero = zero;'));
 });
@@ -18,6 +34,7 @@ test('takes an array of files as input', async (t) => {
     input: ['test/fixtures/0.js', 'test/fixtures/1.js'],
     plugins: [multiEntry()]
   });
+  t.truthy(await isBundleWritten(bundle, outputOptions, outputPath, testDistDir));
   const code = await getCode(bundle);
   t.truthy(code.includes('exports.zero = zero;'));
   t.truthy(code.includes('exports.one = one;'));
@@ -25,12 +42,14 @@ test('takes an array of files as input', async (t) => {
 
 test('allows an empty array as input', async (t) => {
   const bundle = await rollup({ input: [], plugins: [multiEntry()] });
+  t.truthy(await isBundleWritten(bundle, outputOptions, outputPath, testDistDir));
   const code = await getCode(bundle);
   t.falsy(code.includes('exports'));
 });
 
 test('takes a glob as input', async (t) => {
   const bundle = await rollup({ input: 'test/fixtures/{0,1}.js', plugins: [multiEntry()] });
+  t.truthy(await isBundleWritten(bundle, outputOptions, outputPath, testDistDir));
   const code = await getCode(bundle);
   t.truthy(code.includes('exports.zero = zero;'));
   t.truthy(code.includes('exports.one = one;'));
@@ -41,6 +60,7 @@ test('takes an array of globs as input', async (t) => {
     input: ['test/fixtures/{0,}.js', 'test/fixtures/{1,}.js'],
     plugins: [multiEntry()]
   });
+  t.truthy(await isBundleWritten(bundle, outputOptions, outputPath, testDistDir));
   const code = await getCode(bundle);
   t.truthy(code.includes('exports.zero = zero;'));
   t.truthy(code.includes('exports.one = one;'));
@@ -54,6 +74,7 @@ test('takes an {include,exclude} object as input', async (t) => {
     },
     plugins: [multiEntry()]
   });
+  t.truthy(await isBundleWritten(bundle, outputOptions, outputPath, testDistDir));
   const code = await getCode(bundle);
   t.truthy(code.includes('exports.zero = zero;'));
   t.falsy(code.includes('exports.one = one;'));
@@ -67,8 +88,16 @@ test('allows to prevent exporting', async (t) => {
     },
     plugins: [multiEntry()]
   });
+  t.truthy(await isBundleWritten(bundle, outputOptions, outputPath, testDistDir));
   const code = await getCode(bundle);
   t.truthy(code.includes(`console.log('Hello, 2');`));
   t.falsy(code.includes('zero'));
   t.falsy(code.includes('one'));
 });
+
+async function isBundleWritten(bundle, outputOptions, outputPath) {
+  await bundle.write(outputOptions);
+  const iswritten = fs.existsSync(outputPath);
+  fs.rmdirSync(testDistDir, { recursive: true });
+  return iswritten;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,8 +282,10 @@ importers:
     dependencies:
       matched: 5.0.0
     devDependencies:
+      del: 5.1.0
       rollup: 2.23.0
     specifiers:
+      del: ^5.1.0
       matched: ^5.0.0
       rollup: ^2.23.0
   packages/node-resolve:
@@ -3738,6 +3740,7 @@ packages:
     resolution:
       integrity: sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
   /fsevents/2.1.3:
+    dev: true
     engines:
       node: ^8.16.0 || ^10.6.0 || >=11.0.0
     optional: true
@@ -6368,6 +6371,7 @@ packages:
     resolution:
       integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==
   /rollup/2.23.0:
+    dev: true
     engines:
       node: '>=10.0.0'
     hasBin: true


### PR DESCRIPTION
## Rollup Plugin Name: `multi-entry`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes: I included the real-world tests. 

Previously the tests were using `getCode` which is not what happens in the real world. This fixes an already broken plugin on Windows. To see the difference, you need proper Windows machine or Windows support in Repl.it to run the tests before and after.

- [ ] no: 

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
Fixes #488 

### Description

use U+A789 instead of colon in the file name on Windows