### PR TITLE
feat(html): add type declaration to html package

### DIFF
--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -44,6 +44,7 @@
     "rollup": "^2.23.0",
     "rollup-plugin-postcss": "^3.1.3"
   },
+  "types": "types/index.d.ts",
   "ava": {
     "babel": {
       "compileEnhancements": false

--- a/packages/html/types/index.d.ts
+++ b/packages/html/types/index.d.ts
@@ -1,0 +1,31 @@
+import { Plugin, OutputChunk, OutputAsset } from 'rollup';
+
+export interface RollupPluginHtmlOptions {
+  title?: string;
+  attributes?: Record<string, any>;
+  fileName?: string;
+  meta?: Record<string, any>[];
+  publicPath?: string;
+  template?: (templateOptions: RollupPluginHtmlTemplateOptions) => string;
+}
+
+export interface RollupPluginHtmlTemplateOptions {
+  title: string;
+  attributes: string;
+  publicPath: string;
+  bundle: Record<string, OutputChunk | OutputAsset>;
+  files: {
+    js: (OutputChunk | OutputAsset)[];
+    css: (OutputChunk | OutputAsset)[];
+    map: (OutputChunk | OutputAsset)[];
+  };
+}
+
+export function makeHtmlAttributes(attributes: Record<string, string>): string;
+
+/**
+ * A Rollup plugin which creates HTML files to serve Rollup bundles.
+ * @param options - Plugin options.
+ * @returns Plugin instance.
+ */
+export default function html(options: RollupPluginHtmlOptions): Plugin;


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `@rollup/plugin-html`

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

I've added types to the `html` plugin because while using it I saw that they were missing. I've opened another PR about the the docs (#631) and @shellscape said that it needed tests to verify the changes so I'll assume this one needs tests as well. I'll be happy to add them if you could give some hint about what would you like to see in the tests.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
