### PR TITLE
refactor(node-resolve): remove deep-freeze and deepmerge from dependencies

### DIFF
--- a/packages/node-resolve/package.json
+++ b/packages/node-resolve/package.json
@@ -52,7 +52,6 @@
     "@rollup/pluginutils": "^3.1.0",
     "@types/resolve": "1.17.1",
     "builtin-modules": "^3.1.0",
-    "deep-freeze": "^0.0.1",
     "deepmerge": "^4.2.2",
     "is-module": "^1.0.0",
     "resolve": "^1.17.0"

--- a/packages/node-resolve/src/index.js
+++ b/packages/node-resolve/src/index.js
@@ -2,7 +2,6 @@
 import { dirname, normalize, resolve, sep } from 'path';
 
 import builtinList from 'builtin-modules';
-import deepFreeze from 'deep-freeze';
 import deepMerge from 'deepmerge';
 import isModule from 'is-module';
 
@@ -19,6 +18,17 @@ import {
 const builtins = new Set(builtinList);
 const ES6_BROWSER_EMPTY = '\0node-resolve:empty.js';
 const nullFn = () => null;
+const deepFreeze = object => {
+  Object.freeze(object);
+
+  for (const value of Object.values(object)) {
+    if (typeof value === 'object' && !Object.isFrozen(value)) {
+      deepFreeze(value);
+    }
+  }
+
+  return object;
+};
 const defaults = {
   customResolveOptions: {},
   dedupe: [],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -291,7 +291,6 @@ importers:
       '@rollup/pluginutils': 3.1.0_rollup@2.23.0
       '@types/resolve': 1.17.1
       builtin-modules: 3.1.0
-      deep-freeze: 0.0.1
       deepmerge: 4.2.2
       is-module: 1.0.0
       resolve: 1.17.0
@@ -314,7 +313,6 @@ importers:
       '@rollup/pluginutils': ^3.1.0
       '@types/resolve': 1.17.1
       builtin-modules: ^3.1.0
-      deep-freeze: ^0.0.1
       deepmerge: ^4.2.2
       es5-ext: ^0.10.53
       is-module: ^1.0.0
@@ -3076,6 +3074,7 @@ packages:
     resolution:
       integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
   /deep-freeze/0.0.1:
+    dev: true
     resolution:
       integrity: sha1-OgsABd4YZygZ39OM0x+RF5yJPoQ=
   /deep-is/0.1.3:
@@ -3746,7 +3745,6 @@ packages:
     resolution:
       integrity: sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
   /fsevents/2.1.3:
-    dev: true
     engines:
       node: ^8.16.0 || ^10.6.0 || >=11.0.0
     optional: true
@@ -6377,7 +6375,6 @@ packages:
     resolution:
       integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==
   /rollup/2.23.0:
-    dev: true
     engines:
       node: '>=10.0.0'
     hasBin: true


### PR DESCRIPTION

This 2 dependencies are currently used to deepfreeze an exported symbol. Which seems to be an wasteful to add 2 extra dependencies for something trivial.

Also `deep-freeze` is licensed as Public Domain, which might be problematic for some 3rd parties such as the Angular CLI.

In Angular CLI we have a license validator that validates direct and transitive dependencies, and Public Domain is a problematic license becuse it falls under the "unencumbered' group which requires legal audit.

More context: https://opensource.google/docs/thirdparty/licenses/#unencumbered