### PR TITLE
docs(babel): Add warning to tell about configuration name change runtimeHelpers -> babelHelpers

### DIFF
--- a/packages/babel/src/index.js
+++ b/packages/babel/src/index.js
@@ -30,6 +30,21 @@ const unpackOptions = ({
 };
 
 const unpackInputPluginOptions = ({ skipPreflightCheck = false, ...rest }, rollupVersion) => {
+  if ('runtimeHelpers' in rest) {
+    const valueAsString = `runtimeHelpers: ${rest.runtimeHelpers}`;
+    const suggestion =
+      rest.runtimeHelpers === true
+        ? `try changing your configuration to babelHelpers: 'runtime'. `
+        : '';
+    // eslint-disable-next-line no-console
+    console.warn(
+      '"runtimeHelpers" is now called "babelHelpers". ' +
+        `At the moment, your configuration is set as ${valueAsString}. ` +
+        suggestion +
+        'Refer to the documentation to adjust to your use-case. ' +
+        'https://rollupjs.org/guide/en/#babel'
+    );
+  }
   if (!rest.babelHelpers) {
     // eslint-disable-next-line no-console
     console.warn(

--- a/packages/babel/src/index.js
+++ b/packages/babel/src/index.js
@@ -29,23 +29,26 @@ const unpackOptions = ({
   };
 };
 
+const warnAboutDeprecatedHelpersOption = ({ deprecatedOption, suggestion }) => {
+  // eslint-disable-next-line no-console
+  console.warn(
+    `\`${deprecatedOption}\` has been removed in favor a \`babelHelpers\` option. Try changing your configuration to \`${suggestion}\`. ` +
+      `Refer to the documentation to learn more: https://github.com/rollup/plugins/tree/master/packages/babel#babelhelpers`
+  );
+}
+
 const unpackInputPluginOptions = ({ skipPreflightCheck = false, ...rest }, rollupVersion) => {
   if ('runtimeHelpers' in rest) {
-    const valueAsString = `runtimeHelpers: ${rest.runtimeHelpers}`;
-    const suggestion =
-      rest.runtimeHelpers === true
-        ? `try changing your configuration to babelHelpers: 'runtime'. `
-        : '';
-    // eslint-disable-next-line no-console
-    console.warn(
-      '"runtimeHelpers" is now called "babelHelpers". ' +
-        `At the moment, your configuration is set as ${valueAsString}. ` +
-        suggestion +
-        'Refer to the documentation to adjust to your use-case. ' +
-        'https://rollupjs.org/guide/en/#babel'
-    );
-  }
-  if (!rest.babelHelpers) {
+    warnAboutDeprecatedHelpersOption({
+      deprecatedOption: 'runtimeHelpers',
+      suggestion: `babelHelpers: 'runtime'`
+    });
+  } else if ('externalHelpers' in rest) {
+    warnAboutDeprecatedHelpersOption({
+      deprecatedOption: 'externalHelpers',
+      suggestion: `babelHelpers: 'external'`
+    });
+  } else if (!rest.babelHelpers) {
     // eslint-disable-next-line no-console
     console.warn(
       "babelHelpers: 'bundled' option was used by default. It is recommended to configure this option explicitly, read more here: " +


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `babel`

This PR contains:

- [x] documentation
- [x] other

Are tests included?

- [x] no

Breaking Changes?

- [x] no

### Description

When a person upgrades from earlier version of `@rollup/plugin-babel` (say, [from the time of `rollup-plugin-babel` for a use-case such as the one in this issue](https://github.com/rollup/rollup-plugin-babel/issues/322)) which used `runtimeHelpers`, gets into error somewhere between other errors and unexpected outputs with a behavior change.

I wished, as a user of this fine package, that the error message would've told me about the variable name change.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
