### PR TITLE
feat(node-resolve): improve message when an import cannot be resolved

### DIFF
--- a/packages/node-resolve/src/index.js
+++ b/packages/node-resolve/src/index.js
@@ -190,6 +190,7 @@ export function nodeResolve(opts = {}) {
       const exportConditions = isRequire ? conditionsCjs : conditionsEsm;
 
       const resolvedWithoutBuiltins = await resolveImportSpecifiers({
+        importer,
         importSpecifierList,
         exportConditions,
         warn,

--- a/packages/node-resolve/src/resolveImportSpecifiers.js
+++ b/packages/node-resolve/src/resolveImportSpecifiers.js
@@ -11,8 +11,11 @@ import { isDirCached, isFileCached, readCachedFile } from './cache';
 const resolveImportPath = promisify(resolve);
 const readFile = promisify(fs.readFile);
 
-const pathNotFoundError = (subPath, pkgPath) =>
-  new Error(`Package subpath '${subPath}' is not defined by "exports" in ${pkgPath}`);
+const pathNotFoundError = (importer, subPath, pkgPath) =>
+  new Error(
+    `Could not resolve import in ${importer}.` +
+      ` Package subpath '${subPath}' is not defined by "exports" in ${pkgPath}`
+  );
 
 function findExportKeyMatch(exportMap, subPath) {
   for (const key of Object.keys(exportMap)) {
@@ -37,7 +40,7 @@ function findExportKeyMatch(exportMap, subPath) {
   return null;
 }
 
-function mapSubPath(pkgJsonPath, subPath, key, value) {
+function mapSubPath(importer, pkgJsonPath, subPath, key, value) {
   if (typeof value === 'string') {
     if (typeof key === 'string' && key.endsWith('*')) {
       // star match: "./foo/*": "./foo/*.js"
@@ -60,34 +63,41 @@ function mapSubPath(pkgJsonPath, subPath, key, value) {
     return value.find((v) => v.startsWith('./'));
   }
 
-  throw pathNotFoundError(subPath, pkgJsonPath);
+  throw pathNotFoundError(importer, subPath, pkgJsonPath);
 }
 
-function findEntrypoint(pkgJsonPath, subPath, exportMap, conditions, key) {
+function findEntrypoint(importer, pkgJsonPath, subPath, exportMap, conditions, key) {
   if (typeof exportMap !== 'object') {
-    return mapSubPath(pkgJsonPath, subPath, key, exportMap);
+    return mapSubPath(importer, pkgJsonPath, subPath, key, exportMap);
   }
 
   // iterate conditions recursively, find the first that matches all conditions
   for (const [condition, subExportMap] of Object.entries(exportMap)) {
     if (conditions.includes(condition)) {
-      const mappedSubPath = findEntrypoint(pkgJsonPath, subPath, subExportMap, conditions, key);
+      const mappedSubPath = findEntrypoint(
+        importer,
+        pkgJsonPath,
+        subPath,
+        subExportMap,
+        conditions,
+        key
+      );
       if (mappedSubPath) {
         return mappedSubPath;
       }
     }
   }
-  throw pathNotFoundError(subPath, pkgJsonPath);
+  throw pathNotFoundError(importer, subPath, pkgJsonPath);
 }
 
-export function findEntrypointTopLevel(pkgJsonPath, subPath, exportMap, conditions) {
+export function findEntrypointTopLevel(importer, pkgJsonPath, subPath, exportMap, conditions) {
   if (typeof exportMap !== 'object') {
     // the export map shorthand, for example { exports: "./index.js" }
     if (subPath !== '.') {
       // shorthand only supports a main entrypoint
-      throw pathNotFoundError(subPath, pkgJsonPath);
+      throw pathNotFoundError(importer, subPath, pkgJsonPath);
     }
-    return mapSubPath(pkgJsonPath, subPath, null, exportMap);
+    return mapSubPath(importer, pkgJsonPath, subPath, null, exportMap);
   }
 
   // export map is an object, the top level can be either conditions or sub path mappings
@@ -110,22 +120,23 @@ export function findEntrypointTopLevel(pkgJsonPath, subPath, exportMap, conditio
     // top level is conditions, for example { "import": ..., "require": ..., "module": ... }
     if (subPath !== '.') {
       // package with top level conditions means it only supports a main entrypoint
-      throw pathNotFoundError(subPath, pkgJsonPath);
+      throw pathNotFoundError(importer, subPath, pkgJsonPath);
     }
     exportMapForSubPath = exportMap;
   } else {
     // top level is sub path mappings, for example { ".": ..., "./foo": ..., "./bar": ... }
     key = findExportKeyMatch(exportMap, subPath);
     if (!key) {
-      throw pathNotFoundError(subPath, pkgJsonPath);
+      throw pathNotFoundError(importer, subPath, pkgJsonPath);
     }
     exportMapForSubPath = exportMap[key];
   }
 
-  return findEntrypoint(pkgJsonPath, subPath, exportMapForSubPath, conditions, key);
+  return findEntrypoint(importer, pkgJsonPath, subPath, exportMapForSubPath, conditions, key);
 }
 
 async function resolveId({
+  importer,
   importPath,
   exportConditions,
   warn,
@@ -188,6 +199,7 @@ async function resolveId({
         const packageSubPath =
           pkgName === importPath ? '.' : `.${importPath.substring(pkgName.length)}`;
         const mappedSubPath = findEntrypointTopLevel(
+          importer,
           pkgJsonPath,
           packageSubPath,
           pkgJson.exports,
@@ -231,6 +243,7 @@ async function resolveId({
 // Resolve module specifiers in order. Promise resolves to the first module that resolves
 // successfully, or the error that resulted from the last attempted module resolution.
 export async function resolveImportSpecifiers({
+  importer,
   importSpecifierList,
   exportConditions,
   warn,
@@ -245,6 +258,7 @@ export async function resolveImportSpecifiers({
   for (let i = 0; i < importSpecifierList.length; i++) {
     // eslint-disable-next-line no-await-in-loop
     const resolved = await resolveId({
+      importer,
       importPath: importSpecifierList[i],
       exportConditions,
       warn,

--- a/packages/node-resolve/test/package-entry-points.js
+++ b/packages/node-resolve/test/package-entry-points.js
@@ -135,7 +135,7 @@ test('handles main directory exports', async (t) => {
 });
 
 test('logs a warning when using shorthand and importing a subpath', async (t) => {
-  t.plan(1);
+  t.plan(2);
   const errors = [];
   await rollup({
     input: 'exports-shorthand-subpath.js',
@@ -144,11 +144,12 @@ test('logs a warning when using shorthand and importing a subpath', async (t) =>
     },
     plugins: [nodeResolve()]
   });
+  t.true(errors[0].message.includes('Could not resolve import in'));
   t.true(errors[0].message.includes('Package subpath \'./foo\' is not defined by "exports" in'));
 });
 
 test('logs a warning when a subpath cannot be found', async (t) => {
-  t.plan(1);
+  t.plan(2);
   const errors = [];
   await rollup({
     input: 'exports-non-existing-subpath.js',
@@ -157,11 +158,12 @@ test('logs a warning when a subpath cannot be found', async (t) => {
     },
     plugins: [nodeResolve()]
   });
+  t.true(errors[0].message.includes('Could not resolve import in'));
   t.true(errors[0].message.includes('Package subpath \'./bar\' is not defined by "exports" in'));
 });
 
 test('prevents importing files not specified in exports map', async (t) => {
-  t.plan(1);
+  t.plan(2);
   const errors = [];
   await rollup({
     input: 'exports-prevent-unspecified-subpath.js',
@@ -170,6 +172,7 @@ test('prevents importing files not specified in exports map', async (t) => {
     },
     plugins: [nodeResolve()]
   });
+  t.true(errors[0].message.includes('Could not resolve import in'));
   t.true(errors[0].message.includes('Package subpath \'./bar\' is not defined by "exports" in'));
 });
 


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `node-resolve`

This PR contains:

- [ ] bugfix
- [X] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [X] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [X] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

This improves the error message when a package export could not be resolved. It now points to the actual file doing the import. 

Before:

```
(!) Plugin node-resolve: Package subpath './foo' is not defined by "exports" in /Users/x/y/package.json
```

After:
```
(!) Plugin node-resolve: Could not resolve import in /Users/x/y/z.js. Package subpath './foo' is not defined by "exports" in /Users/x/y/package.json
```
