### PR TITLE
fix(commonjs): `isRestorableCompiledEsm` should also trigger code transform

### DIFF
--- a/packages/commonjs/src/transform-commonjs.js
+++ b/packages/commonjs/src/transform-commonjs.js
@@ -437,7 +437,8 @@ export default function transformCommonjs(
       uses.exports ||
       uses.require ||
       uses.commonjsHelpers ||
-      hasRemovedRequire
+      hasRemovedRequire ||
+      isRestorableCompiledEsm
     ) &&
     (ignoreGlobal || !uses.global)
   ) {

--- a/packages/commonjs/test/fixtures/form/compiled-esm-define-exports-empty/input.js
+++ b/packages/commonjs/test/fixtures/form/compiled-esm-define-exports-empty/input.js
@@ -1,0 +1,1 @@
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/packages/commonjs/test/fixtures/form/compiled-esm-define-exports-empty/output.js
+++ b/packages/commonjs/test/fixtures/form/compiled-esm-define-exports-empty/output.js
@@ -1,0 +1,6 @@
+var input = /*#__PURE__*/Object.defineProperty({
+
+}, '__esModule', {value: true});
+
+export default input;
+export { input as __moduleExports };


### PR DESCRIPTION
## Rollup Plugin Name: `commonjs`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
resolves #762

### Description

Currently if there are no inclusions of commonjs helpers, references to module/exports or dynamic requires - then the transform functions returns without modifying the code.
This PR changes that to consider `isRestorableCompiledEsm`, as this basically means that an ES module was transformed into CJS, and we want to return an ES module.