### PR TITLE
Better error messages

### DIFF
--- a/packages/typescript/src/options/validate.ts
+++ b/packages/typescript/src/options/validate.ts
@@ -56,7 +56,7 @@ export function validatePaths(
     if (compilerOptions[dirProperty]) {
       if (!outputOptions.dir) {
         context.error(
-          `@rollup/plugin-typescript: 'dir' must be used when '${dirProperty}' is specified.`
+          `@rollup/plugin-typescript: 'output.dir' must be used in rollup config when '${dirProperty}' is specified in tsconfig.`
         );
       }
 
@@ -72,7 +72,7 @@ export function validatePaths(
   if (tsBuildInfoPath && compilerOptions.incremental) {
     if (!outputOptions.dir) {
       context.error(
-        `@rollup/plugin-typescript: 'dir' must be used when 'tsBuildInfoFile' or 'incremental' are specified.`
+        `@rollup/plugin-typescript: 'output.dir' must be used in rollup config when 'tsBuildInfoFile' or 'incremental' are specified in tsconfig.`
       );
     }
 


### PR DESCRIPTION


<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `{name}`

This PR contains:

- [x] other

Are tests included?

- [x] no

Breaking Changes?

- [x] no

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

I saw the original `'dir' must be used when 'outDir' is specified` error and spent a lot of time figuring it out because ts compiler doesn't have this 'dir' option (https://www.typescriptlang.org/docs/handbook/compiler-options.html), but the error sounds as if it should

I changed the message a bit to avoid this confusion.
