### PR TITLE
chore(node-resolve): mark `url` as an external and throw on warning

### DIFF
--- a/packages/node-resolve/rollup.config.js
+++ b/packages/node-resolve/rollup.config.js
@@ -7,7 +7,10 @@ import pkg from './package.json';
 export default {
   input: 'src/index.js',
   plugins: [json()],
-  external: Object.keys(pkg.dependencies).concat(['fs', 'path', 'os', 'util']),
+  external: [...Object.keys(pkg.dependencies), 'fs', 'path', 'os', 'util', 'url'],
+  onwarn: (warning) => {
+    throw new Error(warning);
+  },
   output: [
     { file: pkg.main, format: 'cjs', exports: 'named' },
     { file: pkg.module, format: 'es', plugins: [emitModulePackageFile()] }


### PR DESCRIPTION
## Rollup Plugin Name: `node-resolve`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

### Description
Noticed a warning when building because we were using `url` but not listed it as an external. This does that, and also makes the build fail on a warning so we catch things like this in the future.