### PR TITLE
feat(pluginutils): normalizePath

### DIFF
--- a/packages/pluginutils/README.md
+++ b/packages/pluginutils/README.md
@@ -232,6 +232,22 @@ makeLegalIdentifier('foo-bar'); // 'foo_bar'
 makeLegalIdentifier('typeof'); // '_typeof'
 ```
 
+### normalizePath
+
+Converts path separators to forward slash.
+
+Parameters: `(filename: String)`<br>
+Returns: `String`
+
+#### Usage
+
+```js
+import { normalizePath } from '@rollup/pluginutils';
+
+normalizePath('foo\\bar'); // 'foo/bar'
+normalizePath('foo/bar'); // 'foo/bar'
+```
+
 ## Meta
 
 [CONTRIBUTING](/.github/CONTRIBUTING.md)

--- a/packages/pluginutils/README.md
+++ b/packages/pluginutils/README.md
@@ -50,9 +50,9 @@ export default function myPlugin(options = {}) {
   return {
     resolveId(code, id) {
       // only adds an extension if there isn't one already
-      id = addExtension(id); // `foo` -> `foo.js`, `foo.js -> foo.js`
-      id = addExtension(id, '.myext'); // `foo` -> `foo.myext`, `foo.js -> `foo.js`
-    }
+      id = addExtension(id); // `foo` -> `foo.js`, `foo.js` -> `foo.js`
+      id = addExtension(id, '.myext'); // `foo` -> `foo.myext`, `foo.js` -> `foo.js`
+    },
   };
 }
 ```
@@ -88,9 +88,9 @@ export default function myPlugin(options = {}) {
         },
         leave(node) {
           if (node.scope) scope = scope.parent;
-        }
+        },
       });
-    }
+    },
   };
 }
 ```
@@ -126,7 +126,7 @@ import { createFilter } from '@rollup/pluginutils';
 export default function myPlugin(options = {}) {
   // assume that the myPlugin accepts options of `options.include` and `options.exclude`
   var filter = createFilter(options.include, options.exclude, {
-    resolve: '/my/base/dir'
+    resolve: '/my/base/dir',
   });
 
   return {
@@ -134,7 +134,7 @@ export default function myPlugin(options = {}) {
       if (!filter(id)) return;
 
       // proceed with the transformation...
-    }
+    },
   };
 }
 ```
@@ -160,14 +160,14 @@ import { dataToEsm } from '@rollup/pluginutils';
 const esModuleSource = dataToEsm(
   {
     custom: 'data',
-    to: ['treeshake']
+    to: ['treeshake'],
   },
   {
     compact: false,
     indent: '\t',
     preferConst: false,
     objectShorthand: false,
-    namedExports: true
+    namedExports: true,
   }
 );
 /*
@@ -207,11 +207,11 @@ export default function myPlugin(options = {}) {
           if (node.type === 'VariableDeclarator') {
             const declaredNames = extractAssignedNames(node.id);
             // do something with the declared names
-            // e.g. for `const {x, y: z} = ... => declaredNames = ['x', 'z']
+            // e.g. for `const {x, y: z} = ...` => declaredNames = ['x', 'z']
           }
-        }
+        },
       });
