### PR TITLE
feat(commonjs): add requireReturnsDefault to types

### DIFF
--- a/packages/commonjs/types/index.d.ts
+++ b/packages/commonjs/types/index.d.ts
@@ -55,6 +55,22 @@ interface RollupCommonJSOptions {
    *   like `"/Users/John/Desktop/foo-project/"` -> `"/"`.
    */
   dynamicRequireTargets?: string | ReadonlyArray<string>;
+  /**
+   * Controls what is returned when requiring an ES module or external dependency
+   * from a CommonJS file. By default, this plugin will render it as a namespace
+   * import, i.e.
+   *
+   * ```js
+   * // input
+   * const foo = require('foo');
+   *
+   * // output
+   * import * as foo from 'foo';
+   * ```
+   *
+   * @default false
+   */
+  requireReturnsDefault?: boolean | 'auto' | 'preferred' | ((id: string) => boolean | 'auto' | 'preferred');
 }
 
 /**


### PR DESCRIPTION

## Rollup Plugin Name:  commonjs

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

add `requireReturnsDefault` to `types/index.d.ts`
