### PR TITLE
fix(wasm): Remove `eval` calls and enable dummy sourcemap

### DIFF
--- a/packages/wasm/src/helper.ts
+++ b/packages/wasm/src/helper.ts
@@ -17,8 +17,8 @@ function _loadWasmModule (sync, filepath, src, imports) {
   var isNode = typeof process !== 'undefined' && process.versions != null && process.versions.node != null
 
   if (filepath && isNode) {
-    var fs = eval('require("fs")')
-    var path = eval('require("path")')
+    var fs = require("fs")
+    var path = require("path")
 
     return new Promise((resolve, reject) => {
       fs.readFile(path.resolve(__dirname, filepath), (error, buffer) => {

--- a/packages/wasm/src/index.ts
+++ b/packages/wasm/src/index.ts
@@ -76,8 +76,13 @@ export function wasm(options: RollupWasmOptions = {}): Plugin {
           src = null;
         }
 
-        return `import { _loadWasmModule } from ${JSON.stringify(HELPERS_ID)};
-export default function(imports){return _loadWasmModule(${+isSync}, ${publicFilepath}, ${src}, imports)}`;
+        return {
+          map: {
+            mappings: ''
+          },
+          code: `import { _loadWasmModule } from ${JSON.stringify(HELPERS_ID)};
+export default function(imports){return _loadWasmModule(${+isSync}, ${publicFilepath}, ${src}, imports)}`
+        };
       }
       return null;
     },

--- a/packages/wasm/test/test.js
+++ b/packages/wasm/test/test.js
@@ -51,6 +51,7 @@ test('fetching WASM from separate file', async (t) => {
 
   global.result = null;
   global.t = t;
+  // eslint-disable-next-line global-require, import/no-dynamic-require
   require(outputFile);
 
   await global.result;
@@ -97,6 +98,7 @@ test('imports', async (t) => {
 });
 
 try {
+  // eslint-disable-next-line global-require
   const { Worker } = require('worker_threads');
   test('worker', async (t) => {
     t.plan(2);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `@rollup/wasm`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers: #574 

### Description

* Remove calls to `eval` which would raise warnings in rollup
* Add a dummy sourcemap to suppress warnings in rollup (See [@rollup/json/index.js#L23](https://github.com/rollup/plugins/blob/8c3a3a6eaa4dc301a4dcd6ea0b4efcc8243c9e12/packages/json/src/index.js#L23))
* Add eslint ignore statements to wasm test files to pass linting


<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
