### PR TITLE
chore(pluginutils): fix lint errors

### DIFF
--- a/packages/pluginutils/src/extractAssignedNames.ts
+++ b/packages/pluginutils/src/extractAssignedNames.ts
@@ -1,3 +1,11 @@
+import type {
+  ArrayPattern,
+  AssignmentPattern,
+  Identifier,
+  ObjectPattern,
+  RestElement
+} from 'estree';
+
 import { ExtractAssignedNames } from '../types';
 
 interface Extractors {
@@ -5,23 +13,23 @@ interface Extractors {
 }
 
 const extractors: Extractors = {
-  ArrayPattern(names: string[], param: import('estree').ArrayPattern) {
+  ArrayPattern(names: string[], param: ArrayPattern) {
     for (const element of param.elements) {
       if (element) extractors[element.type](names, element);
     }
   },
 
-  AssignmentPattern(names: string[], param: import('estree').AssignmentPattern) {
+  AssignmentPattern(names: string[], param: AssignmentPattern) {
     extractors[param.left.type](names, param.left);
   },
 
-  Identifier(names: string[], param: import('estree').Identifier) {
+  Identifier(names: string[], param: Identifier) {
     names.push(param.name);
   },
 
   MemberExpression() {},
 
-  ObjectPattern(names: string[], param: import('estree').ObjectPattern) {
+  ObjectPattern(names: string[], param: ObjectPattern) {
     for (const prop of param.properties) {
       // @ts-ignore Typescript reports that this is not a valid type
       if (prop.type === 'RestElement') {
@@ -32,7 +40,7 @@ const extractors: Extractors = {
     }
   },
 
-  RestElement(names: string[], param: import('estree').RestElement) {
+  RestElement(names: string[], param: RestElement) {
     extractors[param.argument.type](names, param.argument);
   }
 };

--- a/packages/pluginutils/src/normalizePath.ts
+++ b/packages/pluginutils/src/normalizePath.ts
@@ -2,7 +2,7 @@ import { win32, posix } from 'path';
 
 import { NormalizePath } from '../types';
 
-const normalizePath: NormalizePath = function(filename: string) {
+const normalizePath: NormalizePath = function (filename: string) {
   return filename.split(win32.sep).join(posix.sep);
 };
 

--- a/packages/pluginutils/test/addExtension.ts
+++ b/packages/pluginutils/test/addExtension.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
 
-import { addExtension } from '../';
+import { addExtension } from '../src/index';
 
 test('adds .js to an ID without an extension', (t) => {
   t.is(addExtension('foo'), 'foo.js');

--- a/packages/pluginutils/test/attachScopes.ts
+++ b/packages/pluginutils/test/attachScopes.ts
@@ -4,7 +4,8 @@ import * as estree from 'estree';
 import test from 'ava';
 import { parse } from 'acorn';
 
-import { attachScopes, AttachedScope } from '../';
+import { attachScopes } from '../src/index';
+import { AttachedScope } from '../types';
 
 test('attaches a scope to the top level', (t) => {
   const ast = parse('var foo;', { ecmaVersion: 2020, sourceType: 'module' });

--- a/packages/pluginutils/test/createFilter.ts
+++ b/packages/pluginutils/test/createFilter.ts
@@ -2,7 +2,7 @@ import { resolve as rawResolve } from 'path';
 
 import test from 'ava';
 
-import { createFilter, normalizePath } from '../';
+import { createFilter, normalizePath } from '../src/index';
 
 const resolve = (...parts: string[]) => normalizePath(rawResolve(...parts));
 

--- a/packages/pluginutils/test/dataToEsm.ts
+++ b/packages/pluginutils/test/dataToEsm.ts
@@ -92,7 +92,7 @@ test('supports empty keys', (t) => {
 test('avoid U+2029 U+2029 -0 be ignored by JSON.stringify, and avoid it return non-string (undefined) before replacing', (t) => {
   t.is(
     // eslint-disable-next-line no-undefined, func-names
-    dataToEsm([-0, '\u2028\u2029', undefined, function() {}], { compact: true }),
+    dataToEsm([-0, '\u2028\u2029', undefined, function () {}], { compact: true }),
     'export default[-0,"\\u2028\\u2029",undefined,undefined];'
   );
 });

--- a/packages/pluginutils/test/extractAssignedNames.ts
+++ b/packages/pluginutils/test/extractAssignedNames.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
 
-import { extractAssignedNames } from '../';
+import { extractAssignedNames } from '../src/index';
 
 test('extracts an Identifier', (t) => {
   const node = {

--- a/packages/pluginutils/test/makeLegalIdentifier.ts
+++ b/packages/pluginutils/test/makeLegalIdentifier.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
 
-import { makeLegalIdentifier } from '../';
+import { makeLegalIdentifier } from '../src/index';
 
 test('camel-cases names', (t) => {
   t.is(makeLegalIdentifier('foo-bar'), 'fooBar');

--- a/packages/pluginutils/test/normalizePath.ts
+++ b/packages/pluginutils/test/normalizePath.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
 
-import { normalizePath } from '../';
+import { normalizePath } from '../src/index';
 
 test('replaces \\ with /', (t) => {
   t.is(normalizePath('foo\\bar'), 'foo/bar');


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `pluginutils`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [X] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [X] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [X] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

This fixes all but one lint error. I think the last one is a bug in `typescript-eslint` and not a real error. I'll file a bug there to try to get it addressed after this is merged
