### PR TITLE
docs(node-resolve): clearer "Resolving Built-Ins" doc

### DIFF
--- a/packages/node-resolve/README.md
+++ b/packages/node-resolve/README.md
@@ -187,14 +187,17 @@ By default this plugin will prefer built-ins over local modules, marking them as
 
 See [`preferBuiltins`](#preferbuiltins).
 
-To provide stubbed versions of Node built-ins, use a plugin like [rollup-plugin-node-polyfills](https://github.com/ionic-team/rollup-plugin-node-polyfills) or use [`builtin-modules`](https://github.com/sindresorhus/builtin-modules) with `external`, and set `preferBuiltins` to `false`. e.g.
+To provide stubbed versions of Node built-ins, use a plugin like [rollup-plugin-node-polyfills](https://github.com/ionic-team/rollup-plugin-node-polyfills) and set `preferBuiltins` to `false`. e.g.
 
 ```js
 import { nodeResolve } from '@rollup/plugin-node-resolve';
-import builtins from 'builtin-modules'
+import nodePolyfills from 'rollup-plugin-node-polyfills';
 export default ({
   input: ...,
-  plugins: [nodeResolve()],
+  plugins: [
+    nodePolyfills(),
+    nodeResolve({ preferBuiltins: false })
+  ],
   external: builtins,
   output: ...
 })


### PR DESCRIPTION
## Rollup Plugin Name: `node-resolve`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers: #772

### Description
With a recent update the plugin now marks builtins as external automatically when `resolveBuiltins` is not explicitly `false`.

Therefore I think the documentation to use `builtins` to achieve the same behaviour is not needed, given doing it is essentially a no-op.

Also when using `rollup-plugin-node-polyfills` you should set `preferBuiltins ` to `false`, and this was not super clear the way it was worded previously.