### PR TITLE
fix(typescript): remove unnecessary validation

### DIFF
--- a/packages/typescript/src/options/validate.ts
+++ b/packages/typescript/src/options/validate.ts
@@ -54,18 +54,14 @@ export function validatePaths(
 
   for (const dirProperty of DIRECTORY_PROPS) {
     if (compilerOptions[dirProperty]) {
-      if (!outputOptions.dir) {
-        context.error(
-          `@rollup/plugin-typescript: Rollup 'dir' option must be used when Typescript compiler option '${dirProperty}' is specified.`
-        );
-      }
-
       // Checks if the given path lies within Rollup output dir
-      const fromRollupDirToTs = relative(outputOptions.dir, compilerOptions[dirProperty]!);
-      if (fromRollupDirToTs.startsWith('..')) {
-        context.error(
-          `@rollup/plugin-typescript: Path of Typescript compiler option '${dirProperty}' must be located inside Rollup 'dir' option.`
-        );
+      if (outputOptions.dir) {
+       const fromRollupDirToTs = relative(outputOptions.dir, compilerOptions[dirProperty]!);
+        if (fromRollupDirToTs.startsWith('..')) {
+          context.error(
+            `@rollup/plugin-typescript: Path of Typescript compiler option '${dirProperty}' must be located inside Rollup 'dir' option.`
+          );
+        }
       }
     }
   }

--- a/packages/typescript/test/test.js
+++ b/packages/typescript/test/test.js
@@ -206,16 +206,6 @@ test.serial('ensures outDir is located in Rollup output dir', async (t) => {
     onwarn
   });
 
-  const noDirError = await t.throwsAsync(() =>
-    getCode(bundle, { format: 'esm', file: 'fixtures/basic/other/out.js' }, true)
-  );
-  t.true(
-    noDirError.message.includes(
-      `Rollup 'dir' option must be used when Typescript compiler option 'outDir' is specified`
-    ),
-    `Unexpected error message: ${noDirError.message}`
-  );
-
   const wrongDirError = await t.throwsAsync(() =>
     getCode(bundle, { format: 'esm', dir: 'fixtures/basic/dist' }, true)
   );
@@ -239,16 +229,6 @@ test.serial('ensures declarationDir is located in Rollup output dir', async (t) 
     ],
     onwarn
   });
-
-  const noDirError = await t.throwsAsync(() =>
-    getCode(bundle, { format: 'esm', file: 'fixtures/basic/other/out.js' }, true)
-  );
-  t.true(
-    noDirError.message.includes(
-      `Rollup 'dir' option must be used when Typescript compiler option 'declarationDir' is specified`
-    ),
-    `Unexpected error message: ${noDirError.message}`
-  );
 
   const wrongDirError = await t.throwsAsync(() =>
     getCode(bundle, { format: 'esm', dir: 'fixtures/basic/dist' }, true)


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `typescript`

This PR contains:

- [X] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are test changes included?

- [X] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [X] no

List any relevant issue numbers: https://github.com/rollup/plugins/issues/247

### Description

Fixes https://github.com/rollup/plugins/issues/247 by removing unnecessary validation. Today you can't use Rollup's `input.file` in a project that specifies `outputDir` in `tsconfig.json`. I'm not sure there's a compelling reason for this restriction. `rollup-plugin-typescript2` does not have such a restriction and works just fine