### PR TITLE
refact(wasm): use helper module instead of banner

### DIFF
--- a/packages/wasm/src/helper.ts
+++ b/packages/wasm/src/helper.ts
@@ -1,0 +1,55 @@
+export const HELPERS_ID = '\0wasmHelpers.js';
+
+export const getHelpersModule = () => `
+function _loadWasmModule (sync, filepath, src, imports) {
+  function _instantiateOrCompile(source, imports, stream) {
+    var instantiateFunc = stream ? WebAssembly.instantiateStreaming : WebAssembly.instantiate;
+    var compileFunc = stream ? WebAssembly.compileStreaming : WebAssembly.compile;
+
+    if (imports) {
+      return instantiateFunc(source, imports)
+    } else {
+      return compileFunc(source)
+    }
+  }
+
+  var buf = null
+  var isNode = typeof process !== 'undefined' && process.versions != null && process.versions.node != null
+
+  if (filepath && isNode) {
+    var fs = eval('require("fs")')
+    var path = eval('require("path")')
+
+    return new Promise((resolve, reject) => {
+      fs.readFile(path.resolve(__dirname, filepath), (error, buffer) => {
+        if (error != null) {
+          reject(error)
+        }
+
+        resolve(_instantiateOrCompile(buffer, imports, false))
+      });
+    });
+  } else if (filepath) {
+    return _instantiateOrCompile(fetch(filepath), imports, true)
+  }
+
+  if (isNode) {
+    buf = Buffer.from(src, 'base64')
+  } else {
+    var raw = globalThis.atob(src)
+    var rawLength = raw.length
+    buf = new Uint8Array(new ArrayBuffer(rawLength))
+    for(var i = 0; i < rawLength; i++) {
+       buf[i] = raw.charCodeAt(i)
+    }
+  }
+
+  if(sync) {
+    var mod = new WebAssembly.Module(buf)
+    return imports ? new WebAssembly.Instance(mod, imports) : mod
+  } else {
+    return _instantiateOrCompile(buf, imports, false)
+  }
+}
+export { _loadWasmModule };
+`;

--- a/packages/wasm/src/index.ts
+++ b/packages/wasm/src/index.ts
@@ -6,6 +6,8 @@ import { Plugin } from 'rollup';
 
 import { RollupWasmOptions } from '../types';
 
+import { getHelpersModule, HELPERS_ID } from './helper';
+
 export function wasm(options: RollupWasmOptions = {}): Plugin {
   const { sync = [], maxFileSize = 14 * 1024, publicPath = '' } = options;
 
@@ -15,7 +17,19 @@ export function wasm(options: RollupWasmOptions = {}): Plugin {
   return {
     name: 'wasm',
 
+    resolveId(id) {
+      if (id === HELPERS_ID) {
+        return id;
+      }
+
+      return null;
+    },
+
     load(id) {
+      if (id === HELPERS_ID) {
+        return getHelpersModule();
+      }
+
       if (!/\.wasm$/.test(id)) {
         return null;
       }
@@ -46,59 +60,6 @@ export function wasm(options: RollupWasmOptions = {}): Plugin {
       );
     },
 
-    banner: `
-      function _loadWasmModule (sync, filepath, src, imports) {
-        function _instantiateOrCompile(source, imports, stream) {
-          var instantiateFunc = stream ? WebAssembly.instantiateStreaming : WebAssembly.instantiate;
-          var compileFunc = stream ? WebAssembly.compileStreaming : WebAssembly.compile;
-          
-          if (imports) {
-            return instantiateFunc(source, imports)
-          } else {
-            return compileFunc(source)
-          }
-        }
-
-        var buf = null
-        var isNode = typeof process !== 'undefined' && process.versions != null && process.versions.node != null
-        
-        if (filepath && isNode) {
-          var fs = eval('require("fs")')
-          var path = eval('require("path")')
-
-          return new Promise((resolve, reject) => {
-            fs.readFile(path.resolve(__dirname, filepath), (error, buffer) => {
-              if (error != null) {
-                reject(error)
-              }
-
-              resolve(_instantiateOrCompile(buffer, imports, false))
-            });
-          });
-        } else if (filepath) {
-          return _instantiateOrCompile(fetch(filepath), imports, true)
-        }
-        
-        if (isNode) {
-          buf = Buffer.from(src, 'base64')
-        } else {
-          var raw = globalThis.atob(src)
-          var rawLength = raw.length
-          buf = new Uint8Array(new ArrayBuffer(rawLength))
-          for(var i = 0; i < rawLength; i++) {
-             buf[i] = raw.charCodeAt(i)
-          }
-        }
-
-        if(sync) {
-          var mod = new WebAssembly.Module(buf)
-          return imports ? new WebAssembly.Instance(mod, imports) : mod
-        } else {
-          return _instantiateOrCompile(buf, imports, false)
-        }
-      }
-    `.trim(),
-
     transform(code, id) {
       if (code && /\.wasm$/.test(id)) {
         const isSync = syncFiles.indexOf(id) !== -1;
@@ -115,7 +76,8 @@ export function wasm(options: RollupWasmOptions = {}): Plugin {
           src = null;
         }
 
-        return `export default function(imports){return _loadWasmModule(${+isSync}, ${publicFilepath}, ${src}, imports)}`;
+        return `import { _loadWasmModule } from ${JSON.stringify(HELPERS_ID)};
+export default function(imports){return _loadWasmModule(${+isSync}, ${publicFilepath}, ${src}, imports)}`;
       }
       return null;
     },

--- a/packages/wasm/test/fixtures/foo.js
+++ b/packages/wasm/test/fixtures/foo.js
@@ -1,0 +1,1 @@
+export default 'foo';

--- a/packages/wasm/test/fixtures/injectHelper.js
+++ b/packages/wasm/test/fixtures/injectHelper.js
@@ -1,0 +1,8 @@
+import sample from './sample.wasm';
+import foo from './foo';
+
+const instance = sample({ env: {} });
+
+t.is(instance.exports.main(), 3, 'wasm loaded');
+
+t.is(foo, 'foo');


### PR DESCRIPTION
## Rollup Plugin Name: `@rollup/plugin-wasm`

This PR contains:

- [ ] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

For now, `wasm` plugin is using `banner` API to inject helper function `_loadWasmModule`, but it will inject this helper function in every file, even those files is unrelated to wasm things.
After this PR merged, it uses a helper module to inject `_loadWasmModule`, hopes to help removing the redundant code
