### PR TITLE
Turn off lint rule that's causing attempted reformatting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,6 +35,7 @@ module.exports = {
     'import/no-named-export': 'off',
     'no-redeclare': 'off',
     'no-unused-vars': 'off',
+    'prefer-object-spread': 'off',
     'spaced-comment': 'off',
     'prettier/prettier': [
       'error',


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `all`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [X] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [X] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [X] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
This project runs `eslint --fix` as part of `pnpm -r lint`. There are a lot of files that do not abide by this rule, so it tries to replace every instance of `Object.assign` with a spread operator. There are a pretty good number of places where the code does not conform to these expectations. This would let the code remain how it is instead of it being automatically updated

There's one other major issue to address and I've raised a separate issue for it: https://github.com/rollup/plugins/issues/734