### PR TITLE
chore(commonjs): fix lint error

### DIFF
--- a/packages/commonjs/test/types.ts
+++ b/packages/commonjs/test/types.ts
@@ -1,6 +1,8 @@
+import type { RollupOptions } from 'rollup';
+
 import commonjs from '../types';
 
-const config: import('rollup').RollupOptions = {
+const config: RollupOptions = {
   input: 'main.js',
   output: {
     file: 'bundle.js',


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `commonjs`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [X] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [X] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [X] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

`lint` fails on `master` for this project:

>packages/commonjs/test/types.ts
  3:32  error  'RollupOptions' is not defined  no-undef
