### PR TITLE
feat(node-resolve): support pkg imports and export array

### DIFF
--- a/packages/node-resolve/README.md
+++ b/packages/node-resolve/README.md
@@ -34,13 +34,17 @@ export default {
   input: 'src/index.js',
   output: {
     dir: 'output',
-    format: 'cjs',
+    format: 'cjs'
   },
-  plugins: [nodeResolve()],
+  plugins: [nodeResolve()]
 };
 ```
 
 Then call `rollup` either via the [CLI](https://www.rollupjs.org/guide/en/#command-line-reference) or the [API](https://www.rollupjs.org/guide/en/#javascript-api).
+
+## Package entrypoints
+
+This plugin supports the package entrypoints feature from node js, specified in the `exports` or `imports` field of a package. Check the [official documentation](https://nodejs.org/api/packages.html#packages_package_entry_points) for more information on how this works.
 
 ## Options
 
@@ -61,6 +65,8 @@ Type: `Boolean`<br>
 Default: `false`
 
 If `true`, instructs the plugin to use the `"browser"` property in `package.json` files to specify alternative files to load for bundling. This is useful when bundling for a browser environment. Alternatively, a value of `'browser'` can be added to the `mainFields` option. If `false`, any `"browser"` properties in package files will be ignored. This option takes precedence over `mainFields`.
+
+> This option does not work when a package is using [package entrypoints](https://nodejs.org/api/packages.html#packages_package_entry_points)
 
 ### `moduleDirectories`
 
@@ -169,9 +175,9 @@ export default {
   output: {
     file: 'bundle.js',
     format: 'iife',
-    name: 'MyModule',
+    name: 'MyModule'
   },
-  plugins: [nodeResolve(), commonjs()],
+  plugins: [nodeResolve(), commonjs()]
 };
 ```
 
