### PR TITLE
test(typescript): add generating declarations with non-default rootDir

### DIFF
--- a/packages/typescript/test/fixtures/declaration-root-dir/src/main.ts
+++ b/packages/typescript/test/fixtures/declaration-root-dir/src/main.ts
@@ -1,0 +1,3 @@
+const answer = 42;
+// eslint-disable-next-line no-console
+console.log(`the answer is ${answer}`);

--- a/packages/typescript/test/fixtures/declaration-root-dir/tsconfig.json
+++ b/packages/typescript/test/fixtures/declaration-root-dir/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "outDir": "lib",
+    "rootDir": "src"
+  }
+}

--- a/packages/typescript/test/test.js
+++ b/packages/typescript/test/test.js
@@ -82,6 +82,28 @@ test.serial('supports creating declaration files in subfolder', async (t) => {
   t.true(declarationSource.includes('//# sourceMappingURL=main.d.ts.map'), declarationSource);
 });
 
+test.serial('supports creating declarations with non-default rootDir', async (t) => {
+  const bundle = await rollup({
+    input: 'fixtures/declaration-root-dir/src/main.ts',
+    plugins: [
+      typescript({
+        tsconfig: 'fixtures/declaration-root-dir/tsconfig.json'
+      })
+    ],
+    onwarn
+  });
+  const output = await getCode(
+    bundle,
+    { format: 'esm', dir: 'fixtures/declaration-root-dir/lib' },
+    true
+  );
+
+  t.deepEqual(
+    output.map((out) => out.fileName),
+    ['main.js', 'main.d.ts']
+  );
+});
+
 test.serial('supports creating declaration files for interface only source file', async (t) => {
   const bundle = await rollup({
     input: 'fixtures/export-interface-only/main.ts',


### PR DESCRIPTION
<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `typescript`



- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

### Description

This PR relates to https://github.com/rollup/plugins/issues/287 and adds working example of declarations being generated with non-default `rootDir` specified. This PR might also be supplemented by failing test and additional input configs validation as described in this comment https://github.com/rollup/plugins/issues/287#issuecomment-678757955.
