### PR TITLE
fix(babel): strip hash and query param in extension filter

### DIFF
--- a/packages/babel/package.json
+++ b/packages/babel/package.json
@@ -62,6 +62,7 @@
     "@babel/plugin-transform-runtime": "^7.10.5",
     "@babel/preset-env": "^7.10.4",
     "@rollup/plugin-json": "^4.1.0",
+    "@rollup/plugin-node-resolve": "^10.0.0",
     "@types/babel__core": "^7.1.9",
     "rollup": "^2.23.0",
     "source-map": "^0.7.3"

--- a/packages/babel/src/index.js
+++ b/packages/babel/src/index.js
@@ -5,7 +5,7 @@ import { BUNDLED, HELPERS } from './constants';
 import bundledHelpersPlugin from './bundledHelpersPlugin';
 import preflightCheck from './preflightCheck';
 import transformCode from './transformCode';
-import { addBabelPlugin, escapeRegExpCharacters, warnOnce } from './utils';
+import { addBabelPlugin, escapeRegExpCharacters, warnOnce, stripQuery } from './utils';
 
 const unpackOptions = ({
   extensions = babel.DEFAULT_EXTENSIONS,
@@ -35,7 +35,7 @@ const warnAboutDeprecatedHelpersOption = ({ deprecatedOption, suggestion }) => {
     `\`${deprecatedOption}\` has been removed in favor a \`babelHelpers\` option. Try changing your configuration to \`${suggestion}\`. ` +
       `Refer to the documentation to learn more: https://github.com/rollup/plugins/tree/master/packages/babel#babelhelpers`
   );
-}
+};
 
 const unpackInputPluginOptions = ({ skipPreflightCheck = false, ...rest }, rollupVersion) => {
   if ('runtimeHelpers' in rest) {
@@ -110,13 +110,18 @@ function createBabelInputPluginFactory(customCallback = returnObject) {
       overrides
     );
 
-    let babelHelpers, babelOptions, filter, skipPreflightCheck;
+    let babelHelpers;
+    let babelOptions;
+    let filter;
+    let skipPreflightCheck;
     return {
       name: 'babel',
 
       options() {
-        //todo: remove options hook and hoist declarations when version checks are removed
-        let exclude, include, extensions;
+        // todo: remove options hook and hoist declarations when version checks are removed
+        let exclude;
+        let include;
+        let extensions;
 
         ({
           exclude,
@@ -127,9 +132,11 @@ function createBabelInputPluginFactory(customCallback = returnObject) {
           ...babelOptions
         } = unpackInputPluginOptions(pluginOptionsWithOverrides, this.meta.rollupVersion));
 
-        const extensionRegExp = new RegExp(`(${extensions.map(escapeRegExpCharacters).join('|')})$`);
+        const extensionRegExp = new RegExp(
+          `(${extensions.map(escapeRegExpCharacters).join('|')})$`
+        );
         const includeExcludeFilter = createFilter(include, exclude);
-        filter = (id) => extensionRegExp.test(id) && includeExcludeFilter(id);
+        filter = (id) => extensionRegExp.test(stripQuery(id).bareId) && includeExcludeFilter(id);
 
         return null;
       },

--- a/packages/babel/src/utils.js
+++ b/packages/babel/src/utils.js
@@ -14,3 +14,14 @@ export function warnOnce(ctx, msg) {
 
 const regExpCharactersRegExp = /[\\^$.*+?()[\]{}|]/g;
 export const escapeRegExpCharacters = (str) => str.replace(regExpCharactersRegExp, '\\$&');
+
+export function stripQuery(id) {
+  // strip query params from import
+  const [bareId, query] = id.split('?');
+  const suffix = `${query ? `?${query}` : ''}`;
+  return {
+    bareId,
+    query,
+    suffix
+  };
+}

--- a/packages/babel/test/as-input-plugin.js
+++ b/packages/babel/test/as-input-plugin.js
@@ -312,10 +312,10 @@ test('transpiles files when path contains query and hash', async (t) => {
       ]
     }
   );
-  t.false(code.includes('class WithQuery '), 'should transpile when path contains query');
-  t.false(code.includes('class WithHash '), 'should transpile when path contains hash');
-  t.false(
-    code.includes('class WithQueryAndHash '),
+  t.true(code.includes('function WithQuery()'), 'should transpile when path contains query');
+  t.true(code.includes('function WithHash()'), 'should transpile when path contains hash');
+  t.true(
+    code.includes('function WithQueryAndHash()'),
     'should transpile when path contains query and hash'
   );
 });

--- a/packages/babel/test/as-input-plugin.js
+++ b/packages/babel/test/as-input-plugin.js
@@ -159,12 +159,14 @@ test('allows transform-runtime to be used instead of bundled helpers', async (t)
     code,
     `'use strict';
 
-function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
+var _classCallCheck = require('@babel/runtime/helpers/classCallCheck');
 
-var _classCallCheck = _interopDefault(require('@babel/runtime/helpers/classCallCheck'));
+function _interopDefaultLegacy (e) { return e && typeof e === 'object' && 'default' in e ? e : { 'default': e }; }
+
+var _classCallCheck__default = /*#__PURE__*/_interopDefaultLegacy(_classCallCheck);
 
 var Foo = function Foo() {
-  _classCallCheck(this, Foo);
+  _classCallCheck__default['default'](this, Foo);
 };
 
 module.exports = Foo;

--- a/packages/babel/test/fixtures/with-query-and-hash/main.js
+++ b/packages/babel/test/fixtures/with-query-and-hash/main.js
@@ -1,0 +1,10 @@
+/* eslint-disable import/extensions */
+/* eslint-disable import/no-unresolved */
+
+// ? should be treated as special symbol for query params
+export { default as WithQuery } from './moduleQuery?q=asd';
+// # should be treated as normal filename character
+export { default as WithHash } from './module#Hash';
+
+// So, this is an import with path "./moduleQueryAnd#Hash" and query "?q=asd#hash"
+export { default as WithQueryAndHash } from './moduleQueryAnd#Hash?q=asd#hash';

--- a/packages/babel/test/fixtures/with-query-and-hash/module#Hash.js
+++ b/packages/babel/test/fixtures/with-query-and-hash/module#Hash.js
@@ -1,0 +1,1 @@
+export default class WithHash {}

--- a/packages/babel/test/fixtures/with-query-and-hash/moduleQuery.js
+++ b/packages/babel/test/fixtures/with-query-and-hash/moduleQuery.js
@@ -1,0 +1,1 @@
+export default class WithQuery {}

--- a/packages/babel/test/fixtures/with-query-and-hash/moduleQueryAnd#Hash.js
+++ b/packages/babel/test/fixtures/with-query-and-hash/moduleQueryAnd#Hash.js
@@ -1,0 +1,1 @@
+export default class WithQueryAndHash {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,7 @@ importers:
       '@babel/plugin-transform-runtime': 7.12.1_@babel+core@7.12.3
       '@babel/preset-env': 7.12.1_@babel+core@7.12.3
       '@rollup/plugin-json': 4.1.0_rollup@2.32.1
+      '@rollup/plugin-node-resolve': 10.0.0_rollup@2.32.1
       '@types/babel__core': 7.1.10
       rollup: 2.32.1
       source-map: 0.7.3
@@ -102,6 +103,7 @@ importers:
       '@babel/plugin-transform-runtime': ^7.10.5
       '@babel/preset-env': ^7.10.4
       '@rollup/plugin-json': ^4.1.0
+      '@rollup/plugin-node-resolve': ^10.0.0
       '@rollup/pluginutils': ^3.1.0
       '@types/babel__core': ^7.1.9
       rollup: ^2.23.0
@@ -1668,6 +1670,22 @@ packages:
       rollup: ^1.20.0 || ^2.0.0
     resolution:
       integrity: sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==
+  /@rollup/plugin-node-resolve/10.0.0_rollup@2.32.1:
+    dependencies:
+      '@rollup/pluginutils': 3.1.0_rollup@2.32.1
+      '@types/resolve': 1.17.1
+      builtin-modules: 3.1.0
+      deepmerge: 4.2.2
+      is-module: 1.0.0
+      resolve: 1.18.1
+      rollup: 2.32.1
+    dev: true
+    engines:
+      node: '>= 10.0.0'
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0
+    resolution:
+      integrity: sha512-sNijGta8fqzwA1VwUEtTvWCx2E7qC70NMsDh4ZG13byAXYigBNZMxALhKUSycBks5gupJdq0lFrKumFrRZ8H3A==
   /@rollup/plugin-node-resolve/8.4.0_rollup@2.32.1:
     dependencies:
       '@rollup/pluginutils': 3.1.0_rollup@2.32.1
@@ -3965,6 +3983,7 @@ packages:
     resolution:
       integrity: sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
   /fsevents/2.1.3:
+    dev: true
     engines:
       node: ^8.16.0 || ^10.6.0 || >=11.0.0
     optional: true
@@ -4141,6 +4160,7 @@ packages:
   /graphql/14.7.0:
     dependencies:
       iterall: 1.3.0
+    dev: true
     engines:
       node: '>= 6.x'
     resolution:
@@ -4746,6 +4766,7 @@ packages:
     resolution:
       integrity: sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==
   /iterall/1.3.0:
+    dev: true
     resolution:
       integrity: sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==
   /js-string-escape/1.0.1:
@@ -6600,6 +6621,7 @@ packages:
     resolution:
       integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==
   /rollup/2.32.1:
+    dev: true
     engines:
       node: '>=10.0.0'
     hasBin: true


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `@rollup/plugin-babel`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers: Fix: https://github.com/rollup/plugins/issues/500

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

When babel plugin is filtering module by file extensions, it should consider paths that contains hash and query param, and strip them out before doing file extension matching.

The motivation and implementation is similar to [how node-resolve plugin support hash and query](https://github.com/rollup/plugins/pull/487).
