### PR TITLE
fix(replace): add types for `preventAssignment` option

### DIFF
--- a/packages/replace/types/index.d.ts
+++ b/packages/replace/types/index.d.ts
@@ -28,6 +28,11 @@ export interface RollupReplaceOptions {
    * You can separate values to replace from other options.
    */
   values?: { [str: string]: Replacement };
+  /**
+   * Prevents replacing strings where they are followed by a single equals sign
+   * It is recommended to set this option to `true`, as the next major version will default this option to `true`
+   */
+  preventAssignment?: Boolean;
 }
 
 /**


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `{name}`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

Add missing types for new `preventAssignment` option
