### PR TITLE
fix(typescript): only emit tsbuildinfo file when there is something to emit

### DIFF
--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -142,11 +142,15 @@ export default function typescript(options: RollupTypescriptOptions = {}): Plugi
 
       const tsBuildInfoPath = ts.getTsBuildInfoEmitOutputFilePath(parsedOptions.options);
       if (tsBuildInfoPath) {
-        this.emitFile({
-          type: 'asset',
-          fileName: normalizePath(path.relative(outputOptions.dir!, tsBuildInfoPath)),
-          source: emittedFiles.get(tsBuildInfoPath)
-        });
+        const tsBuildInfoSource = emittedFiles.get(tsBuildInfoPath);
+        // https://github.com/rollup/plugins/issues/681
+        if (tsBuildInfoSource) {
+          this.emitFile({
+            type: 'asset',
+            fileName: normalizePath(path.relative(outputOptions.dir!, tsBuildInfoPath)),
+            source: tsBuildInfoSource
+          });
+        }
       }
     }
   };

--- a/packages/typescript/test/fixtures/incremental-output-cache/main.ts
+++ b/packages/typescript/test/fixtures/incremental-output-cache/main.ts
@@ -1,0 +1,6 @@
+type AnswerToQuestion = string | undefined;
+
+const answer: AnswerToQuestion = '42';
+
+// eslint-disable-next-line no-console
+console.log(`the answer is ${answer}`);

--- a/packages/typescript/test/fixtures/incremental-output-cache/tsconfig.json
+++ b/packages/typescript/test/fixtures/incremental-output-cache/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "incremental": true,
+    "outDir": "./dist",
+    "tsBuildInfoFile": "./dist/.tsbuildinfo"
+  }
+}

--- a/packages/typescript/test/test.js
+++ b/packages/typescript/test/test.js
@@ -249,19 +249,29 @@ test.serial('ensures multiple outputs can be built', async (t) => {
     plugins: [typescript({ tsconfig: 'fixtures/multiple-files/tsconfig.json' })]
   });
 
-  const output1 = await getCode(bundle1, { file: 'fixtures/multiple-files/index.js', format: 'cjs' }, true);
+  const output1 = await getCode(
+    bundle1,
+    { file: 'fixtures/multiple-files/index.js', format: 'cjs' },
+    true
+  );
 
   const bundle2 = await rollup({
     input: 'fixtures/multiple-files/src/server.ts',
     plugins: [typescript({ tsconfig: 'fixtures/multiple-files/tsconfig.json' })]
   });
 
