### PR TITLE
fix(node-resolve): only log last resolve error

### DIFF
--- a/packages/node-resolve/test/fixtures/exports-ts-fallback.ts
+++ b/packages/node-resolve/test/fixtures/exports-ts-fallback.ts
@@ -1,0 +1,3 @@
+import a from 'exports-ts-fallback/a.js';
+
+export default { a };

--- a/packages/node-resolve/test/fixtures/node_modules/exports-ts-fallback/a.js
+++ b/packages/node-resolve/test/fixtures/node_modules/exports-ts-fallback/a.js
@@ -1,0 +1,1 @@
+export default 'A';

--- a/packages/node-resolve/test/fixtures/node_modules/exports-ts-fallback/package.json
+++ b/packages/node-resolve/test/fixtures/node_modules/exports-ts-fallback/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "exports-ts-fallback",
+	"main": "index.js",
+	"exports": {
+		"./a.js": "./a.js"
+	}
+}

--- a/packages/node-resolve/test/package-entry-points.js
+++ b/packages/node-resolve/test/package-entry-points.js
@@ -365,3 +365,18 @@ test('can self-import a package when using exports field', async (t) => {
     b: 'b'
   });
 });
+
+test('does not warn when resolving typescript imports with fallback', async (t) => {
+  const bundle = await rollup({
+    input: 'exports-ts-fallback.ts',
+    onwarn: () => {
+      t.fail('No warnings were expected');
+    },
+    plugins: [nodeResolve({ extensions: ['.js', '.ts'] })]
+  });
+  const { module } = await testBundle(t, bundle);
+
+  t.deepEqual(module.exports, {
+    a: 'A'
+  });
+});


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `node-resolve`

This PR contains:

- [X] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [X] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [X] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

When attempting to resolve a list of specifiers we are logging warnings for failed attempts. This change only logs the last failed attempt.

This is visible for example when resolving `.js` imports in a `.ts` file.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
