### PR TITLE
fix(typescript): add composite to validation checks

### DIFF
--- a/packages/typescript/src/options/validate.ts
+++ b/packages/typescript/src/options/validate.ts
@@ -83,7 +83,7 @@ export function validatePaths(
     }
   }
 
-  if (compilerOptions.declaration || compilerOptions.declarationMap) {
+  if (compilerOptions.declaration || compilerOptions.declarationMap || compilerOptions.composite) {
     if (DIRECTORY_PROPS.every((dirProperty) => !compilerOptions[dirProperty])) {
       context.error(
         `@rollup/plugin-typescript: 'outDir' or 'declarationDir' must be specified to generate declaration files.`

--- a/packages/typescript/test/test.js
+++ b/packages/typescript/test/test.js
@@ -189,10 +189,6 @@ test.serial('ensures outDir is set when creating declaration files (declaration)
   await ensureOutDirWhenCreatingDeclarationFiles(t, 'declaration');
 });
 
-test.serial('ensures outDir is set when creating declaration files (declarationMap)', async (t) => {
-  await ensureOutDirWhenCreatingDeclarationFiles(t, 'declarationMap');
-});
-
 test.serial('ensures outDir is set when creating declaration files (composite)', async (t) => {
   await ensureOutDirWhenCreatingDeclarationFiles(t, 'composite');
 });

--- a/packages/typescript/test/test.js
+++ b/packages/typescript/test/test.js
@@ -162,13 +162,13 @@ test.serial('supports creating declaration files in declarationDir', async (t) =
   t.true(output[1].source.includes('declare const answer = 42;'), output[1].source);
 });
 
-test.serial('ensures outDir is set when creating declaration files', async (t) => {
+async function ensureOutDirWhenCreatingDeclarationFiles(compilerOptionName) {
   const bundle = await rollup({
     input: 'fixtures/basic/main.ts',
     plugins: [
       typescript({
         tsconfig: 'fixtures/basic/tsconfig.json',
-        declaration: true
+        [compilerOptionName]: true
       })
     ],
     onwarn
@@ -183,6 +183,18 @@ test.serial('ensures outDir is set when creating declaration files', async (t) =
     ),
     `Unexpected error message: ${caughtError.message}`
   );
+}
+
+test.serial('ensures outDir is set when creating declaration files (declaration)', async (t) => {
+  ensureOutDirWhenCreatingDeclarationFiles('declaration');
+});
+
+test.serial('ensures outDir is set when creating declaration files (declarationMap)', async (t) => {
+  ensureOutDirWhenCreatingDeclarationFiles('declarationMap');
+});
+
+test.serial('ensures outDir is set when creating declaration files (composite)', async (t) => {
+  ensureOutDirWhenCreatingDeclarationFiles('composite');
 });
 
 test.serial('ensures outDir is located in Rollup output dir', async (t) => {

--- a/packages/typescript/test/test.js
+++ b/packages/typescript/test/test.js
@@ -162,7 +162,7 @@ test.serial('supports creating declaration files in declarationDir', async (t) =
   t.true(output[1].source.includes('declare const answer = 42;'), output[1].source);
 });
 
-async function ensureOutDirWhenCreatingDeclarationFiles(compilerOptionName) {
+async function ensureOutDirWhenCreatingDeclarationFiles(t, compilerOptionName) {
   const bundle = await rollup({
     input: 'fixtures/basic/main.ts',
     plugins: [
@@ -186,15 +186,15 @@ async function ensureOutDirWhenCreatingDeclarationFiles(compilerOptionName) {
 }
 
 test.serial('ensures outDir is set when creating declaration files (declaration)', async (t) => {
-  await ensureOutDirWhenCreatingDeclarationFiles('declaration');
+  await ensureOutDirWhenCreatingDeclarationFiles(t, 'declaration');
 });
 
 test.serial('ensures outDir is set when creating declaration files (declarationMap)', async (t) => {
-  await ensureOutDirWhenCreatingDeclarationFiles('declarationMap');
+  await ensureOutDirWhenCreatingDeclarationFiles(t, 'declarationMap');
 });
 
 test.serial('ensures outDir is set when creating declaration files (composite)', async (t) => {
-  await ensureOutDirWhenCreatingDeclarationFiles('composite');
+  await ensureOutDirWhenCreatingDeclarationFiles(t, 'composite');
 });
 
 test.serial('ensures outDir is located in Rollup output dir', async (t) => {

--- a/packages/typescript/test/test.js
+++ b/packages/typescript/test/test.js
@@ -186,15 +186,15 @@ async function ensureOutDirWhenCreatingDeclarationFiles(compilerOptionName) {
 }
 
 test.serial('ensures outDir is set when creating declaration files (declaration)', async (t) => {
-  ensureOutDirWhenCreatingDeclarationFiles('declaration');
+  await ensureOutDirWhenCreatingDeclarationFiles('declaration');
 });
 
 test.serial('ensures outDir is set when creating declaration files (declarationMap)', async (t) => {
-  ensureOutDirWhenCreatingDeclarationFiles('declarationMap');
+  await ensureOutDirWhenCreatingDeclarationFiles('declarationMap');
 });
 
 test.serial('ensures outDir is set when creating declaration files (composite)', async (t) => {
-  ensureOutDirWhenCreatingDeclarationFiles('composite');
+  await ensureOutDirWhenCreatingDeclarationFiles('composite');
 });
 
 test.serial('ensures outDir is located in Rollup output dir', async (t) => {


### PR DESCRIPTION
## Rollup Plugin Name: `typescript`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers: -

### Description

TypeScript's `composite` compiler option produces declaration files, too. I stumbled upon this and did get a generic validation error right at the end when the plugin wants to print the files to the outdir but cannot find one. To fix it, I added an additional check to the relevant validation.