### PR TITLE
Do not process virtual modules from other plugins

### DIFF
--- a/packages/commonjs/src/resolve-id.js
+++ b/packages/commonjs/src/resolve-id.js
@@ -45,9 +45,7 @@ export default function getResolveId(extensions) {
 
   function resolveId(importee, importer) {
     const isProxyModule = importee.endsWith(PROXY_SUFFIX);
-    if (isProxyModule) {
-      importee = getIdFromProxyId(importee);
-    } else if (importee.startsWith('\0')) {
+    if (importee.startsWith('\0')) {
       if (
         importee.startsWith(HELPERS_ID) ||
         importee === DYNAMIC_PACKAGES_ID ||
@@ -56,6 +54,8 @@ export default function getResolveId(extensions) {
         return importee;
       }
       return null;
+    } else if (isProxyModule) {
+      importee = getIdFromProxyId(importee);
     }
 
     if (importee.startsWith(DYNAMIC_JSON_PREFIX)) {

--- a/packages/commonjs/src/resolve-id.js
+++ b/packages/commonjs/src/resolve-id.js
@@ -52,8 +52,11 @@ export default function getResolveId(extensions) {
         importee.startsWith(DYNAMIC_JSON_PREFIX)
       ) {
         return importee;
+      } else if (isProxyModule) {
+        importee = getIdFromProxyId(importee);
+      } else {
+        return null;
       }
-      return null;
     } else if (isProxyModule) {
       importee = getIdFromProxyId(importee);
     }


### PR DESCRIPTION
Fixes proteriax/rollup-plugin-ignore#4.

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `{commonjs}`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:
proteriax/rollup-plugin-ignore#4
rollup/rollup-plugin-commonjs#315
rollup/plugins#248

### Description

According to rollup’s documentation,
> If your plugin uses 'virtual modules' (e.g. for helper functions), prefix the module ID with \0. This prevents other plugins from trying to process it.

The current behavior of `@rollup/plugin-commonjs` violates this presumption by processing a module starting with `\0` included by `require`.

Suppose the following module:
```js
const fs = require('fs')
console.log(fs)
```

It will be overwritten to `\0rollup_plugin_ignore_empty_module_placeholder?commonjs-proxy`, but because `@rollup/plugin-commonjs` provide the contents to all modules with its own suffix without checking `\0`, `rollup-plugin-ignore` would not have a chance to supply the content for this virtual module.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
