### PR TITLE
Correct minimatch to picomatch in the docs

### DIFF
--- a/packages/pluginutils/README.md
+++ b/packages/pluginutils/README.md
@@ -99,14 +99,16 @@ export default function myPlugin(options = {}) {
 
 Constructs a filter function which can be used to determine whether or not certain modules should be operated upon.
 
-Parameters: `(include?: <minmatch>, exclude?: <minmatch>, options?: Object)`<br>
+Parameters: `(include?: <picomatch>, exclude?: <picomatch>, options?: Object)`<br>
 Returns: `String`
 
 #### `include` and `exclude`
 
 Type: `String | RegExp | Array[...String|RegExp]`<br>
 
-A valid [`minimatch`](https://www.npmjs.com/package/minimatch) pattern, or array of patterns. If `options.include` is omitted or has zero length, filter will return `true` by default. Otherwise, an ID must match one or more of the `minimatch` patterns, and must not match any of the `options.exclude` patterns.
+A valid [`picomatch`](https://github.com/micromatch/picomatch#globbing-features) pattern, or array of patterns. If `options.include` is omitted or has zero length, filter will return `true` by default. Otherwise, an ID must match one or more of the `picomatch` patterns, and must not match any of the `options.exclude` patterns.
+
+Note that `picomatch` patterns are very similar to [`minimatch`](https://github.com/isaacs/minimatch#readme) patterns, and in most use cases, they are interchangeable. If you have more specific pattern matching needs, you can view [this comparison table](https://github.com/micromatch/picomatch#library-comparisons) to learn more about where the libraries differ.
 
 #### `options`
 


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `createFilter`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [X] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [X] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [X] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

The current docs say that `createFilter` uses minimatch, but it actually uses picomatch.

https://github.com/rollup/plugins/blob/5fa15590e452d568239a6d8e1c7018865c027fe4/packages/pluginutils/src/createFilter.ts#L3

The differences are pretty subtle, but I think it's important to document them for people with more specific use cases, and for people creating packages that depend on `createFilter`.
