### PR TITLE
Fix TypeScript src-dir test

### DIFF
--- a/packages/typescript/test/test.js
+++ b/packages/typescript/test/test.js
@@ -1257,7 +1257,7 @@ test.serial.skip('works when code is in src directory', async (t) => {
 
   t.deepEqual(
     output.map((out) => out.fileName),
-    ['index.js', 'types/index.d.ts', 'types/index.d.ts.map']
+    ['index.js', 'index.d.ts']
   );
 });
 


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `typescript`

This PR contains:

- [X] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [X] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [X] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers: https://github.com/rollup/plugins/issues/287

### Description

I had the assertion wrong. This is now correct. I verified it matches the output of running `tsc` directly.

The test passes with typescript 4.2.0-beta. I didn't upgrade it and enable the test since it's still in beta, but can do that if you prefer