### PR TITLE
fix(typescript): Change `noEmitOnError` default to false

### DIFF
--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -13,7 +13,7 @@
 
 ## Requirements
 
-This plugin requires an [LTS](https://github.com/nodejs/Release) Node version (v8.0.0+) and Rollup v1.20.0+. Due to the use of `tslib` to inject helpers, this plugin requires at least [TypeScript 2.1](https://github.com/Microsoft/TypeScript/wiki/Roadmap#21-december-2016). See also [here](https://blog.mariusschulz.com/2016/12/16/typescript-2-1-external-helpers-library#the-importhelpers-flag-and-tslib).
+This plugin requires an [LTS](https://github.com/nodejs/Release) Node version (v8.0.0+) and Rollup v1.20.0+. This plugin also requires at least [TypeScript 3.4](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html).
 
 ## Install
 
@@ -41,9 +41,9 @@ export default {
   input: 'src/index.ts',
   output: {
     dir: 'output',
-    format: 'cjs'
+    format: 'cjs',
   },
-  plugins: [typescript()]
+  plugins: [typescript()],
 };
 ```
 
@@ -95,7 +95,7 @@ Overrides the TypeScript module used for transpilation.
 
 ```js
 typescript({
-  typescript: require('some-fork-of-typescript')
+  typescript: require('some-fork-of-typescript'),
 });
 ```
 
@@ -108,7 +108,7 @@ Overrides the injected TypeScript helpers with a custom version.
 
 ```js
 typescript({
-  tslib: require.resolve('some-fork-of-tslib')
+  tslib: require.resolve('some-fork-of-tslib'),
 });
 ```
 
@@ -119,7 +119,7 @@ Some of Typescript's [CompilerOptions](https://www.typescriptlang.org/docs/handb
 #### `noEmitOnError`
 
 Type: `Boolean`<br>
-Default: `true`
+Default: `false`
 
 If a type error is detected, the Rollup build is aborted when this option is set to true.
 
@@ -151,8 +151,8 @@ export default {
   input: './main.ts',
   plugins: [
     typescript({ module: 'CommonJS' }),
-    commonjs({ extensions: ['.js', '.ts'] }) // the ".ts" extension is required
-  ]
+    commonjs({ extensions: ['.js', '.ts'] }), // the ".ts" extension is required
+  ],
 };
 ```
 
@@ -180,7 +180,7 @@ import typescript from '@rollup/plugin-typescript';
 export default {
   // … other options …
   acornInjectPlugins: [jsx()],
-  plugins: [typescript({ jsx: 'preserve' })]
+  plugins: [typescript({ jsx: 'preserve' })],
 };
 ```
 

--- a/packages/typescript/src/options/interfaces.ts
+++ b/packages/typescript/src/options/interfaces.ts
@@ -8,7 +8,6 @@ export type CompilerOptions = import('typescript').CompilerOptions;
 
 export const DEFAULT_COMPILER_OPTIONS: PartialCompilerOptions = {
   module: 'esnext',
-  noEmitOnError: true,
   skipLibCheck: true
 };
 

--- a/packages/typescript/test/fixtures/syntax-error/tsconfig.json
+++ b/packages/typescript/test/fixtures/syntax-error/tsconfig.json
@@ -1,1 +1,5 @@
-{}
+{
+  "compilerOptions": {
+    "noEmitOnError": true
+  }
+}


### PR DESCRIPTION
BREAKING CHANGE: `noEmitOnError` now defaults to false instead of true. This means that Rollup will show a warning when type errors are encountered but will still compile. The previous behaviour is available by changing the setting to `true`.

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `typescript`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [x] yes (_breaking changes will not be merged unless absolutely necessary_)
- [ ] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

For watch mode to work, warnings must be used instead of errors. This behaviour better matches how Typescript works, since it only warns for type errors but compiles anyways. However, its different from how bundlers like Webpack work, as they usually fail. 