### PR TITLE
Check types in typescript packages in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,9 @@ jobs:
       - run:
           name: Run linting.
           command: pnpm run ci:lint
+      - run:
+          name: Run check TS types.
+          command: pnpm run test:ts
       - save_cache:
           key: dependency-cache-{{ checksum "pnpm-lock.yaml" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
           name: Run linting.
           command: pnpm run ci:lint
       - run:
-          name: Run check TS types.
+          name: Check TypeScript types.
           command: pnpm run test:ts
       - save_cache:
           key: dependency-cache-{{ checksum "pnpm-lock.yaml" }}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "pub": "node scripts/pub.js",
     "publish": "node scripts/publish.js",
     "security": "pnpm audit --audit-level=moderate",
-    "test": "node scripts/run-changed.js test"
+    "test": "node scripts/run-changed.js test",
+    "test:ts": "node scripts/run-changed.js test:ts"
   },
   "dependencies": {
     "conventional-commits-parser": "^3.1.0",

--- a/packages/alias/package.json
+++ b/packages/alias/package.json
@@ -29,7 +29,8 @@
     "prepare": "pnpm run build",
     "prepublishOnly": "pnpm run lint && pnpm run test",
     "pretest": "pnpm run build",
-    "test": "ava"
+    "test": "ava",
+    "test:ts": "tsc --noEmit"
   },
   "files": [
     "dist",

--- a/packages/auto-install/package.json
+++ b/packages/auto-install/package.json
@@ -26,7 +26,8 @@
     "prepare": "pnpm run build",
     "prepublishOnly": "pnpm run lint",
     "pretest": "pnpm run build",
-    "test": "ava"
+    "test": "ava",
+    "test:ts": "tsc --noEmit"
   },
   "files": [
     "dist",

--- a/packages/data-uri/package.json
+++ b/packages/data-uri/package.json
@@ -28,7 +28,8 @@
     "prebuild": "del-cli dist",
     "prepublishOnly": "pnpm run lint && pnpm run build",
     "pretest": "pnpm run build -- --sourcemap",
-    "test": "ava"
+    "test": "ava",
+    "test:ts": "tsc --noEmit"
   },
   "files": [
     "dist",

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -29,7 +29,8 @@
     "prepare": "pnpm run build",
     "prepublishOnly": "pnpm run lint && pnpm run test",
     "pretest": "pnpm run build",
-    "test": "ava"
+    "test": "ava",
+    "test:ts": "tsc --noEmit"
   },
   "files": [
     "dist",

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -28,7 +28,8 @@
     "prebuild": "del-cli dist",
     "prepublishOnly": "pnpm build && pnpm lint",
     "pretest": "pnpm run build",
-    "test": "ava"
+    "test": "ava",
+    "test:ts": "tsc --noEmit"
   },
   "files": [
     "lib",

--- a/packages/pluginutils/package.json
+++ b/packages/pluginutils/package.json
@@ -36,7 +36,8 @@
     "prepare": "pnpm run build",
     "prepublishOnly": "pnpm run lint && pnpm run build",
     "pretest": "pnpm run build -- --sourcemap",
-    "test": "ava"
+    "test": "ava",
+    "test:ts": "tsc --noEmit"
   },
   "files": [
     "dist",

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -30,7 +30,8 @@
     "prepare": "pnpm run build",
     "prepublishOnly": "pnpm run lint",
     "pretest": "pnpm run build",
-    "test": "ava"
+    "test": "ava",
+    "test:ts": "tsc --noEmit"
   },
   "files": [
     "dist",

--- a/packages/virtual/package.json
+++ b/packages/virtual/package.json
@@ -29,7 +29,8 @@
     "prepare": "pnpm run build",
     "prepublishOnly": "pnpm run lint",
     "pretest": "pnpm run build",
-    "test": "ava"
+    "test": "ava",
+    "test:ts": "tsc --noEmit"
   },
   "files": [
     "dist",

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -55,7 +55,8 @@
     "@rollup/plugin-typescript": "^5.0.2",
     "del-cli": "^3.0.1",
     "rollup": "^2.23.0",
-    "source-map": "^0.7.3"
+    "source-map": "^0.7.3",
+    "typescript": "^4.1.2"
   },
   "types": "types/index.d.ts",
   "ava": {

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -29,7 +29,8 @@
     "prepare": "pnpm run build",
     "prepublishOnly": "pnpm run lint",
     "pretest": "pnpm run build",
-    "test": "ava"
+    "test": "ava",
+    "test:ts": "tsc --noEmit"
   },
   "files": [
     "dist",

--- a/packages/wasm/tsconfig.json
+++ b/packages/wasm/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*", "types/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,7 +220,7 @@ importers:
       rollup: ^2.23.0
   packages/eslint:
     dependencies:
-      '@rollup/pluginutils': 4.0.0_rollup@2.32.1
+      '@rollup/pluginutils': 4.1.0_rollup@2.32.1
       eslint: 7.12.0
     devDependencies:
       '@rollup/plugin-node-resolve': 9.0.0_rollup@2.32.1
@@ -238,7 +238,7 @@ importers:
       typescript: ^4.1.2
   packages/graphql:
     dependencies:
-      '@rollup/pluginutils': 4.0.0_rollup@2.32.1
+      '@rollup/pluginutils': 4.1.0_rollup@2.32.1
       graphql-tag: 2.11.0_graphql@14.7.0
     devDependencies:
       '@rollup/plugin-buble': 0.21.3_rollup@2.32.1
@@ -458,7 +458,7 @@ importers:
       '@rollup/pluginutils': 3.1.0_rollup@2.32.1
       resolve: 1.18.1
     devDependencies:
-      '@rollup/plugin-buble': 'link:../buble'
+      '@rollup/plugin-buble': 0.21.3_rollup@2.32.1
       '@rollup/plugin-commonjs': 11.1.0_rollup@2.32.1
       '@rollup/plugin-typescript': 5.0.2_rollup@2.32.1+typescript@4.1.2
       '@types/node': 10.17.48
@@ -504,15 +504,17 @@ importers:
       typescript: ^4.1.2
   packages/wasm:
     devDependencies:
-      '@rollup/plugin-typescript': 5.0.2_rollup@2.32.1
+      '@rollup/plugin-typescript': 5.0.2_rollup@2.32.1+typescript@4.1.2
       del-cli: 3.0.1
       rollup: 2.32.1
       source-map: 0.7.3
+      typescript: 4.1.2
     specifiers:
       '@rollup/plugin-typescript': ^5.0.2
       del-cli: ^3.0.1
       rollup: ^2.23.0
       source-map: ^0.7.3
+      typescript: ^4.1.2
   packages/yaml:
     dependencies:
       '@rollup/pluginutils': 3.1.0_rollup@2.32.1
@@ -1773,20 +1775,6 @@ packages:
       rollup: ^1.20.0||^2.0.0
     resolution:
       integrity: sha512-gPz+utFHLRrd41WMP13Jq5mqqzHL3OXrfj3/MkSyB6UBIcuNt9j60GCbarzMzdf1VHFpOxfQh/ez7wyadLMqkg==
-  /@rollup/plugin-typescript/5.0.2_rollup@2.32.1:
-    dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.32.1
-      resolve: 1.18.1
-      rollup: 2.32.1
-    dev: true
-    engines:
-      node: '>=8.0.0'
-    peerDependencies:
-      rollup: ^2.14.0
-      tslib: '*'
-      typescript: '>=3.4.0'
-    resolution:
-      integrity: sha512-CkS028Itwjqm1uLbFVfpJgtVtnNvZ+og/m6UlNRR5wOOnNTWPcVQzOu5xGdEX+WWJxdvWIqUq2uR/RBt2ZipWg==
   /@rollup/plugin-typescript/5.0.2_rollup@2.32.1+typescript@4.1.2:
     dependencies:
       '@rollup/pluginutils': 3.1.0_rollup@2.32.1
@@ -1852,19 +1840,6 @@ packages:
       rollup: ^1.20.0||^2.0.0
     resolution:
       integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==
-  /@rollup/pluginutils/4.0.0_rollup@2.32.1:
-    dependencies:
-      '@types/estree': 0.0.45
-      estree-walker: 2.0.1
-      picomatch: 2.2.2
-      rollup: 2.32.1
-    dev: false
-    engines:
-      node: '>= 8.0.0'
-    peerDependencies:
-      rollup: ^1.20.0||^2.0.0
-    resolution:
-      integrity: sha512-b5QiJRye4JlSg29bKNEECoKbLuPXZkPEHSgEjjP1CJV1CPdDBybfYHfm6kyq8yK51h/Zsyl8OvWUrp0FUBukEQ==
   /@rollup/pluginutils/4.1.0_rollup@2.32.1:
     dependencies:
       estree-walker: 2.0.1
@@ -3095,7 +3070,7 @@ packages:
     resolution:
       integrity: sha512-7ItTKOhOZbznhXAQ2g/slGg1PJV5zDO/WdkTwi7UEOJmkvsE32PWvx6mKtDjiMpjnR2CNf6BAD6sSxIlv7ptng==
   /core-js/2.6.11:
-    deprecated: 'core-js@<3 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.'
+    deprecated: core-js@<3 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.
     dev: true
     requiresBuild: true
     resolution:
@@ -3348,7 +3323,7 @@ packages:
   /debug/4.2.0:
     dependencies:
       ms: 2.1.2
-    deprecated: 'Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)'
+    deprecated: Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)
     engines:
       node: '>=6.0'
     peerDependencies:


### PR DESCRIPTION
## Rollup Plugin Name: `alias, auto-install, data-url, eslint, html, pluginutils, typescript, virtual, wasm`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no (adds tasks to projects and ci)

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
fixes #779 

### Description

Have early feedback in every PR that typescript types are not compromised.
Add task test:ts to every plugin written in typescript
Run  test:ts on circle ci config