### PR TITLE
fix(replace): add missing types for new `preventAssignment` option

### DIFF
--- a/packages/replace/test/types.ts
+++ b/packages/replace/test/types.ts
@@ -16,6 +16,7 @@ const config: RollupOptions = {
       include: 'config.js',
       exclude: 'node_modules/**',
       delimiters: ['<@', '@>'],
+      preventAssignment: true,
       VERSION: '1.0.0',
       ENVIRONMENT: JSON.stringify('development'),
       __dirname: (id) => `'${dirname(id)}'`,

--- a/packages/replace/types/index.d.ts
+++ b/packages/replace/types/index.d.ts
@@ -8,7 +8,11 @@ export interface RollupReplaceOptions {
    * All other options are treated as `string: replacement` replacers,
    * or `string: (id) => replacement` functions.
    */
-  [str: string]: Replacement | RollupReplaceOptions['include'] | RollupReplaceOptions['values'];
+  [str: string]:
+    | Replacement
+    | RollupReplaceOptions['include']
+    | RollupReplaceOptions['values']
+    | RollupReplaceOptions['preventAssignment'];
 
   /**
    * A minimatch pattern, or array of patterns, of files that should be
@@ -24,6 +28,11 @@ export interface RollupReplaceOptions {
    * of `foo`, supply delimiters
    */
   delimiters?: [string, string];
+  /**
+   * Prevents replacing strings where they are followed by a single equals
+   * sign.
+   */
+  preventAssignment?: boolean;
   /**
    * You can separate values to replace from other options.
    */


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `@rollup/replace`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

🤦‍♂️ Failed to add types for change in previous PR (#798). Closes #812.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
