### PR TITLE
Feat resolve fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
       "prettier --single-quote --write"
     ],
     "*package.json": [
-      "prettier --write --plugin=prettier-plugin-package"
+      "prettier --write --plugin=prettier-plugin-package --with-node-modules"
     ]
   },
   "nyc": {

--- a/packages/node-resolve/src/fs.js
+++ b/packages/node-resolve/src/fs.js
@@ -7,3 +7,4 @@ export const readFile = promisify(fs.readFile);
 export const realpath = promisify(fs.realpath);
 export { realpathSync } from 'fs';
 export const stat = promisify(fs.stat);
+export const existsSync = fs.existsSync;

--- a/packages/node-resolve/src/util.js
+++ b/packages/node-resolve/src/util.js
@@ -5,7 +5,7 @@ import { createFilter } from '@rollup/pluginutils';
 
 import resolveModule from 'resolve';
 
-import { realpathSync } from './fs';
+import { realpathSync, existsSync } from './fs';
 
 const resolveId = promisify(resolveModule);
 
@@ -84,10 +84,13 @@ export function getPackageInfo(options) {
   for (let i = 0; i < mainFields.length; i++) {
     const field = mainFields[i];
     if (typeof pkg[field] === 'string') {
-      pkg.main = pkg[field];
-      packageInfo.resolvedMainField = field;
-      overriddenMain = true;
-      break;
+      const fieldPath = resolve(pkgRoot, pkg[field]); 
+      if (existsSync(fieldPath)) {
+        pkg.main = pkg[field];
+        packageInfo.resolvedMainField = field;
+        overriddenMain = true;
+        break;
+      }
     }
   }
 

--- a/packages/node-resolve/test/fixtures/module-non-exists.js
+++ b/packages/node-resolve/test/fixtures/module-non-exists.js
@@ -1,0 +1,3 @@
+import module from 'module-non-exists';
+
+export default module; // MODULE

--- a/packages/node-resolve/test/fixtures/node_modules/module-non-exists/entry.main.js
+++ b/packages/node-resolve/test/fixtures/node_modules/module-non-exists/entry.main.js
@@ -1,0 +1,1 @@
+export default "MAIN";

--- a/packages/node-resolve/test/fixtures/node_modules/module-non-exists/package.json
+++ b/packages/node-resolve/test/fixtures/node_modules/module-non-exists/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "entry.main.js",
+  "module": "entry.module.js"
+}

--- a/packages/node-resolve/test/test.js
+++ b/packages/node-resolve/test/test.js
@@ -22,6 +22,17 @@ test('finds a module with jsnext:main', async (t) => {
   t.is(module.exports, 'JSNEXT');
 });
 
+test('finds a fallback main with non-exists module', async (t) => {
+  const bundle = await rollup({
+    input: 'module-non-exists.js',
+    onwarn: () => t.fail('No warnings were expected'),
+    plugins: [nodeResolve({ mainFields: ['module', 'main'] })]
+  });
+  const { module } = await testBundle(t, bundle);
+
+  t.is(module.exports, 'MAIN');
+});
+
 test('finds and converts a basic CommonJS module', async (t) => {
   const bundle = await rollup({
     input: 'commonjs.js',


### PR DESCRIPTION
## Rollup Plugin Name: `@rollup/plugin-node-resolve`

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

Assuming a  package has the following package.json

```
{ 
  "main": "entry.main.js",
  "module": "entry.esm.js"
}
```

config `@rollup/plugin-node-resolve` with `mainFields: ['module', 'main']`.

but, `entry.esm.js` does not exist. This leads to a `MODULE_NOT_FOUND` error. After this PR merged, `resolve` can fallback to the next `mainField`. `main` in this case.