-    }
+    },
   };
 }
 ```

--- a/packages/pluginutils/src/createFilter.ts
+++ b/packages/pluginutils/src/createFilter.ts
@@ -1,10 +1,11 @@
-import { resolve, sep, posix, isAbsolute } from 'path';
+import { resolve, posix, isAbsolute } from 'path';
 
 import pm from 'picomatch';
 
 import { CreateFilter } from '../types';
 
 import ensureArray from './utils/ensureArray';
+import normalizePath from './normalizePath';
 
 function getMatcherString(id: string, resolutionBase: string | false | null | undefined) {
   if (resolutionBase === false || isAbsolute(id) || id.startsWith('*')) {
@@ -12,9 +13,7 @@ function getMatcherString(id: string, resolutionBase: string | false | null | un
   }
 
   // resolve('') is valid and will default to process.cwd()
-  const basePath = resolve(resolutionBase || '')
-    .split(sep)
-    .join('/')
+  const basePath = normalizePath(resolve(resolutionBase || ''))
     // escape all possible (posix + win) path characters that might interfere with regex
     .replace(/[-^$*+?.()|[\]{}]/g, '\\$&');
   // Note that we use posix.join because:
@@ -48,7 +47,7 @@ const createFilter: CreateFilter = function createFilter(include?, exclude?, opt
     if (typeof id !== 'string') return false;
     if (/\0/.test(id)) return false;
 
-    const pathId = id.split(sep).join('/');
+    const pathId = normalizePath(id);
 
     for (let i = 0; i < excludeMatchers.length; ++i) {
       const matcher = excludeMatchers[i];

--- a/packages/pluginutils/src/index.ts
+++ b/packages/pluginutils/src/index.ts
@@ -4,6 +4,7 @@ import createFilter from './createFilter';
 import dataToEsm from './dataToEsm';
 import extractAssignedNames from './extractAssignedNames';
 import makeLegalIdentifier from './makeLegalIdentifier';
+import normalizePath from './normalizePath';
 
 export {
   addExtension,
@@ -11,7 +12,8 @@ export {
   createFilter,
   dataToEsm,
   extractAssignedNames,
-  makeLegalIdentifier
+  makeLegalIdentifier,
+  normalizePath
 };
 
 // TODO: remove this in next major
@@ -21,5 +23,6 @@ export default {
   createFilter,
   dataToEsm,
   extractAssignedNames,
-  makeLegalIdentifier
+  makeLegalIdentifier,
+  normalizePath
 };

--- a/packages/pluginutils/src/normalizePath.ts
+++ b/packages/pluginutils/src/normalizePath.ts
@@ -1,0 +1,9 @@
+import { win32, posix } from 'path';
+
+import { NormalizePath } from '../types';
+
+const normalizePath: NormalizePath = function(filename: string) {
+  return filename.split(win32.sep).join(posix.sep);
+};
+
+export { normalizePath as default };

--- a/packages/pluginutils/test/createFilter.ts
+++ b/packages/pluginutils/test/createFilter.ts
@@ -1,13 +1,10 @@
-import { resolve as rawResolve, sep } from 'path';
+import { resolve as rawResolve } from 'path';
 
 import test from 'ava';
 
-import { createFilter } from '../';
+import { createFilter, normalizePath } from '../';
 
-const resolve = (...parts: string[]) =>
-  rawResolve(...parts)
-    .split(sep)
-    .join('/');
+const resolve = (...parts: string[]) => normalizePath(rawResolve(...parts));
 
 test.beforeEach(() => process.chdir(__dirname));
 

--- a/packages/pluginutils/test/createFilter.ts
+++ b/packages/pluginutils/test/createFilter.ts
@@ -1,8 +1,13 @@
-import { resolve } from 'path';
+import { resolve as rawResolve, sep } from 'path';
 
 import test from 'ava';
 
 import { createFilter } from '../';
+
+const resolve = (...parts: string[]) =>
+  rawResolve(...parts)
+    .split(sep)
+    .join('/');
 
 test.beforeEach(() => process.chdir(__dirname));
 

--- a/packages/pluginutils/test/normalizePath.ts
+++ b/packages/pluginutils/test/normalizePath.ts
@@ -1,0 +1,17 @@
+import test from 'ava';
+
+import { normalizePath } from '../';
+
+test('replaces \\ with /', (t) => {
+  t.is(normalizePath('foo\\bar'), 'foo/bar');
+  t.is(normalizePath('foo\\bar\\baz'), 'foo/bar/baz');
+});
+
+test('ignores forward slash', (t) => {
+  t.is(normalizePath('foo/bar'), 'foo/bar');
+  t.is(normalizePath('foo/bar\\baz'), 'foo/bar/baz');
+});
+
+test('handles empty string', (t) => {
+  t.is(normalizePath(''), '');
+});

--- a/packages/pluginutils/types/index.d.ts
+++ b/packages/pluginutils/types/index.d.ts
@@ -68,11 +68,17 @@ export function extractAssignedNames(param: BaseNode): string[];
  */
 export function makeLegalIdentifier(str: string): string;
 
+/**
+ * Converts path separators to forward slash.
+ */
+export function normalizePath(filename: string): string;
+
 export type AddExtension = typeof addExtension;
 export type AttachScopes = typeof attachScopes;
 export type CreateFilter = typeof createFilter;
 export type ExtractAssignedNames = typeof extractAssignedNames;
 export type MakeLegalIdentifier = typeof makeLegalIdentifier;
+export type NormalizePath = typeof normalizePath;
 export type DataToEsm = typeof dataToEsm;
 
 declare const defaultExport: {
@@ -82,5 +88,6 @@ declare const defaultExport: {
   dataToEsm: DataToEsm;
   extractAssignedNames: ExtractAssignedNames;
   makeLegalIdentifier: MakeLegalIdentifier;
+  normalizePath: NormalizePath;
 };
 export default defaultExport;


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `pluginutils`

This PR contains:

- [x] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

This PR includes:

1. A new utility `normalizePath`.
2. Fixes a bug on Windows. On Windows 10, test failed because `path.resolve` creates patterns including backward slash `\`. This patch adds a normalization similar to `createFilter`:
https://github.com/rollup/plugins/blob/55a9cb20d7686750aa104d6a45a7d6834f57ba4a/packages/pluginutils/src/createFilter.ts#L15-L17
3. Small quotes typo in README.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
