### PR TITLE
fix(node-resolve): resolve hash in path

### DIFF
--- a/packages/node-resolve/src/index.js
+++ b/packages/node-resolve/src/index.js
@@ -101,7 +101,12 @@ export function nodeResolve(opts = {}) {
       if (/\0/.test(importee)) return null;
 
       // strip hash and query params from import
-      const [withoutHash, hash] = importee.split('#');
+      let [withoutHash, hash] = importee.split('#');
+      // handle hash in path test/#/foo
+      if (hash && hash[0] === '/') {
+        withoutHash = `${withoutHash}#${hash}`;
+        hash = '';
+      }
       const [importPath, params] = withoutHash.split('?');
       const importSuffix = `${params ? `?${params}` : ''}${hash ? `#${hash}` : ''}`;
       importee = importPath;

--- a/packages/node-resolve/src/index.js
+++ b/packages/node-resolve/src/index.js
@@ -18,7 +18,7 @@ import {
 const builtins = new Set(builtinList);
 const ES6_BROWSER_EMPTY = '\0node-resolve:empty.js';
 const nullFn = () => null;
-const deepFreeze = object => {
+const deepFreeze = (object) => {
   Object.freeze(object);
 
   for (const value of Object.values(object)) {
@@ -100,15 +100,9 @@ export function nodeResolve(opts = {}) {
       // ignore IDs with null character, these belong to other plugins
       if (/\0/.test(importee)) return null;
 
-      // strip hash and query params from import
-      let [withoutHash, hash] = importee.split('#');
-      // handle hash in path test/#/foo
-      if (hash && hash[0] === '/') {
-        withoutHash = `${withoutHash}#${hash}`;
-        hash = '';
-      }
-      const [importPath, params] = withoutHash.split('?');
-      const importSuffix = `${params ? `?${params}` : ''}${hash ? `#${hash}` : ''}`;
+      // strip query params from import
+      const [importPath, params] = importee.split('?');
+      const importSuffix = `${params ? `?${params}` : ''}`;
       importee = importPath;
 
       const basedir = !importer || dedupe(importee) ? rootDir : dirname(importer);

--- a/packages/node-resolve/test/fixtures/hash-in-path.js
+++ b/packages/node-resolve/test/fixtures/hash-in-path.js
@@ -1,0 +1,3 @@
+import test from 'test/#/foo';
+
+export default test;

--- a/packages/node-resolve/test/fixtures/hash.js
+++ b/packages/node-resolve/test/fixtures/hash.js
@@ -1,3 +1,0 @@
-import test from 'test#foo';
-
-export default test;

--- a/packages/node-resolve/test/fixtures/node_modules/test/#/foo.js
+++ b/packages/node-resolve/test/fixtures/node_modules/test/#/foo.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/packages/node-resolve/test/test.js
+++ b/packages/node-resolve/test/test.js
@@ -261,6 +261,27 @@ test('can resolve imports with hashes', async (t) => {
   t.is(module.exports, 'resolved with hash');
 });
 
+test('can resolve imports with hash in path', async (t) => {
+  const bundle = await rollup({
+    input: 'hash-in-path.js',
+    onwarn: () => t.fail('No warnings were expected'),
+    plugins: [
+      nodeResolve(),
+      {
+        load(id) {
+          if (id === resolve(__dirname, 'fixtures', 'node_modules', 'test', '#', 'foo.js')) {
+            return 'export default "resolved with hash"';
+          }
+          return null;
+        }
+      }
+    ]
+  });
+  const { module } = await testBundle(t, bundle);
+
+  t.is(module.exports, 'resolved with hash');
+});
+
 test('can resolve imports with search params', async (t) => {
   const bundle = await rollup({
     input: 'search-params.js',

--- a/packages/node-resolve/test/test.js
+++ b/packages/node-resolve/test/test.js
@@ -240,27 +240,6 @@ test('handles package side-effects', async (t) => {
   delete global.sideEffects;
 });
 
-test('can resolve imports with hashes', async (t) => {
-  const bundle = await rollup({
-    input: 'hash.js',
-    onwarn: () => t.fail('No warnings were expected'),
-    plugins: [
-      nodeResolve(),
-      {
-        load(id) {
-          if (id === resolve(__dirname, 'fixtures', 'node_modules', 'test', 'index.js#foo')) {
-            return 'export default "resolved with hash"';
-          }
-          return null;
-        }
-      }
-    ]
-  });
-  const { module } = await testBundle(t, bundle);
-
-  t.is(module.exports, 'resolved with hash');
-});
-
 test('can resolve imports with hash in path', async (t) => {
   const bundle = await rollup({
     input: 'hash-in-path.js',


### PR DESCRIPTION

## Rollup Plugin Name: @rollup/plugin-node-resolve

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [x] yes (_breaking changes will not be merged unless absolutely necessary_)
- [ ] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

This PR is fixing https://github.com/rollup/plugins/issues/587

```
import test from 'test#foo'
```

treats as hash usage

```
import test from 'test/#/foo'
```

treats `hash` as part of package path