### PR TITLE
fix(multi-entry): downgrade matched dependency

### DIFF
--- a/packages/multi-entry/package.json
+++ b/packages/multi-entry/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@rollup/plugin-virtual": "^2.0.3",
-    "matched": "^5.0.0"
+    "matched": "^4.0.0"
   },
   "devDependencies": {
     "rollup": "^2.23.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -311,12 +311,12 @@ importers:
   packages/multi-entry:
     dependencies:
       '@rollup/plugin-virtual': 2.0.3_rollup@2.32.1
-      matched: 5.0.0
+      matched: 4.0.0
     devDependencies:
       rollup: 2.32.1
     specifiers:
       '@rollup/plugin-virtual': ^2.0.3
-      matched: ^5.0.0
+      matched: ^4.0.0
       rollup: ^2.23.0
   packages/node-resolve:
     dependencies:
@@ -508,7 +508,7 @@ importers:
       rollup: ^2.23.0
       source-map-support: ^0.5.19
       tosource: ^1.0.0
-lockfileVersion: 5.1
+lockfileVersion: 5.2
 packages:
   /@ava/babel/1.0.1:
     dependencies:
@@ -5099,15 +5099,15 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==
-  /matched/5.0.0:
+  /matched/4.0.0:
     dependencies:
       glob: 7.1.6
       picomatch: 2.2.2
     dev: false
     engines:
-      node: '>=12'
+      node: '>=8'
     resolution:
-      integrity: sha512-O0LCuxYYBNBjP2dmAg0i6PME0Mb0dvjulpMC0tTIeMRh6kXYsugOT5GOWpFkSzqjQjgOUs/eiyvpVhXdN2La4g==
+      integrity: sha512-mD08ireECeLL/CCgum8EeLx/SZiAmhbbt4FPlCZ4GG2xKBJ/yB8qn0uvuvouQzCORknElll2jSNVdtCWNQdR2g==
   /matcher/3.0.0:
     dependencies:
       escape-string-regexp: 4.0.0


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `multi-entry`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

The `matched@^5` dependency has an [explicit requirement](https://github.com/jonschlinkert/matched/compare/4.0.0..5.0.0) for `node@12`, which conflicts with the supportability of the plugin. This PR downgrades the version to support node 10. I am happy to provide unit tests if possible, please let me know how to move forward on that front 😄 