### PR TITLE
fix(commonjs): correctly replace shorthand `require`

### DIFF
--- a/packages/commonjs/src/ast-utils.js
+++ b/packages/commonjs/src/ast-utils.js
@@ -115,3 +115,7 @@ export function isLocallyShadowed(name, scope) {
   }
   return false;
 }
+
+export function isShorthandProperty(parent) {
+  return parent && parent.shorthand;
+}

--- a/packages/commonjs/src/ast-utils.js
+++ b/packages/commonjs/src/ast-utils.js
@@ -117,5 +117,5 @@ export function isLocallyShadowed(name, scope) {
 }
 
 export function isShorthandProperty(parent) {
-  return parent && parent.shorthand;
+  return parent && parent.type === 'Property' && parent.shorthand;
 }

--- a/packages/commonjs/src/transform-commonjs.js
+++ b/packages/commonjs/src/transform-commonjs.js
@@ -11,6 +11,7 @@ import {
   isDefineCompiledEsm,
   isFalsy,
   isReference,
+  isShorthandProperty,
   isTruthy,
   KEY_COMPILED_ESM
 } from './ast-utils';
@@ -234,10 +235,14 @@ export default function transformCommonjs(
                   )}`
                 );
               }
+              if (isShorthandProperty(parent)) {
+                magicString.appendRight(node.end, `: ${HELPERS_NAME}.commonjsRequire`);
+              } else {
+                magicString.overwrite(node.start, node.end, `${HELPERS_NAME}.commonjsRequire`, {
+                  storeName: true
+                });
+              }
 
-              magicString.overwrite(node.start, node.end, `${HELPERS_NAME}.commonjsRequire`, {
-                storeName: true
-              });
               uses.commonjsHelpers = true;
               return;
             case 'module':

--- a/packages/commonjs/test/fixtures/samples/shorthand-require/main.js
+++ b/packages/commonjs/test/fixtures/samples/shorthand-require/main.js
@@ -1,0 +1,7 @@
+const HOST = {
+  require
+};
+
+module.exports = {
+  HOST
+};

--- a/packages/commonjs/test/test.js
+++ b/packages/commonjs/test/test.js
@@ -734,7 +734,7 @@ test('does not replace shorthand `require` property in object', async (t) => {
 
   const code = await getCodeFromBundle(bundle, { exports: 'named' });
 
-  t.is(/require: commonjsRequire,/.test(code), true);
+  t.is(/require: commonjsRequire/.test(code), true);
 });
 
 // This test uses worker threads to simulate an empty internal cache and needs at least Node 12

--- a/packages/commonjs/test/test.js
+++ b/packages/commonjs/test/test.js
@@ -726,6 +726,17 @@ test('does not wrap commonjsRegister calls in createCommonjsModule', async (t) =
   t.not(/createCommonjsModule\(function/.test(code), true);
 });
 
+test('does not replace shorthand `require` property in object', async (t) => {
+  const bundle = await rollup({
+    input: 'fixtures/samples/shorthand-require/main.js',
+    plugins: [commonjs()]
+  });
+
+  const code = await getCodeFromBundle(bundle, { exports: 'named' });
+
+  t.is(/require: commonjsRequire,/.test(code), true);
+});
+
 // This test uses worker threads to simulate an empty internal cache and needs at least Node 12
 if (Number(/^v(\d+)/.exec(process.version)[1]) >= 12) {
   test('can be cached across instances', async (t) => {


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `commonjs`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers: #763

### Description

Checks that `require` is shorthand property.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
