### PR TITLE
feat(babel): `export * as ns` support

### DIFF
--- a/packages/babel/package.json
+++ b/packages/babel/package.json
@@ -47,7 +47,7 @@
   "peerDependencies": {
     "@babel/core": "^7.0.0",
     "@types/babel__core": "^7.1.9",
-    "rollup": "^1.20.0||^2.0.0"
+    "rollup": "^1.26.0||^2.0.0"
   },
   "dependencies": {
     "@babel/helper-module-imports": "^7.7.4",

--- a/packages/babel/package.json
+++ b/packages/babel/package.json
@@ -47,7 +47,7 @@
   "peerDependencies": {
     "@babel/core": "^7.0.0",
     "@types/babel__core": "^7.1.9",
-    "rollup": "^1.26.0||^2.0.0"
+    "rollup": "^1.20.0||^2.0.0"
   },
   "dependencies": {
     "@babel/helper-module-imports": "^7.7.4",

--- a/packages/babel/src/index.js
+++ b/packages/babel/src/index.js
@@ -1,5 +1,5 @@
 import * as babel from '@babel/core';
-import { version } from "rollup/package.json";
+import { VERSION } from "rollup";
 import { createFilter } from '@rollup/pluginutils';
 
 import { BUNDLED, HELPERS } from './constants';
@@ -47,7 +47,7 @@ const unpackInputPluginOptions = ({ skipPreflightCheck = false, ...rest }) => {
       supportsDynamicImport: true,
       supportsTopLevelAwait: true,
       // todo: remove version checks for 1.20 - 1.25 when we bump peer deps
-      supportsExportNamespaceFrom: !version.match(/^1\.2[0-5]/),
+      supportsExportNamespaceFrom: !VERSION.match(/^1\.2[0-5]\./),
       ...rest.caller
     }
   });

--- a/packages/babel/src/index.js
+++ b/packages/babel/src/index.js
@@ -1,4 +1,5 @@
 import * as babel from '@babel/core';
+import { version } from "rollup/package.json";
 import { createFilter } from '@rollup/pluginutils';
 
 import { BUNDLED, HELPERS } from './constants';
@@ -45,7 +46,8 @@ const unpackInputPluginOptions = ({ skipPreflightCheck = false, ...rest }) => {
       supportsStaticESM: true,
       supportsDynamicImport: true,
       supportsTopLevelAwait: true,
-      supportsExportNamespaceFrom: true,
+      // todo: remove version checks for 1.20 - 1.25 when we bump peer deps
+      supportsExportNamespaceFrom: !version.match(/^1\.2[0-5]/),
       ...rest.caller
     }
   });

--- a/packages/babel/src/index.js
+++ b/packages/babel/src/index.js
@@ -45,6 +45,7 @@ const unpackInputPluginOptions = ({ skipPreflightCheck = false, ...rest }) => {
       supportsStaticESM: true,
       supportsDynamicImport: true,
       supportsTopLevelAwait: true,
+      supportsExportNamespaceFrom: true,
       ...rest.caller
     }
   });


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `{babel}`

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

I can't add tests yet because Babel 7.11 is not yet published.

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

`@babel/preset-env` 7.11 will support `export * as ns`(https://github.com/babel/babel/pull/11849), where a new caller support flag `supportsExportNamespaceFrom` is introduced. This PR declares this flag so Babel can skip `export-namespace-from` transform when it is bundled from Rollup.

The Rollup 1 peer dependence is bumped to [1.26.0](https://github.com/rollup/rollup/releases/tag/v1.26.0), in which `export * as ns` was initially supported.