### PR TITLE
feat(legacy): normalize exports paths

### DIFF
--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -40,6 +40,9 @@
   "peerDependencies": {
     "rollup": "^1.20.0||^2.0.0"
   },
+  "dependencies": {
+    "@rollup/pluginutils": "^4.1.0"
+  },
   "devDependencies": {
     "@rollup/plugin-buble": "^0.21.3",
     "del-cli": "^3.0.1",

--- a/packages/legacy/src/index.js
+++ b/packages/legacy/src/index.js
@@ -1,20 +1,23 @@
 import { resolve } from 'path';
 
+import { normalizePath } from '@rollup/pluginutils';
+
 const validName = /^[a-zA-Z_$][a-zA-Z$_0-9]*$/;
 
 export default function legacy(options) {
   const exports = {};
   Object.keys(options).forEach((file) => {
-    exports[resolve(file)] = options[file];
+    exports[normalizePath(resolve(file))] = options[file];
   });
 
   return {
     name: 'legacy',
 
     transform(content, id) {
-      if (id in exports) {
+      const normalizedId = normalizePath(id);
+      if (normalizedId in exports) {
         let code = content;
-        const value = exports[id];
+        const value = exports[normalizedId];
 
         if (typeof value === 'string') {
           // default export

--- a/packages/legacy/test/test.js
+++ b/packages/legacy/test/test.js
@@ -1,5 +1,9 @@
+const path = require('path');
+
 const test = require('ava');
 const { rollup } = require('rollup');
+
+const { normalizePath } = require('@rollup/pluginutils');
 
 const { testBundle } = require('../../../util/test');
 
@@ -58,6 +62,28 @@ test('adds a unchanged named export', async (t) => {
         './fixtures/named-exports-unchanged/answer.js': {
           answer: 'answer'
         }
+      })
+    ]
+  });
+  t.plan(1);
+  await testBundle(t, bundle);
+});
+
+test('normalized paths', async (t) => {
+  const bundle = await rollup({
+    input: 'fixtures/default-export/main.js',
+    plugins: [
+      {
+        name: 'NormalizedPath',
+        resolveId(importee) {
+          if (importee === './answer') {
+            return normalizePath(path.resolve('./fixtures/default-export/answer.js'));
+          }
+          return null;
+        }
+      },
+      legacy({
+        './fixtures/default-export/answer.js': 'answer'
       })
     ]
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -312,12 +312,15 @@ importers:
       rollup: ^2.23.0
       source-map-support: ^0.5.19
   packages/legacy:
+    dependencies:
+      '@rollup/pluginutils': 4.1.0_rollup@2.32.1
     devDependencies:
       '@rollup/plugin-buble': 0.21.3_rollup@2.32.1
       del-cli: 3.0.1
       rollup: 2.32.1
     specifiers:
       '@rollup/plugin-buble': ^0.21.3
+      '@rollup/pluginutils': ^4.1.0
       del-cli: ^3.0.1
       rollup: ^2.23.0
   packages/multi-entry:
@@ -1786,20 +1789,6 @@ packages:
       typescript: '>=3.4.0'
     resolution:
       integrity: sha512-CkS028Itwjqm1uLbFVfpJgtVtnNvZ+og/m6UlNRR5wOOnNTWPcVQzOu5xGdEX+WWJxdvWIqUq2uR/RBt2ZipWg==
-  /@rollup/plugin-typescript/6.0.0_rollup@2.32.1:
-    dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.32.1
-      resolve: 1.18.1
-      rollup: 2.32.1
-    dev: true
-    engines:
-      node: '>=8.0.0'
-    peerDependencies:
-      rollup: ^2.14.0
-      tslib: '*'
-      typescript: '>=3.4.0'
-    resolution:
-      integrity: sha512-Y5U2L4eaF3wUSgCZRMdvNmuzWkKMyN3OwvhAdbzAi5sUqedaBk/XbzO4T7RlViDJ78MOPhwAIv2FtId/jhMtbg==
   /@rollup/plugin-typescript/6.0.0_rollup@2.32.1+typescript@4.1.2:
     dependencies:
       '@rollup/pluginutils': 3.1.0_rollup@2.32.1
@@ -1863,6 +1852,18 @@ packages:
       rollup: ^1.20.0||^2.0.0
     resolution:
       integrity: sha512-b5QiJRye4JlSg29bKNEECoKbLuPXZkPEHSgEjjP1CJV1CPdDBybfYHfm6kyq8yK51h/Zsyl8OvWUrp0FUBukEQ==
+  /@rollup/pluginutils/4.1.0_rollup@2.32.1:
+    dependencies:
+      estree-walker: 2.0.1
+      picomatch: 2.2.2
+      rollup: 2.32.1
+    dev: false
+    engines:
+      node: '>= 8.0.0'
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0
+    resolution:
+      integrity: sha512-TrBhfJkFxA+ER+ew2U2/fHbebhLT/l/2pRk0hfj9KusXUuRXd2v0R58AfaZK9VXDQ4TogOSEmICVrQAA3zFnHQ==
   /@sindresorhus/is/0.14.0:
     dev: true
     engines:
@@ -3058,7 +3059,7 @@ packages:
     resolution:
       integrity: sha512-7ItTKOhOZbznhXAQ2g/slGg1PJV5zDO/WdkTwi7UEOJmkvsE32PWvx6mKtDjiMpjnR2CNf6BAD6sSxIlv7ptng==
   /core-js/2.6.11:
-    deprecated: 'core-js@<3 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.'
+    deprecated: core-js@<3 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.
     dev: true
     requiresBuild: true
     resolution:
@@ -3311,7 +3312,7 @@ packages:
   /debug/4.2.0:
     dependencies:
       ms: 2.1.2
-    deprecated: 'Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)'
+    deprecated: Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)
     engines:
       node: '>=6.0'
     peerDependencies:


### PR DESCRIPTION
## Rollup Plugin Name: `legacy`

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

### Description

Vite 2 implements a [universal rollup plugin API](https://vitejs.dev/guide/api-plugin.html) (for the ESM based dev server, and the build using rollup). Plugins are mostly compatible. I am maintaining a [compatibility list for official rollup plugins here](http://vite-rollup-plugins.patak.dev/).

One difference in the dev server is that Vite normalizes paths to use posix slashes (in the same way as normalizePath in @rollup/pluginutils) while resolving ids. This is [not an issue](https://github.com/vitejs/vite/pull/1693) generally because utils like createFilter also normalize ids while matching.

This PR uses rolluputils.normalizePath to normalizes ids in the exports map for @rollup/plugin-legacy so it is compatible with Vite. This will fix https://github.com/vitejs/vite/issues/1521