### PR TITLE
fix(babel): clone cached helper identifier before returning it

### DIFF
--- a/packages/babel/src/bundledHelpersPlugin.js
+++ b/packages/babel/src/bundledHelpersPlugin.js
@@ -2,7 +2,7 @@ import { addNamed } from '@babel/helper-module-imports';
 
 import { HELPERS } from './constants';
 
-export default function importHelperPlugin() {
+export default function importHelperPlugin({ types: t }) {
   return {
     pre(file) {
       const cachedHelpers = {};
@@ -12,7 +12,7 @@ export default function importHelperPlugin() {
         }
 
         if (cachedHelpers[name]) {
-          return cachedHelpers[name];
+          return t.cloneNode(cachedHelpers[name]);
         }
 
         return (cachedHelpers[name] = addNamed(file.path, name, HELPERS));


### PR DESCRIPTION
## Rollup Plugin Name: `babel`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

### Description

I don't really have a failing test for this and I don't think it's worth testing any implementation details to just have this verified. Usually one doesn't have to worry about inserting duplicated nodes but it's a good practice to never do this and always insert fresh nodes.