### PR TITLE
refactor(multi-entry): virtualised & entryFileName

### DIFF
--- a/packages/multi-entry/README.md
+++ b/packages/multi-entry/README.md
@@ -17,7 +17,7 @@ _Note: `default` exports cannot be combined and exported by this plugin. Only na
 
 ## Requirements
 
-This plugin requires an [LTS](https://github.com/nodejs/Release) Node version (v8.0.0+) and Rollup v1.20.0+.
+This plugin requires an [LTS](https://github.com/nodejs/Release) Node version (v8.3.0+) and Rollup v1.20.0+.
 
 ## Install
 
@@ -72,6 +72,13 @@ Type: `Boolean`<br>
 Default: `true`
 
 If `true`, instructs the plugin to export named exports to the bundle from all entries. If `false`, the plugin will not export any entry exports to the bundle. This can be useful when wanting to combine code from multiple entry files, but not necessarily to export each entry file's exports.
+
+### `entryFileName`
+
+Type: `String`<br>
+Default: `'multi-entry.js'`
+
+`entryFileName` changes the name of the generated entry file. By default, it will override `outputOptions.entryFileNames` to be `'multi-entry.js'`.
 
 ## Supported Input Types
 

--- a/packages/multi-entry/package.json
+++ b/packages/multi-entry/package.json
@@ -48,6 +48,7 @@
     "rollup": "^1.20.0 || ^2.0.0"
   },
   "dependencies": {
+    "@rollup/plugin-virtual": "^2.0.3",
     "matched": "^5.0.0"
   },
   "devDependencies": {

--- a/packages/multi-entry/src/index.js
+++ b/packages/multi-entry/src/index.js
@@ -1,56 +1,77 @@
-/* eslint-disable consistent-return, no-param-reassign */
+/* eslint-disable no-param-reassign */
 
-import matched from 'matched';
+import virtual from '@rollup/plugin-virtual';
+import { promise as matched } from 'matched';
 
-const entry = '\0rollup:plugin-multi-entry:entry-point';
+const DEFAULT_OUTPUT = 'multi-entry.js';
+const AS_IMPORT = 'import';
+const AS_EXPORT = 'export * from';
 
-export default function multiEntry(conf) {
-  let include = [];
-  let exclude = [];
-  let exporter = (path) => `export * from ${JSON.stringify(path)};`;
+export default function multiEntry(conf = {}) {
+  const config = {
+    include: [],
+    exclude: [],
+    entryFileName: DEFAULT_OUTPUT,
+    exports: true,
+    ...conf
+  };
 
-  function configure(config) {
-    if (typeof config === 'string') {
-      include = [config];
-    } else if (Array.isArray(config)) {
-      include = config;
+  let prefix = config.exports === false ? AS_IMPORT : AS_EXPORT;
+  const exporter = (path) => `${prefix} ${JSON.stringify(path)}`;
+
+  const configure = (input) => {
+    if (typeof input === 'string') {
+      config.include = [input];
+    } else if (Array.isArray(input)) {
+      config.include = input;
     } else {
-      include = config.include || [];
-      exclude = config.exclude || [];
-      if (config.exports === false) {
-        exporter = (path) => `import ${JSON.stringify(path)};`;
+      const { include = [], exclude = [], entryFileName = DEFAULT_OUTPUT, exports } = input;
+      config.include = include;
+      config.exclude = exclude;
+      config.entryFileName = entryFileName;
+      if (exports === false) {
+        prefix = AS_IMPORT;
       }
     }
-  }
+  };
 
-  if (conf) {
-    configure(conf);
-  }
+  let virtualisedEntry;
 
   return {
+    name: 'multi-entry',
+
     options(options) {
-      if (options.input && options.input !== entry) {
+      if (options.input !== config.entryFileName) {
         configure(options.input);
       }
-      options.input = entry;
+      return {
+        ...options,
+        input: config.entryFileName
+      };
     },
 
-    resolveId(id) {
-      if (id === entry) {
-        return entry;
-      }
+    outputOptions(options) {
+      return {
+        ...options,
+        entryFileNames: config.entryFileName
+      };
+    },
+
+    buildStart(options) {
+      const patterns = config.include.concat(config.exclude.map((pattern) => `!${pattern}`));
+      const entries = patterns.length
+        ? matched(patterns, { realpath: true }).then((paths) => paths.map(exporter).join('\n'))
+        : Promise.resolve('');
+
+      virtualisedEntry = virtual({ [options.input]: entries });
+    },
+
+    resolveId(id, importer) {
+      return virtualisedEntry && virtualisedEntry.resolveId(id, importer);
     },
 
     load(id) {
-      if (id === entry) {
-        if (!include.length) {
-          return Promise.resolve('');
-        }
-        const patterns = include.concat(exclude.map((pattern) => `!${pattern}`));
-        return matched(patterns, { realpath: true }).then((paths) =>
-          paths.map(exporter).join('\n')
-        );
-      }
+      return virtualisedEntry && virtualisedEntry.load(id);
     }
   };
 }

--- a/packages/multi-entry/test/test.js
+++ b/packages/multi-entry/test/test.js
@@ -72,3 +72,12 @@ test('allows to prevent exporting', async (t) => {
   t.falsy(code.includes('zero'));
   t.falsy(code.includes('one'));
 });
+
+test('makes a bundle with entryFileName as the filename', async (t) => {
+  const bundle = await rollup({
+    input: 'test/fixtures/{0,1}.js',
+    plugins: [multiEntry({ entryFileName: 'testing.js' })]
+  });
+  const [result] = await getCode(bundle, { format: 'cjs' }, true);
+  t.is(result.fileName, 'testing.js');
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -280,10 +280,12 @@ importers:
       rollup: ^2.23.0
   packages/multi-entry:
     dependencies:
+      '@rollup/plugin-virtual': 2.0.3_rollup@2.23.0
       matched: 5.0.0
     devDependencies:
       rollup: 2.23.0
     specifiers:
+      '@rollup/plugin-virtual': ^2.0.3
       matched: ^5.0.0
       rollup: ^2.23.0
   packages/node-resolve:
@@ -1622,6 +1624,14 @@ packages:
       typescript: '>=3.4.0'
     resolution:
       integrity: sha512-CkS028Itwjqm1uLbFVfpJgtVtnNvZ+og/m6UlNRR5wOOnNTWPcVQzOu5xGdEX+WWJxdvWIqUq2uR/RBt2ZipWg==
+  /@rollup/plugin-virtual/2.0.3_rollup@2.23.0:
+    dependencies:
+      rollup: 2.23.0
+    dev: false
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0
+    resolution:
+      integrity: sha512-pw6ziJcyjZtntQ//bkad9qXaBx665SgEL8C8KI5wO8G5iU5MPxvdWrQyVaAvjojGm9tJoS8M9Z/EEepbqieYmw==
   /@rollup/pluginutils/3.1.0_rollup@2.23.0:
     dependencies:
       '@types/estree': 0.0.39
@@ -3738,6 +3748,7 @@ packages:
     resolution:
       integrity: sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
   /fsevents/2.1.3:
+    dev: true
     engines:
       node: ^8.16.0 || ^10.6.0 || >=11.0.0
     optional: true
@@ -6368,6 +6379,7 @@ packages:
     resolution:
       integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==
   /rollup/2.23.0:
+    dev: true
     engines:
       node: '>=10.0.0'
     hasBin: true


### PR DESCRIPTION
## Rollup Plugin Name: `multi-entry`

This PR contains:

- [ ] bugfix
- [x] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [x] yes (_breaking changes will not be merged unless absolutely necessary_)
- [ ] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

Prompted by #488 
Fixes Windows related error and exposes new option for overriding defaults.
Idea for this PR from #506 

### Description

BREAKING CHANGES: Outputs a multi-entry file with different default name

Refactored multi-entry to use plugin-virtual for resolving/loading the multiple entries into a single entry file. Some tidy-up and adding a new option, `entryFileName`, to override the default entry filename.

First PR for rollup, feel free to provide feedback and further notes for work.
