### PR TITLE
fix(typescript) replace getOutputFileNames

### DIFF
--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -51,6 +51,7 @@
   },
   "dependencies": {
     "@rollup/pluginutils": "^3.1.0",
+    "common-path-prefix": "^3.0.0",
     "resolve": "^1.17.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -443,6 +443,7 @@ importers:
   packages/typescript:
     dependencies:
       '@rollup/pluginutils': 3.1.0_rollup@2.32.1
+      common-path-prefix: 3.0.0
       resolve: 1.18.1
     devDependencies:
       '@rollup/plugin-buble': 0.21.3_rollup@2.32.1
@@ -459,6 +460,7 @@ importers:
       '@rollup/pluginutils': ^3.1.0
       '@types/node': ^10.0.0
       buble: ^0.20.0
+      common-path-prefix: ^3.0.0
       resolve: ^1.17.0
       rollup: ^2.14.0
       typescript: ^4.1.2
@@ -2938,7 +2940,6 @@ packages:
     resolution:
       integrity: sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==
   /common-path-prefix/3.0.0:
-    dev: true
     resolution:
       integrity: sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==
   /commondir/1.0.1:


### PR DESCRIPTION
## Rollup Plugin Name: `{@rollup/plugin-typescript}`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no _(I don't believe so)_


List any relevant issue numbers:
An issue I experienced _(details below)_ and rather than logging it, I set out to fix it.
Potentially resolves #287 
Potentially resolves #608 
### Description

The problem I experienced was that when I used the Rollup API, if I set `tsconfig:false` and passed in all of my compilerOptions to the typescript plugin, the system would fail ... with a very unhelpful message.

Turns out is was a failing assertion deep inside  typescript as part of the `getOutputFileNames` call chain. _(Little did I realise at the time that it had been causing grief for others in a different fashion)_.

So I set out to see if there was another approach...

It turns out that TS knows _(obviously)_ and  _already tells the  typescript plugin where it has generated files and what the corresponding source files are, this comes via the BuildProgram `writeFile` callback.  By utilising the extra information this PR obviates the need for `getOutputFileNames` an external call we no longer need to make. 🥳 

I've added a new test _(that failed pre these changes)_ and I've _slightly_ tweaked a couple of others as the order of files reported to the test harness has changed and the FakeTypescript test needed to also pass in the newly used source file information.

I also changed the way that the `generateBundle` figures out the baseDir path to use ... basing it on the approach MS document on their TS site _(URL in the source)_ ... however, whilst it works and does not break tests ... I feel that there is perhaps a better way to calculate this ... perhaps just copying the hierarchy that the TS program generates? 🤔 

There is a possibility that this may also address issue #287 however I was unsuccessful in getting the test that @benmccann added ... but I think it is close ... 🤞 