### PR TITLE
fix(typescript): type declarations

### DIFF
--- a/packages/typescript/types/index.d.ts
+++ b/packages/typescript/types/index.d.ts
@@ -38,7 +38,7 @@ export interface RollupTypescriptPluginOptions {
   transformers?: CustomTransformerFactories;
 }
 
-type ElementType<T extends Array<any>> = T extends (infer U)[] ? U : never;
+type ElementType<T extends Array<any> | undefined> = T extends (infer U)[] ? U : never;
 
 export type TransformerStage = keyof CustomTransformers;
 type StagedTransformerFactory<T extends TransformerStage> = ElementType<CustomTransformers[T]>;


### PR DESCRIPTION
## Rollup Plugin Name: `typescript`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

~~If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.~~

List any relevant issue numbers:

### Description

Before, using type definitions from this package without the `skipLibCheck` option for TypeScript would result in type checking errors. We fix this and to ensure that the types stay correct we have the checked as part of the build process by disabling the `skipLibCheck` option.