### PR TITLE
fix(node-resolve): export map specificity

### DIFF
--- a/packages/node-resolve/src/index.js
+++ b/packages/node-resolve/src/index.js
@@ -190,6 +190,7 @@ export function nodeResolve(opts = {}) {
       const exportConditions = isRequire ? conditionsCjs : conditionsEsm;
 
       const resolvedWithoutBuiltins = await resolveImportSpecifiers({
+        importer,
         importSpecifierList,
         exportConditions,
         warn,

--- a/packages/node-resolve/src/resolveImportSpecifiers.js
+++ b/packages/node-resolve/src/resolveImportSpecifiers.js
@@ -18,7 +18,15 @@ const pathNotFoundError = (importPath, importer, subPath, pkgPath) =>
   );
 
 function findExportKeyMatch(exportMap, subPath) {
-  for (const key of Object.keys(exportMap)) {
+  if (subPath in exportMap) {
+    return subPath;
+  }
+
+  const matchKeys = Object.keys(exportMap)
+    .filter((key) => key.endsWith('/') || key.endsWith('*'))
+    .sort((a, b) => b.length - a.length);
+
+  for (const key of matchKeys) {
     if (key.endsWith('*')) {
       // star match: "./foo/*": "./foo/*.js"
       const keyWithoutStar = key.substring(0, key.length - 1);

--- a/packages/node-resolve/test/fixtures/exports-directory-specificity.js
+++ b/packages/node-resolve/test/fixtures/exports-directory-specificity.js
@@ -1,0 +1,5 @@
+import a1 from 'exports-directory-specificity/one/a.js';
+import a2 from 'exports-directory-specificity/one/two/a.js';
+import a3 from 'exports-directory-specificity/one/two/three/a.js';
+
+export default { a1, a2, a3 };

--- a/packages/node-resolve/test/fixtures/exports-literal-specificity.js
+++ b/packages/node-resolve/test/fixtures/exports-literal-specificity.js
@@ -1,0 +1,3 @@
+import a from 'exports-literal-specificity/foo/a.js';
+
+export default { a };

--- a/packages/node-resolve/test/fixtures/node_modules/exports-directory-specificity/foo-one/a.js
+++ b/packages/node-resolve/test/fixtures/node_modules/exports-directory-specificity/foo-one/a.js
@@ -1,0 +1,1 @@
+export default 'foo-one a';

--- a/packages/node-resolve/test/fixtures/node_modules/exports-directory-specificity/foo-three/a.js
+++ b/packages/node-resolve/test/fixtures/node_modules/exports-directory-specificity/foo-three/a.js
@@ -1,0 +1,1 @@
+export default 'foo-three a';

--- a/packages/node-resolve/test/fixtures/node_modules/exports-directory-specificity/foo-two/a.js
+++ b/packages/node-resolve/test/fixtures/node_modules/exports-directory-specificity/foo-two/a.js
@@ -1,0 +1,1 @@
+export default 'foo-two a';

--- a/packages/node-resolve/test/fixtures/node_modules/exports-directory-specificity/package.json
+++ b/packages/node-resolve/test/fixtures/node_modules/exports-directory-specificity/package.json
@@ -1,0 +1,9 @@
+{
+	"name": "exports-directory-specificity",
+	"main": "index.js",
+	"exports": {
+		"./one/": "./foo-one/",
+		"./one/two/": "./foo-two/",
+		"./one/two/three/": "./foo-three/"
+	}
+}

--- a/packages/node-resolve/test/fixtures/node_modules/exports-literal-specificity/exported-foo/a.js
+++ b/packages/node-resolve/test/fixtures/node_modules/exports-literal-specificity/exported-foo/a.js
@@ -1,0 +1,1 @@
+export default 'exported-foo a';

--- a/packages/node-resolve/test/fixtures/node_modules/exports-literal-specificity/foo-a.js
+++ b/packages/node-resolve/test/fixtures/node_modules/exports-literal-specificity/foo-a.js
@@ -1,0 +1,1 @@
+export default 'foo a';

--- a/packages/node-resolve/test/fixtures/node_modules/exports-literal-specificity/package.json
+++ b/packages/node-resolve/test/fixtures/node_modules/exports-literal-specificity/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "exports-literal-specificity",
+	"main": "index.js",
+	"exports": {
+		"./foo/": "./exported-foo/",
+		"./foo/a.js": "./foo-a.js"
+	}
+}

--- a/packages/node-resolve/test/package-entry-points.js
+++ b/packages/node-resolve/test/package-entry-points.js
@@ -135,7 +135,7 @@ test('handles main directory exports', async (t) => {
 });
 
 test('logs a warning when using shorthand and importing a subpath', async (t) => {
-  t.plan(1);
+  t.plan(2);
   const errors = [];
   await rollup({
     input: 'exports-shorthand-subpath.js',
@@ -144,11 +144,13 @@ test('logs a warning when using shorthand and importing a subpath', async (t) =>
     },
     plugins: [nodeResolve()]
   });
-  t.true(errors[0].message.includes('Package subpath \'./foo\' is not defined by "exports" in'));
+
+  t.true(errors[0].message.includes('Could not resolve import "exports-shorthand/foo" in '));
+  t.true(errors[0].message.includes('Package subpath "./foo" is not defined by "exports" in'));
 });
 
 test('logs a warning when a subpath cannot be found', async (t) => {
-  t.plan(1);
+  t.plan(2);
   const errors = [];
   await rollup({
     input: 'exports-non-existing-subpath.js',
@@ -157,11 +159,15 @@ test('logs a warning when a subpath cannot be found', async (t) => {
     },
     plugins: [nodeResolve()]
   });
-  t.true(errors[0].message.includes('Package subpath \'./bar\' is not defined by "exports" in'));
+
+  t.true(
+    errors[0].message.includes('Could not resolve import "exports-non-existing-subpath/bar" in ')
+  );
+  t.true(errors[0].message.includes('Package subpath "./bar" is not defined by "exports" in'));
 });
 
-test('prevents importing files not specified in exports map', async (t) => {
-  t.plan(1);
+test.only('prevents importing files not specified in exports map', async (t) => {
+  t.plan(2);
   const errors = [];
   await rollup({
     input: 'exports-prevent-unspecified-subpath.js',
@@ -170,7 +176,11 @@ test('prevents importing files not specified in exports map', async (t) => {
     },
     plugins: [nodeResolve()]
   });
-  t.true(errors[0].message.includes('Package subpath \'./bar\' is not defined by "exports" in'));
+
+  t.true(
+    errors[0].message.includes('Could not resolve import "exports-top-level-mappings/bar" in ')
+  );
+  t.true(errors[0].message.includes('Package subpath "./bar" is not defined by "exports" in'));
 });
 
 test('uses "require" condition when a module is referenced with require', async (t) => {

--- a/packages/node-resolve/test/package-entry-points.js
+++ b/packages/node-resolve/test/package-entry-points.js
@@ -166,7 +166,7 @@ test('logs a warning when a subpath cannot be found', async (t) => {
   t.true(errors[0].message.includes('Package subpath "./bar" is not defined by "exports" in'));
 });
 
-test.only('prevents importing files not specified in exports map', async (t) => {
+test('prevents importing files not specified in exports map', async (t) => {
   t.plan(2);
   const errors = [];
   await rollup({
@@ -207,4 +207,34 @@ test('can use star pattern in exports field', async (t) => {
   const { module } = await testBundle(t, bundle);
 
   t.deepEqual(module.exports, { a: 'A', b: 'B', c: 'C' });
+});
+
+test('a literal match takes presedence', async (t) => {
+  const bundle = await rollup({
+    input: 'exports-literal-specificity.js',
+    onwarn: () => {
+      t.fail('No warnings were expected');
+    },
+    plugins: [nodeResolve()]
+  });
+  const { module } = await testBundle(t, bundle);
+
+  t.deepEqual(module.exports, { a: 'foo a' });
+});
+
+test('longest matching directory takes priority', async (t) => {
+  const bundle = await rollup({
+    input: 'exports-directory-specificity.js',
+    onwarn: () => {
+      t.fail('No warnings were expected');
+    },
+    plugins: [nodeResolve()]
+  });
+  const { module } = await testBundle(t, bundle);
+
+  t.deepEqual(module.exports, {
+    a1: 'foo-one a',
+    a2: 'foo-two a',
+    a3: 'foo-three a'
+  });
 });


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `node-resolve`

This PR contains:

- [X] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [X] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [X] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers: https://github.com/rollup/plugins/issues/672

### Description

We didn't properly account for specificity when selecting the exports condition. This applies that properly, selecting first a literal match and then iterating the sorted list of keys based on specificity.

This also includes https://github.com/rollup/plugins/pull/669 to avoid two PRs creating merge conflicts.