@@ -203,7 +209,7 @@ The node resolve plugin uses `import` by default, you can opt into using the `re
 ```js
 this.resolve(importee, importer, {
   skipSelf: true,
-  custom: { 'node-resolve': { isRequire: true } },
+  custom: { 'node-resolve': { isRequire: true } }
 });
 ```
 

--- a/packages/node-resolve/src/index.js
+++ b/packages/node-resolve/src/index.js
@@ -7,7 +7,7 @@ import isModule from 'is-module';
 
 import { isDirCached, isFileCached, readCachedFile } from './cache';
 import { exists, readFile, realpath } from './fs';
-import { resolveImportSpecifiers } from './resolveImportSpecifiers';
+import resolveImportSpecifiers from './resolveImportSpecifiers';
 import { getMainFields, getPackageName, normalizeInput } from './util';
 import handleDeprecatedOptions from './deprecated-options';
 

--- a/packages/node-resolve/src/package/resolvePackageExports.js
+++ b/packages/node-resolve/src/package/resolvePackageExports.js
@@ -1,0 +1,48 @@
+import {
+  InvalidModuleSpecifierError,
+  InvalidConfigurationError,
+  isMappings,
+  isConditions,
+  isMixedExports
+} from './utils';
+import resolvePackageTarget from './resolvePackageTarget';
+import resolvePackageImportsExports from './resolvePackageImportsExports';
+
+async function resolvePackageExports(context, subpath, exports) {
+  if (isMixedExports(exports)) {
+    throw new InvalidConfigurationError(
+      context,
+      'All keys must either start with ./, or without one.'
+    );
+  }
+
+  if (subpath === '.') {
+    let mainExport;
+    // If exports is a String or Array, or an Object containing no keys starting with ".", then
+    if (typeof exports === 'string' || Array.isArray(exports) || isConditions(exports)) {
+      mainExport = exports;
+    } else if (isMappings(exports)) {
+      mainExport = exports['.'];
+    }
+
+    if (mainExport) {
+      const resolved = await resolvePackageTarget(context, { target: mainExport, subpath: '' });
+      if (resolved) {
+        return resolved;
+      }
+    }
+  } else if (isMappings(exports)) {
+    const resolvedMatch = await resolvePackageImportsExports(context, {
+      matchKey: subpath,
+      matchObj: exports
+    });
+
+    if (resolvedMatch) {
+      return resolvedMatch;
+    }
+  }
+
+  throw new InvalidModuleSpecifierError(context);
+}
+
+export default resolvePackageExports;

--- a/packages/node-resolve/src/package/resolvePackageImports.js
+++ b/packages/node-resolve/src/package/resolvePackageImports.js
@@ -1,32 +1,7 @@
-/* eslint-disable no-await-in-loop */
-import path from 'path';
-import fs from 'fs';
 import { pathToFileURL } from 'url';
-import { promisify } from 'util';
 
-import { createBaseErrorMsg, InvalidModuleSpecifierError } from './utils';
+import { createBaseErrorMsg, findPackageJson, InvalidModuleSpecifierError } from './utils';
 import resolvePackageImportsExports from './resolvePackageImportsExports';
-
-const fileExists = promisify(fs.exists);
-
-function isModuleDir(current, moduleDirs) {
-  return moduleDirs.some((dir) => current.endsWith(dir));
-}
-
-async function findPackageJson(base, moduleDirs) {
-  const { root } = path.parse(base);
-  let current = base;
-
-  while (current !== root && !isModuleDir(current, moduleDirs)) {
-    const pkgJsonPath = path.join(current, 'package.json');
-    if (await fileExists(pkgJsonPath)) {
-      const pkgJsonString = fs.readFileSync(pkgJsonPath, 'utf-8');
-      return { pkgJson: JSON.parse(pkgJsonString), pkgPath: current, pkgJsonPath };
-    }
-    current = path.resolve(current, '..');
-  }
-  return null;
-}
 
 async function resolvePackageImports({
   importSpecifier,

--- a/packages/node-resolve/src/package/resolvePackageImports.js
+++ b/packages/node-resolve/src/package/resolvePackageImports.js
@@ -1,0 +1,71 @@
+/* eslint-disable no-await-in-loop */
+import path from 'path';
+import fs from 'fs';
+import { pathToFileURL } from 'url';
+import { promisify } from 'util';
+
+import { createBaseErrorMsg, InvalidModuleSpecifierError } from './utils';
+import resolvePackageImportsExports from './resolvePackageImportsExports';
+
+const fileExists = promisify(fs.exists);
+
+function isModuleDir(current, moduleDirs) {
+  return moduleDirs.some((dir) => current.endsWith(dir));
+}
+
+async function findPackageJson(base, moduleDirs) {
+  const { root } = path.parse(base);
+  let current = base;
+
+  while (current !== root && !isModuleDir(current, moduleDirs)) {
+    const pkgJsonPath = path.join(current, 'package.json');
+    if (await fileExists(pkgJsonPath)) {
+      const pkgJsonString = fs.readFileSync(pkgJsonPath, 'utf-8');
+      return { pkgJson: JSON.parse(pkgJsonString), pkgPath: current, pkgJsonPath };
+    }
+    current = path.resolve(current, '..');
+  }
+  return null;
+}
+
+async function resolvePackageImports({
+  importSpecifier,
+  importer,
+  moduleDirs,
+  conditions,
+  resolveId
+}) {
+  const result = await findPackageJson(importer, moduleDirs);
+  if (!result) {
+    throw new Error(createBaseErrorMsg('. Could not find a parent package.json.'));
+  }
+
+  const { pkgPath, pkgJsonPath, pkgJson } = result;
+  const pkgURL = pathToFileURL(`${pkgPath}/`);
+  const context = {
+    importer,
+    importSpecifier,
+    moduleDirs,
+    pkgURL,
+    pkgJsonPath,
+    conditions,
+    resolveId
+  };
+
+  const { imports } = pkgJson;
+  if (!imports) {
+    throw new InvalidModuleSpecifierError(context, true);
+  }
+
+  if (importSpecifier === '#' || importSpecifier.startsWith('#/')) {
+    throw new InvalidModuleSpecifierError(context, 'Invalid import specifier.');
+  }
+
+  return resolvePackageImportsExports(context, {
+    matchKey: importSpecifier,
+    matchObj: imports,
+    internal: true
+  });
+}
+
+export default resolvePackageImports;

--- a/packages/node-resolve/src/package/resolvePackageImportsExports.js
+++ b/packages/node-resolve/src/package/resolvePackageImportsExports.js
@@ -1,0 +1,44 @@
+/* eslint-disable no-await-in-loop */
+import resolvePackageTarget from './resolvePackageTarget';
+
+import { InvalidModuleSpecifierError } from './utils';
+
+async function resolvePackageImportsExports(context, { matchKey, matchObj, internal }) {
+  if (!matchKey.endsWith('*') && matchKey in matchObj) {
+    const target = matchObj[matchKey];
+    const resolved = await resolvePackageTarget(context, { target, subpath: '', internal });
+    return resolved;
+  }
+
+  const expansionKeys = Object.keys(matchObj)
+    .filter((k) => k.endsWith('/') || k.endsWith('*'))
+    .sort((a, b) => b.length - a.length);
+
+  for (const expansionKey of expansionKeys) {
+    const prefix = expansionKey.substring(0, expansionKey.length - 1);
+
+    if (expansionKey.endsWith('*') && matchKey.startsWith(prefix)) {
+      const target = matchObj[expansionKey];
+      const subpath = matchKey.substring(expansionKey.length - 1);
+      const resolved = await resolvePackageTarget(context, {
+        target,
+        subpath,
+        pattern: true,
+        internal
+      });
+      return resolved;
+    }
+
+    if (matchKey.startsWith(expansionKey)) {
+      const target = matchObj[expansionKey];
+      const subpath = matchKey.substring(expansionKey.length);
+
+      const resolved = await resolvePackageTarget(context, { target, subpath, internal });
+      return resolved;
+    }
+  }
+
+  throw new InvalidModuleSpecifierError(context, internal);
+}
+
+export default resolvePackageImportsExports;

--- a/packages/node-resolve/src/package/resolvePackageTarget.js
+++ b/packages/node-resolve/src/package/resolvePackageTarget.js
@@ -1,0 +1,114 @@
+/* eslint-disable no-await-in-loop, no-undefined */
+import { pathToFileURL } from 'url';
+
+import { isUrl, InvalidModuleSpecifierError, InvalidPackageTargetError } from './utils';
+
+function includesInvalidSegments(pathSegments, moduleDirs) {
+  return pathSegments
+    .split('/')
+    .slice(1)
+    .some((t) => ['.', '..', ...moduleDirs].includes(t));
+}
+
+async function resolvePackageTarget(context, { target, subpath, pattern, internal }) {
+  if (typeof target === 'string') {
+    if (!pattern && subpath.length > 0 && !target.endsWith('/')) {
+      throw new InvalidModuleSpecifierError(context);
+    }
+
+    if (!target.startsWith('./')) {
+      if (internal && !['/', '../'].some((p) => target.startsWith(p)) && !isUrl(target)) {
+        // this is a bare package import, remap it and resolve it using regular node resolve
+        if (pattern) {
+          const result = await context.resolveId(
+            target.replace(/\*/g, subpath),
+            context.pkgURL.href
+          );
+          return result ? pathToFileURL(result.location) : null;
+        }
+
+        const result = await context.resolveId(`${target}${subpath}`, context.pkgURL.href);
+        return result ? pathToFileURL(result.location) : null;
+      }
+      throw new InvalidPackageTargetError(context, `Invalid mapping: "${target}".`);
+    }
+
+    if (includesInvalidSegments(target, context.moduleDirs)) {
+      throw new InvalidPackageTargetError(context, `Invalid mapping: "${target}".`);
+    }
+
+    const resolvedTarget = new URL(target, context.pkgURL);
+    if (!resolvedTarget.href.startsWith(context.pkgURL.href)) {
+      throw new InvalidPackageTargetError(
+        context,
+        `Resolved to ${resolvedTarget.href} which is outside package ${context.pkgURL.href}`
+      );
+    }
+
+    if (includesInvalidSegments(subpath, context.moduleDirs)) {
+      throw new InvalidModuleSpecifierError(context);
+    }
+
+    if (pattern) {
+      return resolvedTarget.href.replace(/\*/g, subpath);
+    }
+    return new URL(subpath, resolvedTarget).href;
+  }
+
+  if (Array.isArray(target)) {
+    let lastError;
+    for (const item of target) {
+      try {
+        const resolved = await resolvePackageTarget(context, {
+          target: item,
+          subpath,
+          pattern,
+          internal
+        });
+
+        // return if defined or null, but not undefined
+        if (resolved !== undefined) {
+          return resolved;
+        }
+      } catch (error) {
+        if (!(error instanceof InvalidPackageTargetError)) {
+          throw error;
+        } else {
+          lastError = error;
+        }
+      }
+    }
+
+    if (lastError) {
+      throw lastError;
+    }
+    return null;
+  }
+
+  if (target && typeof target === 'object') {
+    for (const [key, value] of Object.entries(target)) {
+      if (key === 'default' || context.conditions.includes(key)) {
+        const resolved = await resolvePackageTarget(context, {
+          target: value,
+          subpath,
+          pattern,
+          internal
+        });
+
+        // return if defined or null, but not undefined
+        if (resolved !== undefined) {
+          return resolved;
+        }
+      }
+    }
+    return undefined;
+  }
+
+  if (target === null) {
+    return null;
+  }
+
+  throw new InvalidPackageTargetError(context, `Invalid exports field.`);
+}
+
+export default resolvePackageTarget;

--- a/packages/node-resolve/src/package/utils.js
+++ b/packages/node-resolve/src/package/utils.js
@@ -1,0 +1,51 @@
+export function isUrl(str) {
+  try {
+    return !!new URL(str);
+  } catch (_) {
+    return false;
+  }
+}
+
+export function isConditions(exports) {
+  return typeof exports === 'object' && Object.keys(exports).every((k) => !k.startsWith('.'));
+}
+
+export function isMappings(exports) {
+  return typeof exports === 'object' && !isConditions(exports);
+}
+
+export function isMixedExports(exports) {
+  const keys = Object.keys(exports);
+  return keys.some((k) => k.startsWith('.')) && keys.some((k) => !k.startsWith('.'));
+}
+
+export function createBaseErrorMsg(importSpecifier, importer) {
+  return `Could not resolve import "${importSpecifier}" in ${importer}`;
+}
+
+export function createErrorMsg(context, reason, internal) {
+  const { importSpecifier, importer, pkgJsonPath } = context;
+  const base = createBaseErrorMsg(importSpecifier, importer);
+  const field = internal ? 'imports' : 'exports';
+  return `${base} using ${field} defined in ${pkgJsonPath}.${reason ? ` ${reason}` : ''}`;
+}
+
+export class ResolveError extends Error {}
+
+export class InvalidConfigurationError extends ResolveError {
+  constructor(context, reason) {
+    super(createErrorMsg(context, `Invalid "exports" field. ${reason}`));
+  }
+}
+
+export class InvalidModuleSpecifierError extends ResolveError {
+  constructor(context, internal) {
+    super(createErrorMsg(context, internal));
+  }
+}
+
+export class InvalidPackageTargetError extends ResolveError {
+  constructor(context, reason) {
+    super(createErrorMsg(context, reason));
+  }
+}

--- a/packages/node-resolve/src/package/utils.js
+++ b/packages/node-resolve/src/package/utils.js
@@ -1,3 +1,29 @@
+/* eslint-disable no-await-in-loop */
+import path from 'path';
+import fs from 'fs';
+import { promisify } from 'util';
+
+const fileExists = promisify(fs.exists);
+
+function isModuleDir(current, moduleDirs) {
+  return moduleDirs.some((dir) => current.endsWith(dir));
+}
+
+export async function findPackageJson(base, moduleDirs) {
+  const { root } = path.parse(base);
+  let current = base;
+
+  while (current !== root && !isModuleDir(current, moduleDirs)) {
+    const pkgJsonPath = path.join(current, 'package.json');
+    if (await fileExists(pkgJsonPath)) {
+      const pkgJsonString = fs.readFileSync(pkgJsonPath, 'utf-8');
+      return { pkgJson: JSON.parse(pkgJsonString), pkgPath: current, pkgJsonPath };
+    }
+    current = path.resolve(current, '..');
+  }
+  return null;
+}
+
 export function isUrl(str) {
   try {
     return !!new URL(str);

--- a/packages/node-resolve/test/fixtures/exports-null-override.js
+++ b/packages/node-resolve/test/fixtures/exports-null-override.js
@@ -1,0 +1,3 @@
+import a from 'exports-null-override/foo/a';
+
+export default a;

--- a/packages/node-resolve/test/fixtures/exports-shorthand-fallback-conditions.js
+++ b/packages/node-resolve/test/fixtures/exports-shorthand-fallback-conditions.js
@@ -1,0 +1,3 @@
+import exportsMapEntry from 'exports-shorthand-fallback-conditions/foo.js';
+
+export default exportsMapEntry;

--- a/packages/node-resolve/test/fixtures/exports-shorthand-fallback-error.js
+++ b/packages/node-resolve/test/fixtures/exports-shorthand-fallback-error.js
@@ -1,0 +1,3 @@
+import exportsMapEntry from 'exports-shorthand-fallback-error';
+
+export default exportsMapEntry;

--- a/packages/node-resolve/test/fixtures/exports-star-specificity.js
+++ b/packages/node-resolve/test/fixtures/exports-star-specificity.js
@@ -1,0 +1,5 @@
+import a1 from 'exports-star-specificity/one/a';
+import a2 from 'exports-star-specificity/one/two/a';
+import a3 from 'exports-star-specificity/one/two/three/a';
+
+export default { a1, a2, a3 };

--- a/packages/node-resolve/test/fixtures/imports-bare-dependency-exports.js
+++ b/packages/node-resolve/test/fixtures/imports-bare-dependency-exports.js
@@ -1,0 +1,3 @@
+import dependencyExports from 'imports-bare-dependency-exports';
+
+export default dependencyExports;

--- a/packages/node-resolve/test/fixtures/imports-bare.js
+++ b/packages/node-resolve/test/fixtures/imports-bare.js
@@ -1,0 +1,3 @@
+import importBare from 'imports-bare';
+
+export default importBare;

--- a/packages/node-resolve/test/fixtures/imports-conditions.js
+++ b/packages/node-resolve/test/fixtures/imports-conditions.js
@@ -1,0 +1,3 @@
+import importsConditions from 'imports-conditions';
+
+export default importsConditions;

--- a/packages/node-resolve/test/fixtures/imports-pattern.js
+++ b/packages/node-resolve/test/fixtures/imports-pattern.js
@@ -1,0 +1,3 @@
+import importsPattern from 'imports-pattern';
+
+export default importsPattern;

--- a/packages/node-resolve/test/fixtures/imports-relative.js
+++ b/packages/node-resolve/test/fixtures/imports-relative.js
@@ -1,0 +1,3 @@
+import importsRelative from 'imports-relative';
+
+export default importsRelative;

--- a/packages/node-resolve/test/fixtures/node_modules/exports-null-override/foo/a.js
+++ b/packages/node-resolve/test/fixtures/node_modules/exports-null-override/foo/a.js
@@ -1,0 +1,1 @@
+export default 'A';

--- a/packages/node-resolve/test/fixtures/node_modules/exports-null-override/foo/b.js
+++ b/packages/node-resolve/test/fixtures/node_modules/exports-null-override/foo/b.js
@@ -1,0 +1,1 @@
+export default 'B';

--- a/packages/node-resolve/test/fixtures/node_modules/exports-null-override/package.json
+++ b/packages/node-resolve/test/fixtures/node_modules/exports-null-override/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "exports-null-override",
+	"main": "index.js",
+	"exports": {
+		"./foo/*": "./foo/*.js",
+		"./foo/a": null
+	}
+}

--- a/packages/node-resolve/test/fixtures/node_modules/exports-shorthand-fallback-conditions/index-mapped.js
+++ b/packages/node-resolve/test/fixtures/node_modules/exports-shorthand-fallback-conditions/index-mapped.js
@@ -1,0 +1,1 @@
+export default 'MAIN MAPPED';

--- a/packages/node-resolve/test/fixtures/node_modules/exports-shorthand-fallback-conditions/index.js
+++ b/packages/node-resolve/test/fixtures/node_modules/exports-shorthand-fallback-conditions/index.js
@@ -1,0 +1,1 @@
+export default 'MAIN';

--- a/packages/node-resolve/test/fixtures/node_modules/exports-shorthand-fallback-conditions/package.json
+++ b/packages/node-resolve/test/fixtures/node_modules/exports-shorthand-fallback-conditions/package.json
@@ -1,0 +1,10 @@
+{
+	"name": "exports-shorthand-fallback-conditions",
+	"main": "index.js",
+	"exports": {
+		"./foo.js": [
+			{ "require": "./not-index-mapped.js" },
+			{ "import": "./index-mapped.js" }
+		]
+	}
+}

--- a/packages/node-resolve/test/fixtures/node_modules/exports-shorthand-fallback-error/index-mapped.js
+++ b/packages/node-resolve/test/fixtures/node_modules/exports-shorthand-fallback-error/index-mapped.js
@@ -1,0 +1,1 @@
+export default 'MAIN MAPPED';

--- a/packages/node-resolve/test/fixtures/node_modules/exports-shorthand-fallback-error/index.js
+++ b/packages/node-resolve/test/fixtures/node_modules/exports-shorthand-fallback-error/index.js
@@ -1,0 +1,1 @@
+export default 'MAIN';

--- a/packages/node-resolve/test/fixtures/node_modules/exports-shorthand-fallback-error/package.json
+++ b/packages/node-resolve/test/fixtures/node_modules/exports-shorthand-fallback-error/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "exports-shorthand-fallback-error",
+	"main": "index.js",
+	"exports": [
+		"./node_modules/not-index-mapped.js",
+		"./index-mapped.js"
+	]
+}

--- a/packages/node-resolve/test/fixtures/node_modules/exports-star-specificity/foo-one/a.js
+++ b/packages/node-resolve/test/fixtures/node_modules/exports-star-specificity/foo-one/a.js
@@ -1,0 +1,1 @@
+export default 'foo-one a';

--- a/packages/node-resolve/test/fixtures/node_modules/exports-star-specificity/foo-three/a.js
+++ b/packages/node-resolve/test/fixtures/node_modules/exports-star-specificity/foo-three/a.js
@@ -1,0 +1,1 @@
+export default 'foo-three a';

--- a/packages/node-resolve/test/fixtures/node_modules/exports-star-specificity/foo-two/a.js
+++ b/packages/node-resolve/test/fixtures/node_modules/exports-star-specificity/foo-two/a.js
@@ -1,0 +1,1 @@
+export default 'foo-two a';

--- a/packages/node-resolve/test/fixtures/node_modules/exports-star-specificity/package.json
+++ b/packages/node-resolve/test/fixtures/node_modules/exports-star-specificity/package.json
@@ -1,0 +1,9 @@
+{
+	"name": "exports-star-specificity",
+	"main": "index.js",
+	"exports": {
+		"./one/*": "./foo-one/*.js",
+		"./one/two/*": "./foo-two/*.js",
+		"./one/two/three/*": "./foo-three/*.js"
+	}
+}

--- a/packages/node-resolve/test/fixtures/node_modules/imports-bare-dependency-exports/index.js
+++ b/packages/node-resolve/test/fixtures/node_modules/imports-bare-dependency-exports/index.js
@@ -1,0 +1,1 @@
+export default 'imports-bare-dependency-exports';

--- a/packages/node-resolve/test/fixtures/node_modules/imports-bare-dependency-exports/mapped-index.js
+++ b/packages/node-resolve/test/fixtures/node_modules/imports-bare-dependency-exports/mapped-index.js
@@ -1,0 +1,1 @@
+export default 'imports-bare-dependency-exports mapped';

--- a/packages/node-resolve/test/fixtures/node_modules/imports-bare-dependency-exports/package.json
+++ b/packages/node-resolve/test/fixtures/node_modules/imports-bare-dependency-exports/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "imports-bare-dependency-exports",
+	"main": "index.js",
+	"exports": "./mapped-index.js"
+}

--- a/packages/node-resolve/test/fixtures/node_modules/imports-bare-dependency/index.js
+++ b/packages/node-resolve/test/fixtures/node_modules/imports-bare-dependency/index.js
@@ -1,0 +1,1 @@
+export default 'imports-bare-dependency';

--- a/packages/node-resolve/test/fixtures/node_modules/imports-bare-dependency/package.json
+++ b/packages/node-resolve/test/fixtures/node_modules/imports-bare-dependency/package.json
@@ -1,0 +1,4 @@
+{
+	"name": "imports-bare-dependency",
+	"main": "index.js"
+}

--- a/packages/node-resolve/test/fixtures/node_modules/imports-bare-exports/index.js
+++ b/packages/node-resolve/test/fixtures/node_modules/imports-bare-exports/index.js
@@ -1,0 +1,3 @@
+import foo from '#foo';
+
+export default `imports-remap-exports imported ${foo}`;

--- a/packages/node-resolve/test/fixtures/node_modules/imports-bare-exports/package.json
+++ b/packages/node-resolve/test/fixtures/node_modules/imports-bare-exports/package.json
@@ -1,0 +1,10 @@
+{
+	"name": "imports-remap-exports",
+	"main": "index.js",
+	"imports": {
+		"#foo": "./src/foo.js"
+	},
+	"exports": {
+		"./src/foo.js": "./src/foo.js"
+	}
+}

--- a/packages/node-resolve/test/fixtures/node_modules/imports-bare-exports/src/foo.js
+++ b/packages/node-resolve/test/fixtures/node_modules/imports-bare-exports/src/foo.js
@@ -1,0 +1,1 @@
+export default './src/foo';

--- a/packages/node-resolve/test/fixtures/node_modules/imports-bare/index.js
+++ b/packages/node-resolve/test/fixtures/node_modules/imports-bare/index.js
@@ -1,0 +1,3 @@
+import foo from '#foo';
+
+export default `imports-bare imported ${foo}`;

--- a/packages/node-resolve/test/fixtures/node_modules/imports-bare/package.json
+++ b/packages/node-resolve/test/fixtures/node_modules/imports-bare/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "imports-bare",
+	"main": "index.js",
+	"imports": {
+		"#foo": "imports-bare-dependency"
+	}
+}

--- a/packages/node-resolve/test/fixtures/node_modules/imports-conditions/index.js
+++ b/packages/node-resolve/test/fixtures/node_modules/imports-conditions/index.js
@@ -1,0 +1,3 @@
+import foo from '#foo';
+
+export default `imports-conditions imported ${foo}`;

--- a/packages/node-resolve/test/fixtures/node_modules/imports-conditions/package.json
+++ b/packages/node-resolve/test/fixtures/node_modules/imports-conditions/package.json
@@ -1,0 +1,10 @@
+{
+	"name": "imports-conditions",
+	"main": "index.js",
+	"imports": {
+		"#foo": {
+			"import": "./src/foo.mjs",
+			"require": "./src/foo.cjs"
+		}
+	}
+}

--- a/packages/node-resolve/test/fixtures/node_modules/imports-conditions/src/foo.cjs
+++ b/packages/node-resolve/test/fixtures/node_modules/imports-conditions/src/foo.cjs
@@ -1,0 +1,1 @@
+export default './src/foo.cjs';

--- a/packages/node-resolve/test/fixtures/node_modules/imports-conditions/src/foo.mjs
+++ b/packages/node-resolve/test/fixtures/node_modules/imports-conditions/src/foo.mjs
@@ -1,0 +1,1 @@
+export default './src/foo.mjs';

--- a/packages/node-resolve/test/fixtures/node_modules/imports-pattern/foo/x-a.js
+++ b/packages/node-resolve/test/fixtures/node_modules/imports-pattern/foo/x-a.js
@@ -1,0 +1,1 @@
+export default './foo/x-a.js';

--- a/packages/node-resolve/test/fixtures/node_modules/imports-pattern/foo/x-b.js
+++ b/packages/node-resolve/test/fixtures/node_modules/imports-pattern/foo/x-b.js
@@ -1,0 +1,1 @@
+export default './foo/x-b.js';

--- a/packages/node-resolve/test/fixtures/node_modules/imports-pattern/index.js
+++ b/packages/node-resolve/test/fixtures/node_modules/imports-pattern/index.js
@@ -1,0 +1,6 @@
+import a from '#a';
+import b from '#b';
+import fooA from '#foo/a';
+import fooB from '#foo/b';
+
+export default { a, b, fooA, fooB };

--- a/packages/node-resolve/test/fixtures/node_modules/imports-pattern/package.json
+++ b/packages/node-resolve/test/fixtures/node_modules/imports-pattern/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "imports-pattern",
+	"main": "index.js",
+	"imports": {
+		"#*": "./src/*.js",
+		"#foo/*": "./foo/x-*.js"
+	}
+}

--- a/packages/node-resolve/test/fixtures/node_modules/imports-pattern/src/a.js
+++ b/packages/node-resolve/test/fixtures/node_modules/imports-pattern/src/a.js
@@ -1,0 +1,1 @@
+export default './src/a.js';

--- a/packages/node-resolve/test/fixtures/node_modules/imports-pattern/src/b.js
+++ b/packages/node-resolve/test/fixtures/node_modules/imports-pattern/src/b.js
@@ -1,0 +1,1 @@
+export default './src/b.js';

--- a/packages/node-resolve/test/fixtures/node_modules/imports-relative/index.js
+++ b/packages/node-resolve/test/fixtures/node_modules/imports-relative/index.js
@@ -1,0 +1,3 @@
+import foo from '#foo';
+
+export default `imports-relative imported ${foo}`;

--- a/packages/node-resolve/test/fixtures/node_modules/imports-relative/package.json
+++ b/packages/node-resolve/test/fixtures/node_modules/imports-relative/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "imports-relative",
+	"main": "index.js",
+	"imports": {
+		"#foo": "./src/foo.js"
+	}
+}

--- a/packages/node-resolve/test/fixtures/node_modules/imports-relative/src/foo.js
+++ b/packages/node-resolve/test/fixtures/node_modules/imports-relative/src/foo.js
@@ -1,0 +1,1 @@
+export default './src/foo';

--- a/packages/node-resolve/test/fixtures/node_modules/self-package-import/foo/a.js
+++ b/packages/node-resolve/test/fixtures/node_modules/self-package-import/foo/a.js
@@ -1,0 +1,3 @@
+import b from 'self-package-import/b';
+
+export default { a: 'a', b };

--- a/packages/node-resolve/test/fixtures/node_modules/self-package-import/foo/b.js
+++ b/packages/node-resolve/test/fixtures/node_modules/self-package-import/foo/b.js
@@ -1,0 +1,1 @@
+export default 'b';

--- a/packages/node-resolve/test/fixtures/node_modules/self-package-import/package.json
+++ b/packages/node-resolve/test/fixtures/node_modules/self-package-import/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "self-package-import",
+	"main": "index.js",
+	"exports": {
+		"./*": "./foo/*.js"
+	}
+}

--- a/packages/node-resolve/test/fixtures/self-package-import.js
+++ b/packages/node-resolve/test/fixtures/self-package-import.js
@@ -1,0 +1,3 @@
+import selfPkgImport from 'self-package-import/a';
+
+export default selfPkgImport;

--- a/packages/node-resolve/test/package-entry-points.js
+++ b/packages/node-resolve/test/package-entry-points.js
@@ -349,3 +349,19 @@ test('can override a star pattern using null', async (t) => {
 
   t.true(errors[0].message.includes('Could not resolve import "exports-null-override/foo/a" in '));
 });
+
+test('can self-import a package when using exports field', async (t) => {
+  const bundle = await rollup({
+    input: 'self-package-import',
+    onwarn: () => {
+      t.fail('No warnings were expected');
+    },
+    plugins: [nodeResolve()]
+  });
+  const { module } = await testBundle(t, bundle);
+
+  t.deepEqual(module.exports, {
+    a: 'a',
+    b: 'b'
+  });
+});

--- a/packages/node-resolve/test/package-entry-points.js
+++ b/packages/node-resolve/test/package-entry-points.js
@@ -135,7 +135,7 @@ test('handles main directory exports', async (t) => {
 });
 
 test('logs a warning when using shorthand and importing a subpath', async (t) => {
-  t.plan(2);
+  t.plan(1);
   const errors = [];
   await rollup({
     input: 'exports-shorthand-subpath.js',
@@ -146,11 +146,10 @@ test('logs a warning when using shorthand and importing a subpath', async (t) =>
   });
 
   t.true(errors[0].message.includes('Could not resolve import "exports-shorthand/foo" in '));
-  t.true(errors[0].message.includes('Package subpath "./foo" is not defined by "exports" in'));
 });
 
 test('logs a warning when a subpath cannot be found', async (t) => {
-  t.plan(2);
+  t.plan(1);
   const errors = [];
   await rollup({
     input: 'exports-non-existing-subpath.js',
@@ -163,11 +162,10 @@ test('logs a warning when a subpath cannot be found', async (t) => {
   t.true(
     errors[0].message.includes('Could not resolve import "exports-non-existing-subpath/bar" in ')
   );
-  t.true(errors[0].message.includes('Package subpath "./bar" is not defined by "exports" in'));
 });
 
 test('prevents importing files not specified in exports map', async (t) => {
-  t.plan(2);
+  t.plan(1);
   const errors = [];
   await rollup({
     input: 'exports-prevent-unspecified-subpath.js',
@@ -180,7 +178,6 @@ test('prevents importing files not specified in exports map', async (t) => {
   t.true(
     errors[0].message.includes('Could not resolve import "exports-top-level-mappings/bar" in ')
   );
-  t.true(errors[0].message.includes('Package subpath "./bar" is not defined by "exports" in'));
 });
 
 test('uses "require" condition when a module is referenced with require', async (t) => {
@@ -209,6 +206,23 @@ test('can use star pattern in exports field', async (t) => {
   t.deepEqual(module.exports, { a: 'A', b: 'B', c: 'C' });
 });
 
+test('the most specific star pattern matches', async (t) => {
+  const bundle = await rollup({
+    input: 'exports-star-specificity.js',
+    onwarn: () => {
+      t.fail('No warnings were expected');
+    },
+    plugins: [nodeResolve()]
+  });
+  const { module } = await testBundle(t, bundle);
+
+  t.deepEqual(module.exports, {
+    a1: 'foo-one a',
+    a2: 'foo-two a',
+    a3: 'foo-three a'
+  });
+});
+
 test('a literal match takes presedence', async (t) => {
   const bundle = await rollup({
     input: 'exports-literal-specificity.js',
@@ -222,7 +236,7 @@ test('a literal match takes presedence', async (t) => {
   t.deepEqual(module.exports, { a: 'foo a' });
 });
 
-test('longest matching directory takes priority', async (t) => {
+test('the most specific directory mapping pattern matches', async (t) => {
   const bundle = await rollup({
     input: 'exports-directory-specificity.js',
     onwarn: () => {
@@ -237,4 +251,101 @@ test('longest matching directory takes priority', async (t) => {
     a2: 'foo-two a',
     a3: 'foo-three a'
   });
+});
+
+test('can resolve fallback with conditions', async (t) => {
+  const bundle = await rollup({
+    input: 'exports-shorthand-fallback-conditions.js',
+    onwarn: () => {
+      t.fail('No warnings were expected');
+    },
+    plugins: [nodeResolve()]
+  });
+  const { module } = await testBundle(t, bundle);
+
+  t.deepEqual(module.exports, 'MAIN MAPPED');
+});
+
+test('can resolve fallback with errors', async (t) => {
+  const bundle = await rollup({
+    input: 'exports-shorthand-fallback-error.js',
+    onwarn: () => {
+      t.fail('No warnings were expected');
+    },
+    plugins: [nodeResolve()]
+  });
+  const { module } = await testBundle(t, bundle);
+
+  t.deepEqual(module.exports, 'MAIN MAPPED');
+});
+
+test('can resolve a package import to a relative file', async (t) => {
+  const bundle = await rollup({
+    input: 'imports-relative.js',
+    onwarn: () => {
+      t.fail('No warnings were expected');
+    },
+    plugins: [nodeResolve()]
+  });
+  const { module } = await testBundle(t, bundle);
+
+  t.deepEqual(module.exports, 'imports-relative imported ./src/foo');
+});
+
+test('can resolve a package import to a bare import', async (t) => {
+  const bundle = await rollup({
+    input: 'imports-bare.js',
+    onwarn: () => {
+      t.fail('No warnings were expected');
+    },
+    plugins: [nodeResolve()]
+  });
+  const { module } = await testBundle(t, bundle);
+
+  t.deepEqual(module.exports, 'imports-bare imported imports-bare-dependency');
+});
+
+test('can resolve a package import with conditions', async (t) => {
+  const bundle = await rollup({
+    input: 'imports-conditions.js',
+    onwarn: () => {
+      t.fail('No warnings were expected');
+    },
+    plugins: [nodeResolve()]
+  });
+  const { module } = await testBundle(t, bundle);
+
+  t.deepEqual(module.exports, 'imports-conditions imported ./src/foo.mjs');
+});
+
+test('can resolve a package import with a pattern', async (t) => {
+  const bundle = await rollup({
+    input: 'imports-pattern.js',
+    onwarn: () => {
+      t.fail('No warnings were expected');
+    },
+    plugins: [nodeResolve()]
+  });
+  const { module } = await testBundle(t, bundle);
+
+  t.deepEqual(module.exports, {
+    a: './src/a.js',
+    b: './src/b.js',
+    fooA: './foo/x-a.js',
+    fooB: './foo/x-b.js'
+  });
+});
+
+test('can override a star pattern using null', async (t) => {
+  const errors = [];
+  const bundle = await rollup({
+    input: 'exports-null-override.js',
+    onwarn: (e) => {
+      errors.push(e);
+    },
+    plugins: [nodeResolve()]
+  });
+  await testBundle(t, bundle);
+
+  t.true(errors[0].message.includes('Could not resolve import "exports-null-override/foo/a" in '));
 });


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `node-resolve`

This PR contains:

- [X] bugfix
- [X] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [X] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [X] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers: https://github.com/rollup/plugins/issues/670

### Description

To fix https://github.com/rollup/plugins/issues/670 I started reviewing the algorithm at https://nodejs.org/dist/latest-v15.x/docs/api/esm.html#esm_resolver_algorithm_specification and figured it would be better to implement that more closely. 

This PR re-implements the whole package exports feature, basing it on the spec. This fixes the reported bug, and also adds support for the package imports feature defined at https://nodejs.org/api/packages.html#packages_subpath_imports