### PR TITLE
yaml plugin: provide file id to transform function

### DIFF
--- a/packages/yaml/README.md
+++ b/packages/yaml/README.md
@@ -90,8 +90,8 @@ A function which can optionally mutate parsed YAML. The function should return t
 
 ```js
 yaml({
-  transform(data) {
-    if (Array.isArray(data)) {
+  transform(data, filePath) {
+    if (Array.isArray(data) && filePath === './my-file.yml') {
       return data.filter(character => !character.batman);
     }
   }

--- a/packages/yaml/src/index.js
+++ b/packages/yaml/src/index.js
@@ -9,7 +9,7 @@ const defaults = {
 };
 const ext = /\.ya?ml$/;
 
-export default function yamll(opts = {}) {
+export default function yaml(opts = {}) {
   const options = Object.assign({}, defaults, opts);
   const { documentMode, safe } = options;
   const filter = createFilter(options.include, options.exclude);

--- a/packages/yaml/src/index.js
+++ b/packages/yaml/src/index.js
@@ -35,7 +35,7 @@ export default function yamll(opts = {}) {
       let data = loadMethod(content);
 
       if (typeof options.transform === 'function') {
-        const result = options.transform(data);
+        const result = options.transform(data, id);
         // eslint-disable-next-line no-undefined
         if (result !== undefined) {
           data = result;

--- a/packages/yaml/test/test.js
+++ b/packages/yaml/test/test.js
@@ -59,8 +59,11 @@ test('resolves extensionless imports in conjunction with nodeResolve plugin', as
 });
 
 test('applies the optional transform method to parsed YAML', async (t) => {
-  const transform = (data) => {
+  const transform = (data, filePath) => {
+    // check that transformer is passed a correct file path
+    t.truthy(typeof filePath === 'string' && filePath.endsWith('.yaml'));
     if (Array.isArray(data)) {
+      t.truthy(filePath.endsWith('array.yaml'));
       return data.filter((datum) => !datum.private);
     }
     Object.keys(data).forEach((key) => {

--- a/packages/yaml/test/test.js
+++ b/packages/yaml/test/test.js
@@ -61,9 +61,9 @@ test('resolves extensionless imports in conjunction with nodeResolve plugin', as
 test('applies the optional transform method to parsed YAML', async (t) => {
   const transform = (data, filePath) => {
     // check that transformer is passed a correct file path
-    t.truthy(typeof filePath === 'string' && filePath.endsWith('.yaml'));
+    t.true(typeof filePath === 'string' && filePath.endsWith('.yaml'), filePath);
     if (Array.isArray(data)) {
-      t.truthy(filePath.endsWith('array.yaml'));
+      t.true(filePath.endsWith('array.yaml'), filePath);
       return data.filter((datum) => !datum.private);
     }
     Object.keys(data).forEach((key) => {


### PR DESCRIPTION
## Rollup Plugin Name: `YAML`

This PR contains:

- [ ] bugfix
- [x] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

Non-breaking change since people don't have to use the extra transformer argument.

### Description

Reason for this change: I need to apply different content transformations depending on which file the data came from. Without knowing the file, the transformer function has to rely on brittle heuristics to identify the file based on its content (which can obviously change over time).

I think a new test case isn't needed for this but happy to provide one if someone thinks otherwise.