-  const output2 = await getCode(bundle2, { file: 'fixtures/multiple-files/server.js', format: 'cjs' }, true);
-
-  t.deepEqual(
-    [...new Set(output1.concat(output2).map((out) => out.fileName))].sort(),
-    ['index.d.ts', 'index.js', 'server.d.ts', 'server.js']
+  const output2 = await getCode(
+    bundle2,
+    { file: 'fixtures/multiple-files/server.js', format: 'cjs' },
+    true
   );
+
+  t.deepEqual([...new Set(output1.concat(output2).map((out) => out.fileName))].sort(), [
+    'index.d.ts',
+    'index.js',
+    'server.d.ts',
+    'server.js'
+  ]);
 });
 
 test.serial('relative paths in tsconfig.json are resolved relative to the file', async (t) => {
@@ -877,6 +887,41 @@ test.serial('supports consecutive incremental rebuilds', async (t) => {
   );
 });
 
+// https://github.com/rollup/plugins/issues/681
+test.serial('supports incremental rebuilds with no change to cache', async (t) => {
+  process.chdir('fixtures/incremental-output-cache');
+  const cleanup = () => fs.rmdirSync('dist', { recursive: true });
+
+  cleanup();
+
+  const firstBundle = await rollup({
+    input: 'main.ts',
+    plugins: [typescript()],
+    onwarn
+  });
+
+  const firstRun = await getCode(firstBundle, { format: 'esm', dir: 'dist' }, true);
+  t.deepEqual(
+    firstRun.map((out) => out.fileName),
+    ['main.js', '.tsbuildinfo']
+  );
+  await firstBundle.write({ dir: 'dist' });
+
+  const secondBundle = await rollup({
+    input: 'main.ts',
+    plugins: [typescript()],
+    onwarn
+  });
+  const secondRun = await getCode(secondBundle, { format: 'esm', dir: 'dist' }, true);
+  t.deepEqual(
+    secondRun.map((out) => out.fileName),
+    // .tsbuildinfo should not be emitted
+    ['main.js']
+  );
+
+  cleanup();
+});
+
 test.serial.skip('supports project references', async (t) => {
   process.chdir('fixtures/project-references');
 
@@ -1088,50 +1133,48 @@ test('supports custom transformers', async (t) => {
 });
 
 function fakeTypescript(custom) {
-  return Object.assign(
-    {
-      sys: ts.sys,
-      createModuleResolutionCache: ts.createModuleResolutionCache,
-      ModuleKind: ts.ModuleKind,
+  return {
+    sys: ts.sys,
+    createModuleResolutionCache: ts.createModuleResolutionCache,
+    ModuleKind: ts.ModuleKind,
 
-      transpileModule() {
-        return {
-          outputText: '',
-          diagnostics: [],
-          sourceMapText: JSON.stringify({ mappings: '' })
-        };
-      },
-
-      createWatchCompilerHost() {
-        return {
-          afterProgramCreate() {}
-        };
-      },
-
-      createWatchProgram() {
-        return {};
-      },
-
-      parseJsonConfigFileContent(json, host, basePath, existingOptions) {
-        return {
-          options: {
-            ...json.compilerOptions,
-            ...existingOptions
-          },
-          fileNames: [],
-          errors: []
-        };
-      },
-
-      getOutputFileNames(_, id) {
-        return [id.replace(/\.tsx?/, '.js')];
-      },
-
-      // eslint-disable-next-line no-undefined
-      getTsBuildInfoEmitOutputFilePath: () => undefined
+    transpileModule() {
+      return {
+        outputText: '',
+        diagnostics: [],
+        sourceMapText: JSON.stringify({ mappings: '' })
+      };
     },
-    custom
-  );
+
+    createWatchCompilerHost() {
+      return {
+        afterProgramCreate() {}
+      };
+    },
+
+    createWatchProgram() {
+      return {};
+    },
+
+    parseJsonConfigFileContent(json, host, basePath, existingOptions) {
+      return {
+        options: {
+          ...json.compilerOptions,
+          ...existingOptions
+        },
+        fileNames: [],
+        errors: []
+      };
+    },
+
+    getOutputFileNames(_, id) {
+      return [id.replace(/\.tsx?/, '.js')];
+    },
+
+    // eslint-disable-next-line no-undefined
+    getTsBuildInfoEmitOutputFilePath: () => undefined,
+    ...custom
+  };
 }
 
 test.serial('picks up on newly included typescript files in watch mode', async (t) => {

--- a/packages/typescript/test/test.js
+++ b/packages/typescript/test/test.js
@@ -890,7 +890,16 @@ test.serial('supports consecutive incremental rebuilds', async (t) => {
 // https://github.com/rollup/plugins/issues/681
 test.serial('supports incremental rebuilds with no change to cache', async (t) => {
   process.chdir('fixtures/incremental-output-cache');
-  const cleanup = () => fs.rmdirSync('dist', { recursive: true });
+  const cleanup = () => {
+    let files;
+    try {
+      files = fs.readdirSync('dist');
+    } catch (error) {
+      if (error.code === 'ENOENT') return;
+      throw error;
+    }
+    files.forEach((file) => fs.unlinkSync(path.join('dist', file)));
+  };
 
   cleanup();
 


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `typescript`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no
~~I'm still trying to figure out why [this test](https://github.com/rollup/plugins/blob/e4a4cec3ef0419f0a9a6ef6a02ef4034c7919451/packages/typescript/test/test.js#L853-L878) didn't fail before this fix.~~
It was because the bundle output wasn't written to disk, so the second run would be identical to the first as TypeScript wouldn't find the existing `.tsbuildinfo`.

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers: #681

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

Fixes #681

The plugin now checks if TypeScript has emitted a tsbuildinfo file. If and only if it has, the plugin emits the tsbuildinfo file.

This prevents the TypeError from occurring when the plugin used to emit the file even when there was no source for it (`emittedFiles.get(tsBuildInfoPath)` was `undefined`).