### PR TITLE
feat(babel): add filter option

### DIFF
--- a/packages/babel/README.md
+++ b/packages/babel/README.md
@@ -92,6 +92,21 @@ Type: `String | RegExp | Array[...String|RegExp]`<br>
 
 A [minimatch pattern](https://github.com/isaacs/minimatch), or array of patterns, which specifies the files in the build the plugin should operate on. When relying on Babel configuration files you cannot include files already excluded there.
 
+### `filter`
+
+Type: (id: unknown) => boolean<br>
+
+Custom [filter function](https://github.com/rollup/plugins/tree/master/packages/pluginutils#createfilter) can be used to determine whether or not certain modules should be operated upon.
+
+Usage:
+
+```js
+import { createFilter } from '@rollup/pluginutils';
+const include = 'include/**.js';
+const exclude = 'exclude/**.js';
+const filter = createFilter(include, exclude, {});
+```
+
 ### `extensions`
 
 Type: `Array[...String]`<br>

--- a/packages/babel/README.md
+++ b/packages/babel/README.md
@@ -94,7 +94,7 @@ A [minimatch pattern](https://github.com/isaacs/minimatch), or array of patterns
 
 ### `filter`
 
-Type: (id: unknown) => boolean<br>
+Type: (id: string) => boolean<br>
 
 Custom [filter function](https://github.com/rollup/plugins/tree/master/packages/pluginutils#createfilter) can be used to determine whether or not certain modules should be operated upon.
 

--- a/packages/babel/src/index.js
+++ b/packages/babel/src/index.js
@@ -137,13 +137,11 @@ function createBabelInputPluginFactory(customCallback = returnObject) {
         const extensionRegExp = new RegExp(
           `(${extensions.map(escapeRegExpCharacters).join('|')})$`
         );
-        const userDefinedFilter = (id) => {
-          let ret = createFilter(include, exclude)(id);
-          if (typeof customFilter === 'function') {
-            ret = ret && customFilter(id);
-          }
-          return ret;
-        };
+        if (customFilter && (include || exclude)) {
+          throw new Error('Could not handle include or exclude with custom filter together');
+        }
+        const userDefinedFilter =
+          typeof customFilter === 'function' ? customFilter : createFilter(include, exclude);
         filter = (id) => extensionRegExp.test(stripQuery(id).bareId) && userDefinedFilter(id);
 
         return null;

--- a/packages/babel/test/as-input-plugin.js
+++ b/packages/babel/test/as-input-plugin.js
@@ -6,6 +6,7 @@ import { rollup } from 'rollup';
 import { SourceMapConsumer } from 'source-map';
 import jsonPlugin from '@rollup/plugin-json';
 import nodeResolvePlugin from '@rollup/plugin-node-resolve';
+import { createFilter } from '@rollup/pluginutils';
 
 import { getCode } from '../../../util/test';
 
@@ -97,6 +98,44 @@ test('does not babelify excluded code', async (t) => {
 const foo = () => 42;
 
 console.log("the answer is ".concat(foo()));
+`
+  );
+});
+
+test('does not babelify excluded code with custom filter', async (t) => {
+  const filter = createFilter([], '**/foo.js');
+  const code = await generate('fixtures/exclusions/main.js', { filter });
+  // eslint-disable-next-line no-template-curly-in-string
+  t.false(code.includes('${foo()}'));
+  t.true(code.includes('=> 42'));
+  t.is(
+    code,
+    `'use strict';
+
+const foo = () => 42;
+
+console.log("the answer is ".concat(foo()));
+`
+  );
+});
+
+test('does babelify included code with custom filter', async (t) => {
+  const filter = createFilter('**/foo.js', [], {
+    resolve: __dirname
+  });
+  const code = await generate('fixtures/exclusions/main.js', { filter });
+  // eslint-disable-next-line no-template-curly-in-string
+  t.true(code.includes('${foo()}'));
+  t.false(code.includes('=> 42'));
+  t.is(
+    code,
+    `'use strict';
+
+var foo = function foo() {
+  return 42;
+};
+
+console.log(\`the answer is \${foo()}\`);
 `
   );
 });

--- a/packages/babel/test/as-input-plugin.js
+++ b/packages/babel/test/as-input-plugin.js
@@ -140,6 +140,27 @@ console.log(\`the answer is \${foo()}\`);
   );
 });
 
+test('can not pass include or exclude when custom filter specified', async (t) => {
+  const filter = createFilter('**/foo.js', [], {
+    resolve: __dirname
+  });
+  let errorWithExclude = '';
+  try {
+    await generate('fixtures/exclusions/main.js', { filter, exclude: [] });
+  } catch (e) {
+    errorWithExclude = e.message;
+  }
+  t.true(!!errorWithExclude);
+
+  let errorWithInclude = '';
+  try {
+    await generate('fixtures/exclusions/main.js', { filter, include: [] });
+  } catch (e) {
+    errorWithInclude = e.message;
+  }
+  t.true(!!errorWithInclude);
+});
+
 test('generates sourcemap by default', async (t) => {
   const bundle = await rollup({
     input: 'fixtures/class/main.js',

--- a/packages/babel/types/index.d.ts
+++ b/packages/babel/types/index.d.ts
@@ -1,5 +1,5 @@
 import { Plugin, PluginContext, TransformPluginContext } from 'rollup';
-import { FilterPattern } from '@rollup/pluginutils';
+import { FilterPattern, CreateFilter } from '@rollup/pluginutils';
 import * as babelCore from '@babel/core';
 
 export interface RollupBabelInputPluginOptions
@@ -14,6 +14,16 @@ export interface RollupBabelInputPluginOptions
    * @default undefined;
    */
   exclude?: FilterPattern;
+  /**
+   * Custom filter function can be used to determine whether or not certain modules should be operated upon.
+   * Example:
+   *   import { createFilter } from '@rollup/pluginutils';
+   *   const include = 'include/**.js';
+   *   const exclude = 'exclude/**.js';
+   *   const filter = createFilter(include, exclude, {});
+   * @default undefined;
+   */
+  filter?: ReturnType<CreateFilter>;
   /**
    * An array of file extensions that Babel should transpile. If you want to transpile TypeScript files with this plugin it's essential to include .ts and .tsx in this option.
    * @default ['.js', '.jsx', '.es6', '.es', '.mjs']


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `babel`

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

~Since `createFilter` has a third options, which can pass `resolutionBase`. It might be better the option can be controlled by `rollup-plugin-babel`~

According to the following discussion, adding filter option to @rollup/plugin-babel.
