### PR TITLE
fix(typescript): normalize returned module ids

### DIFF
--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -98,7 +98,7 @@ export default function typescript(options: RollupTypescriptOptions = {}): Plugi
 
       if (resolved) {
         if (resolved.extension === '.d.ts') return null;
-        return resolved.resolvedFileName;
+        return path.normalize(resolved.resolvedFileName);
       }
 
       return null;

--- a/packages/typescript/test/fixtures/normalize-ids/one.js
+++ b/packages/typescript/test/fixtures/normalize-ids/one.js
@@ -1,0 +1,4 @@
+/* eslint-disable */
+export function one() {
+    console.log('one');
+}

--- a/packages/typescript/test/fixtures/normalize-ids/tsconfig.json
+++ b/packages/typescript/test/fixtures/normalize-ids/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+  },
+  "include": ["*.js", "**/*.js"]
+}

--- a/packages/typescript/test/fixtures/normalize-ids/two.js
+++ b/packages/typescript/test/fixtures/normalize-ids/two.js
@@ -1,0 +1,7 @@
+/* eslint-disable */
+import * as one from './one.js';
+
+export function two() {
+    one.one();
+    console.log('two');
+}

--- a/packages/typescript/test/test.js
+++ b/packages/typescript/test/test.js
@@ -927,6 +927,24 @@ test.serial('warns if sourceMap is set in Rollup but not Typescript', async (t) 
   );
 });
 
+test.serial('normalizes resolved ids to avoid duplicate output on windows', async (t) => {
+  const bundle = await rollup({
+    input: ['fixtures/normalize-ids/one.js', 'fixtures/normalize-ids/two.js'],
+    plugins: [
+      typescript({
+        include: ['*.js', '**/*.js'],
+        tsconfig: 'fixtures/normalize-ids/tsconfig.json'
+      })
+    ]
+  });
+
+  const files = await getCode(bundle, { format: 'esm' }, true);
+
+  t.is(files.length, 2);
+  t.true(files[1].fileName.includes('two.js'), files[1].fileName);
+  t.true(files[1].code.includes("import { one } from './one.js';"), files[1].code);
+});
+
 test.serial('does not warn if sourceMap is set in Rollup and unset in Typescript', async (t) => {
   const warnings = [];
   const bundle = await rollup({


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `typescript`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers: #643

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
Fix #643 by normalizing module ids to use host os separators before returning to rollup.

I initially opened this PR with just a failing test case to confirm the failure in CI before adding the fix.