### PR TITLE
fix(babel): Pass chunk filename to output plugin transform

### DIFF
--- a/packages/babel/src/index.js
+++ b/packages/babel/src/index.js
@@ -203,7 +203,13 @@ function createBabelOutputPluginFactory(customCallback = returnObject) {
         } = unpackOutputPluginOptions(pluginOptionsWithOverrides, outputOptions);
         /* eslint-enable no-unused-vars */
 
-        return transformCode(code, babelOptions, overrides, customOptions, this);
+        return transformCode(
+          code,
+          { ...babelOptions, filename: chunk.fileName },
+          overrides,
+          customOptions,
+          this
+        );
       }
     };
   };

--- a/packages/babel/test/as-output-plugin.js
+++ b/packages/babel/test/as-output-plugin.js
@@ -332,7 +332,7 @@ test('allows using Babel to transform to other formats', async (t) => {
       exports: {}
     };
     factory();
-    global.unknown = mod.exports;
+    global.main = mod.exports;
   }
 })(typeof globalThis !== "undefined" ? globalThis : typeof self !== "undefined" ? self : this, function () {
   "use strict";
@@ -356,4 +356,21 @@ const answer = Math.pow(42, 2);
 console.log(\`the answer is \${answer}\`);
 `
   );
+});
+
+test('passes chunk filename to transform', async (t) => {
+  t.plan(2);
+
+  const customOutputPlugin = createBabelOutputPluginFactory(() => {
+    return {
+      config(cfg) {
+        // eslint-disable-next-line no-undefined
+        t.not(cfg.options.filename, undefined, 'cfg.options.filename wasn’t set');
+        t.is(nodePath.relative(cfg.options.cwd, cfg.options.filename), 'main.js');
+        return cfg.options;
+      }
+    };
+  });
+  const bundle = await rollup({ input: 'fixtures/basic/main.js' });
+  await getCode(bundle, { format: 'cjs', plugins: [customOutputPlugin()] });
 });


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `@rollup/plugin-babel`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers: N/A

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

This _appears_ to be an oversight, as the `filename` is passed at the same place in the input plugin transform Babel options. Without this field, a Babel error including text `"Preset /* your preset */ requires a filename to be set when babel is
called directly"` is thrown when using a custom preset.

    [!] (plugin babel) Error: [BABEL] unknown: Preset /* your preset */ requires a filename to be set when babel is called directly,
    ```
    babel.transform(code, { filename: 'file.ts', presets: [/* your preset */] });
    ```
    See https://babeljs.io/docs/en/options#filename for more information.
    Error: [BABEL] unknown: Preset /* your preset */ requires a filename to be set when babel is called directly,
    ```
    babel.transform(code, { filename: 'file.ts', presets: [/* your preset */] });
    ```
    See https://babeljs.io/docs/en/options#filename for more information.
        at validateIfOptionNeedsFilename ($PWD/node_modules/@babel/core/lib/config/full.js:274:11)
        at options.overrides.forEach.overrideOptions ($PWD/node_modules/@babel/core/lib/config/full.js:286:52)
        at Array.forEach (<anonymous>)
        at validatePreset ($PWD/node_modules/@babel/core/lib/config/full.js:286:25)
        at loadPresetDescriptor ($PWD/node_modules/@babel/core/lib/config/full.js:293:3)
        at loadPresetDescriptor.next (<anonymous>)
        at recurseDescriptors ($PWD/node_modules/@babel/core/lib/config/full.js:107:30)
        at recurseDescriptors.next (<anonymous>)
        at recurseDescriptors ($PWD/node_modules/@babel/core/lib/config/full.js:128:34)
        at recurseDescriptors.next (<anonymous>)

(stack trace is using `@babel/core@7.10.5`)

The test is not ideal, but without replicating a huge stack of other Rollup plugins and complicated Babel config, it's unclear how else to regress this in a focused, minimal way. A local edit of the Rollup Babel plugin in `node_modules` of the offending build does indicate the error is mitigated, however.
