### PR TITLE
alias: add missing readonly to internal function

### DIFF
--- a/packages/alias/src/index.ts
+++ b/packages/alias/src/index.ts
@@ -34,7 +34,7 @@ function normalizeId(id: string | undefined) {
   return id;
 }
 
-function getEntries({ entries }: RollupAliasOptions): Alias[] {
+function getEntries({ entries }: RollupAliasOptions): readonly Alias[] {
   if (!entries) {
     return [];
   }


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `alias`

This PR contains:

- [ ] bugfix
- [ ] feature
- [X] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [X] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [X] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers: https://github.com/rollup/plugins/issues/679

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

`entries` is specified as `readonly` here: https://github.com/rollup/plugins/blob/366380eb33c31957fa80dd1df9d4cec8477294c2/packages/alias/types/index.d.ts#L30

This change makes the implementation `readonly` to match the type definition. TypeScript 4 has stricter checks for `readonly` and will eventually require this change.