### PR TITLE
Clarify docstring

### DIFF
--- a/packages/typescript/types/index.d.ts
+++ b/packages/typescript/types/index.d.ts
@@ -9,8 +9,7 @@ export interface RollupTypescriptPluginOptions {
    */
   include?: FilterPattern;
   /**
-   * Determine which files are transpiled by Typescript (all `.ts` and
-   * `.tsx` files by default).
+   * Determine which files are ignored by Typescript
    */
   exclude?: FilterPattern;
   /**


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `{typescript}`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

I noticed while trying to debug an error that the docstring for the `exclude` field was (erroneously) the same as the `include` field. That's all.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
