### PR TITLE
fix(pluginutils)!: don't add cwd to absolute or patterns that start with a glob

### DIFF
--- a/packages/pluginutils/src/createFilter.ts
+++ b/packages/pluginutils/src/createFilter.ts
@@ -1,4 +1,4 @@
-import { resolve, sep, posix } from 'path';
+import { resolve, sep, posix, isAbsolute } from 'path';
 
 import pm from 'picomatch';
 
@@ -7,7 +7,7 @@ import { CreateFilter } from '../types';
 import ensureArray from './utils/ensureArray';
 
 function getMatcherString(id: string, resolutionBase: string | false | null | undefined) {
-  if (resolutionBase === false) {
+  if (resolutionBase === false || isAbsolute(id) || id.startsWith('*')) {
     return id;
   }
 

--- a/packages/pluginutils/test/createFilter.ts
+++ b/packages/pluginutils/test/createFilter.ts
@@ -124,3 +124,16 @@ test('handles relative paths', (t) => {
   t.truthy(filter(resolve('a.js')));
   t.falsy(filter(resolve('foo/a.js')));
 });
+
+test('does not add current working directory when pattern is an absolute path', (t) => {
+  const filter = createFilter([resolve('..', '..', '*')]);
+  t.truthy(filter(resolve('..', '..', 'a')));
+  t.truthy(filter(resolve('..', '..', 'b')));
+  t.falsy(filter(resolve('..', 'c')));
+});
+
+test('does not add current working directory when pattern starts with a glob', (t) => {
+  const filter = createFilter(['**/*']);
+  t.truthy(filter(resolve('a')));
+  t.truthy(filter(resolve('..', '..', 'a')));
+});


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `pluginutils`

This PR contains:

- [X] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [X] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [x] yes (_breaking changes will not be merged unless absolutely necessary_)
- [ ] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers: Fixes https://github.com/rollup/plugins/issues/490

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

When a pattern is an absolute path or when it starts with a glob star, the current working directory is not prefixed.

If a pattern is an absolute pattern: `/Users/me/some/path/to/code.js`, the pattern becomes `/Users/me/some/path/Users/me/some/path/to/code.js` which is a useless path. 

If a pattern starts with a glob, like: `**/*` the user's intent is to clearly match all parent directories. This becomes: `/Users/me/some/path/**/*`, and the user (unknowingly) does not include or exclude files outside of the current working directory.

 I consider this a bugfix because in both cases it goes against the user's intent. However if code is relying on this behavior, it might have an unintended side effect. I think the benefit outweighs this risk.