### PR TITLE
docs(dynamic-import-vars): fix typo in README.md

### DIFF
--- a/packages/dynamic-import-vars/README.md
+++ b/packages/dynamic-import-vars/README.md
@@ -34,7 +34,7 @@ npm install @rollup/plugin-dynamic-import-vars --save-dev
 Create a `rollup.config.js` [configuration file](https://www.rollupjs.org/guide/en/#configuration-files) and import the plugin:
 
 ```js
-import dynamicImportVars from 'rollup/plugin-dynamic-import-vars';
+import dynamicImportVars from '@rollup/plugin-dynamic-import-vars';
 
 export default {
   plugins: [


### PR DESCRIPTION
## Rollup Plugin Name: `dynamic-import-vars`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

### Description

Typo in the import statement, should be @rollup since it's a scoped package. Fixing this typo will prevent accidental "cannot resolve module" errors ;).