### PR TITLE
feat(run): add `allowRestarts` option

### DIFF
--- a/packages/run/README.md
+++ b/packages/run/README.md
@@ -32,9 +32,9 @@ export default {
   input: 'src/index.js',
   output: {
     file: 'dist/index.js',
-    format: 'cjs'
+    format: 'cjs',
   },
-  plugins: [run()]
+  plugins: [run()],
 };
 ```
 
@@ -71,6 +71,19 @@ export default {
   ]
 };
 ```
+
+### `allowRestarts`
+
+Type: `Boolean`<br>
+Default: `false`
+
+If `true`, instructs the plugin to listen to `stdin` for the sequences listed below followed by enter (carriage return).
+
+`restart` - Kills the currently running bundle and starts it again. _Note: This does not create a new bundle, the bundle is run again "as-is". This can be used to test configuration changes or other changes that are made without modifying your source_
+Also allowed: `rs`, `CTRL+K`
+
+`clear` - Clears the screen of all text
+Also allowed: `cls`, `CTRL+L`
 
 ## Practical Example
 

--- a/packages/run/README.md
+++ b/packages/run/README.md
@@ -79,11 +79,15 @@ Default: `false`
 
 If `true`, instructs the plugin to listen to `stdin` for the sequences listed below followed by enter (carriage return).
 
-`restart` - Kills the currently running bundle and starts it again. _Note: This does not create a new bundle, the bundle is run again "as-is". This can be used to test configuration changes or other changes that are made without modifying your source_
-Also allowed: `rs`, `CTRL+K`
+#### `stdin` Input Actions
 
-`clear` - Clears the screen of all text
-Also allowed: `cls`, `CTRL+L`
+When this option is enabled, `stdin` will listen for the following input and perform the associated action:
+
+- `restart` → Kills the currently running bundle and starts it again. _Note: This does not create a new bundle, the bundle is run again "as-is". This can be used to test configuration changes or other changes that are made without modifying your source_
+  Also allowed: `rs`, `CTRL+K`
+
+- `clear` → Clears the screen of all text
+  Also allowed: `cls`, `CTRL+L`
 
 ## Practical Example
 

--- a/packages/run/src/index.ts
+++ b/packages/run/src/index.ts
@@ -43,10 +43,10 @@ export default function run(opts: RollupRunOptions = {}): Plugin {
     },
 
     writeBundle(outputOptions, bundle) {
-      function forkBundle(dir: string, entryFileName: string) {
+      const forkBundle = (dir: string, entryFileName: string) => {
         if (proc) proc.kill();
         proc = fork(path.join(dir, entryFileName), args, forkOptions);
-      }
+      };
 
       const dir = outputOptions.dir || path.dirname(outputOptions.file!);
       const entryFileName = Object.keys(bundle).find((fileName) => {

--- a/packages/run/src/index.ts
+++ b/packages/run/src/index.ts
@@ -10,8 +10,10 @@ export default function run(opts: RollupRunOptions = {}): Plugin {
   let proc: ChildProcess;
 
   const args = opts.args || [];
+  const allowRestarts = opts.allowRestarts || false;
   const forkOptions = opts.options || opts;
   delete (forkOptions as RollupRunOptions).args;
+  delete (forkOptions as RollupRunOptions).allowRestarts;
 
   return {
     name: 'run',
@@ -41,6 +43,11 @@ export default function run(opts: RollupRunOptions = {}): Plugin {
     },
 
     writeBundle(outputOptions, bundle) {
+      function forkBundle(dir: string, entryFileName: string) {
+        if (proc) proc.kill();
+        proc = fork(path.join(dir, entryFileName), args, forkOptions);
+      }
+
       const dir = outputOptions.dir || path.dirname(outputOptions.file!);
       const entryFileName = Object.keys(bundle).find((fileName) => {
         const chunk = bundle[fileName] as RenderedChunk;
@@ -48,8 +55,22 @@ export default function run(opts: RollupRunOptions = {}): Plugin {
       });
 
       if (entryFileName) {
-        if (proc) proc.kill();
-        proc = fork(path.join(dir, entryFileName), args, forkOptions);
+        forkBundle(dir, entryFileName);
+
+        if (allowRestarts) {
+          process.stdin.resume();
+          process.stdin.setEncoding('utf8');
+
+          process.stdin.on('data', (data) => {
+            const line = data.toString().trim().toLowerCase();
+
+            if (line === 'rs' || line === 'restart' || data.toString().charCodeAt(0) === 11) {
+              forkBundle(dir, entryFileName);
+            } else if (line === 'cls' || line === 'clear' || data.toString().charCodeAt(0) === 12) {
+              console.clear();
+            }
+          });
+        }
       } else {
         this.error(`@rollup/plugin-run could not find output chunk`);
       }

--- a/packages/run/test/test.js
+++ b/packages/run/test/test.js
@@ -110,6 +110,15 @@ test('detects changes - forks a new child process and kills older process', asyn
   t.is(mockChildProcess().kill.callCount, 1);
 });
 
+test('allow the allowRestart option', async (t) => {
+  const bundle = await rollup({
+    input,
+    plugins: [run({ allowRestarts: true })]
+  });
+  await bundle.write(outputOptions);
+  t.true(mockChildProcess.calledWithExactly(outputOptions.file, [], {}));
+});
+
 test.after(async () => {
   await del(['output']);
 });

--- a/packages/run/types/index.d.ts
+++ b/packages/run/types/index.d.ts
@@ -5,6 +5,7 @@ import { Plugin } from 'rollup';
 export interface RollupRunOptions extends ForkOptions {
   args?: readonly string[];
   options?: ForkOptions;
+  allowRestarts?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Rollup Plugin Name: `run`

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:
#769 

### Description
This PR adds functionality to enable optional manual restarts of the running bundle by entering `rs`, `restart` or pressing <kbd>Ctrl</kbd>+<kbd>K</kbd> on the terminal followed by <kbd>Enter</kbd>. This mimics the behavior of [nodemon](https://github.com/remy/nodemon#manual-restarting). Additionally, the terminal screen can be cleared by entering `cls`, `clear` or pressing <kbd>Ctrl</kbd>+<kbd>L</kbd> followed by <kbd>Enter</kbd>.

The use case for this functionality is developing applications that reference external configuration files, resources or databases that may change while the application source remains unchanged. When these are updated often times the application will need to be restarted. In my case, this is currently accomplished by terminating the current instance using <kbd>Ctrl</kbd>+<kbd>C</kbd> and then restarting it by running `pnpm run dev`.

I've tested this on Windows (under `cmd.exe` as well as under Bash using Windows Terminal) and Linux (bash, over SSH using Putty, as well as using `ssh` under Windows Terminal) and it works as expected.

I did add a single test case but I admit it is pretty simplistic and could use improvement. I was unable to get `sinon` to properly mock the `process.stdin.resume` function call to determine whether or not it was called.