### PR TITLE
chore(repo): Add "directory" to package.json repository fields.

### DIFF
--- a/packages/alias/package.json
+++ b/packages/alias/package.json
@@ -6,7 +6,10 @@
   },
   "description": "Define and resolve aliases for bundle dependencies",
   "license": "MIT",
-  "repository": "rollup/plugins",
+  "repository": {
+    "url": "rollup/plugins",
+    "directory": "packages/alias"
+  },
   "author": "Johannes Stein",
   "homepage": "https://github.com/rollup/plugins/tree/master/packages/alias#readme",
   "bugs": "https://github.com/rollup/plugins/issues",

--- a/packages/auto-install/package.json
+++ b/packages/auto-install/package.json
@@ -6,7 +6,10 @@
   },
   "description": "Automatically install dependencies that are imported by a bundle",
   "license": "MIT",
-  "repository": "rollup/plugins",
+  "repository": {
+    "url": "rollup/plugins",
+    "directory": "packages/auto-install"
+  },
   "author": "Rich Harris",
   "homepage": "https://github.com/rollup/plugins/tree/master/packages/auto-install/#readme",
   "bugs": "https://github.com/rollup/plugins/issues",

--- a/packages/babel/package.json
+++ b/packages/babel/package.json
@@ -6,7 +6,10 @@
   },
   "description": "Seamless integration between Rollup and Babel.",
   "license": "MIT",
-  "repository": "rollup/plugins",
+  "repository": {
+    "url": "rollup/plugins",
+    "directory": "packages/babel"
+  },
   "author": "Rich Harris",
   "homepage": "https://github.com/rollup/plugins/tree/master/packages/babel#readme",
   "bugs": "https://github.com/rollup/plugins/issues",

--- a/packages/beep/package.json
+++ b/packages/beep/package.json
@@ -6,7 +6,10 @@
   },
   "description": "A Rollup plugin which beeps on errors and warnings",
   "license": "MIT",
-  "repository": "rollup/plugins",
+  "repository": {
+    "url": "rollup/plugins",
+    "directory": "packages/beep"
+  },
   "author": "shellscape",
   "homepage": "https://github.com/rollup/plugins/tree/master/packages/beep",
   "bugs": "https://github.com/rollup/plugins/issues",

--- a/packages/buble/package.json
+++ b/packages/buble/package.json
@@ -6,7 +6,10 @@
   },
   "description": "Compile ES2015 with buble",
   "license": "MIT",
-  "repository": "rollup/plugins",
+  "repository": {
+    "url": "rollup/plugins",
+    "directory": "packages/buble"
+  },
   "author": "Rich Harris <richard.a.harris@gmail.com>",
   "homepage": "https://github.com/rollup/plugins/tree/master/packages/buble/#readme",
   "bugs": "https://github.com/rollup/plugins/issues",

--- a/packages/commonjs/package.json
+++ b/packages/commonjs/package.json
@@ -6,7 +6,10 @@
   },
   "description": "Convert CommonJS modules to ES2015",
   "license": "MIT",
-  "repository": "rollup/plugins",
+  "repository": {
+    "url": "rollup/plugins",
+    "directory": "packages/commonjs"
+  },
   "author": "Rich Harris <richard.a.harris@gmail.com>",
   "homepage": "https://github.com/rollup/plugins/tree/master/packages/commonjs/#readme",
   "bugs": "https://github.com/rollup/plugins/issues",

--- a/packages/data-uri/package.json
+++ b/packages/data-uri/package.json
@@ -6,7 +6,10 @@
   },
   "description": "Import modules from Data URIs",
   "license": "MIT",
-  "repository": "rollup/plugins",
+  "repository": {
+    "url": "rollup/plugins",
+    "directory": "packages/data-uri"
+  },
   "author": "shellscape",
   "homepage": "https://github.com/rollup/plugins/tree/master/packages/data-uri",
   "bugs": "https://github.com/rollup/plugins/issues",

--- a/packages/dsv/package.json
+++ b/packages/dsv/package.json
@@ -6,7 +6,10 @@
   },
   "description": "Convert .csv and .tsv files into JavaScript modules with d3-dsv",
   "license": "MIT",
-  "repository": "rollup/plugins",
+  "repository": {
+    "url": "rollup/plugins",
+    "directory": "packages/dsv"
+  },
   "author": "Rich Harris",
   "homepage": "https://github.com/rollup/plugins/tree/master/packages/dsv#readme",
   "bugs": "https://github.com/rollup/plugins/issues",

--- a/packages/dynamic-import-vars/package.json
+++ b/packages/dynamic-import-vars/package.json
@@ -6,7 +6,10 @@
   },
   "description": "Resolving dynamic imports that contain variables.",
   "license": "MIT",
-  "repository": "rollup/plugins",
+  "repository": {
+    "url": "rollup/plugins",
+    "directory": "packages/dynamic-import-vars"
+  },
   "author": "LarsDenBakker",
   "homepage": "https://github.com/rollup/plugins/tree/master/packages/dynamic-import-vars",
   "bugs": "https://github.com/rollup/plugins/issues",

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -6,7 +6,10 @@
   },
   "description": "Verify entry point and all imported files with ESLint",
   "license": "MIT",
-  "repository": "rollup/plugins",
+  "repository": {
+    "url": "rollup/plugins",
+    "directory": "packages/eslint"
+  },
   "author": "Bogdan Chadkin <trysound@yandex.ru>",
   "homepage": "https://github.com/rollup/plugins/tree/master/packages/eslint#readme",
   "bugs": "https://github.com/rollup/plugins/issues",

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -6,7 +6,10 @@
   },
   "description": "Convert .gql/.graphql files to ES6 modules",
   "license": "MIT",
-  "repository": "rollup/plugins",
+  "repository": {
+    "url": "rollup/plugins",
+    "directory": "packages/graphql"
+  },
   "author": "rollup",
   "homepage": "https://github.com/rollup/plugins/tree/master/packages/graphql#readme",
   "bugs": "https://github.com/rollup/plugins/issues",

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -6,7 +6,10 @@
   },
   "description": "Creates HTML files to serve Rollup bundles",
   "license": "MIT",
-  "repository": "rollup/plugins",
+  "repository": {
+    "url": "rollup/plugins",
+    "directory": "packages/html"
+  },
   "author": "Andrew Powell <andrew@shellscape.org>",
   "homepage": "https://github.com/rollup/plugins/tree/master/packages/html#readme",
   "bugs": "https://github.com/rollup/plugins/issues",

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -6,7 +6,10 @@
   },
   "description": "Import JPG, PNG, GIF, SVG, and WebP files",
   "license": "MIT",
-  "repository": "rollup/plugins",
+  "repository": {
+    "url": "rollup/plugins",
+    "directory": "packages/image"
+  },
   "author": "Rich Harris",
   "homepage": "https://github.com/rollup/plugins/tree/master/packages/image/#readme",
   "bugs": "https://github.com/rollup/plugins/issues",

--- a/packages/inject/package.json
+++ b/packages/inject/package.json
@@ -6,7 +6,10 @@
   },
   "description": "Scan modules for global variables and injects `import` statements where necessary",
   "license": "MIT",
-  "repository": "rollup/plugins",
+  "repository": {
+    "url": "rollup/plugins",
+    "directory": "packages/inject"
+  },
   "author": "Rich Harris <richard.a.harris@gmail.com>",
   "homepage": "https://github.com/rollup/plugins/tree/master/packages/inject#readme",
   "bugs": "https://github.com/rollup/plugins/issues",

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -6,7 +6,10 @@
   },
   "description": "Convert .json files to ES6 modules",
   "license": "MIT",
-  "repository": "rollup/plugins",
+  "repository": {
+    "url": "rollup/plugins",
+    "directory": "packages/json"
+  },
   "author": "rollup",
   "homepage": "https://github.com/rollup/plugins/tree/master/packages/json#readme",
   "bugs": "https://github.com/rollup/plugins/issues",

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -6,7 +6,10 @@
   },
   "description": "Add export statements to plain scripts",
   "license": "MIT",
-  "repository": "rollup/plugins",
+  "repository": {
+    "url": "rollup/plugins",
+    "directory": "packages/legacy"
+  },
   "author": "Rich Harris",
   "homepage": "https://github.com/rollup/plugins/tree/master/packages/legacy/#readme",
   "bugs": "https://github.com/rollup/plugins/issues",

--- a/packages/multi-entry/package.json
+++ b/packages/multi-entry/package.json
@@ -6,7 +6,10 @@
   },
   "description": "Use multiple entry points for a bundle",
   "license": "MIT",
-  "repository": "rollup/plugins",
+  "repository": {
+    "url": "rollup/plugins",
+    "directory": "packages/multi-entry"
+  },
   "author": "rollup",
   "homepage": "https://github.com/rollup/plugins/tree/master/packages/multi-entry/#readme",
   "bugs": "https://github.com/rollup/plugins/issues",

--- a/packages/node-resolve/package.json
+++ b/packages/node-resolve/package.json
@@ -6,7 +6,10 @@
   },
   "description": "Locate and bundle third-party dependencies in node_modules",
   "license": "MIT",
-  "repository": "rollup/plugins",
+  "repository": {
+    "url": "rollup/plugins",
+    "directory": "packages/node-resolve"
+  },
   "author": "Rich Harris <richard.a.harris@gmail.com>",
   "homepage": "https://github.com/rollup/plugins/tree/master/packages/node-resolve/#readme",
   "bugs": "https://github.com/rollup/plugins/issues",

--- a/packages/pluginutils/package.json
+++ b/packages/pluginutils/package.json
@@ -6,7 +6,10 @@
   },
   "description": "A set of utility functions commonly used by Rollup plugins",
   "license": "MIT",
-  "repository": "rollup/plugins",
+  "repository": {
+    "url": "rollup/plugins",
+    "directory": "packages/pluginutils"
+  },
   "author": "Rich Harris <richard.a.harris@gmail.com>",
   "homepage": "https://github.com/rollup/plugins/tree/master/packages/pluginutils#readme",
   "bugs": {

--- a/packages/replace/package.json
+++ b/packages/replace/package.json
@@ -6,7 +6,10 @@
   },
   "description": "Replace strings in files while bundling",
   "license": "MIT",
-  "repository": "rollup/plugins",
+  "repository": {
+    "url": "rollup/plugins",
+    "directory": "packages/replace"
+  },
   "author": "Rich Harris <richard.a.harris@gmail.com>",
   "homepage": "https://github.com/rollup/plugins/tree/master/packages/replace#readme",
   "bugs": "https://github.com/rollup/plugins/issues",

--- a/packages/run/package.json
+++ b/packages/run/package.json
@@ -6,7 +6,10 @@
   },
   "description": "Run your bundle after you've built it",
   "license": "MIT",
-  "repository": "rollup/plugins",
+  "repository": {
+    "url": "rollup/plugins",
+    "directory": "packages/run"
+  },
   "author": "Rich Harris",
   "homepage": "https://github.com/rollup/plugins/tree/master/packages/run/#readme",
   "bugs": "https://github.com/rollup/plugins/issues",

--- a/packages/strip/package.json
+++ b/packages/strip/package.json
@@ -6,7 +6,10 @@
   },
   "description": "Remove debugger statements and functions like assert.equal and console.log from your code",
   "license": "MIT",
-  "repository": "rollup/@rollup/plugin-strip",
+  "repository": {
+    "url": "rollup/plugins",
+    "directory": "packages/strip"
+  },
   "author": "Rich Harris",
   "homepage": "https://github.com/rollup/plugins/tree/master/packages/strip#readme",
   "bugs": "https://github.com/rollup/plugins/issues",

--- a/packages/sucrase/package.json
+++ b/packages/sucrase/package.json
@@ -6,7 +6,10 @@
   },
   "description": "Compile TypeScript, Flow, JSX, etc with Sucrase",
   "license": "MIT",
-  "repository": "rollup/plugins",
+  "repository": {
+    "url": "rollup/plugins",
+    "directory": "packages/sucrase"
+  },
   "author": "Rich Harris",
   "homepage": "https://github.com/rollup/plugins/tree/master/packages/sucrase/#readme",
   "bugs": "https://github.com/rollup/plugins/issues",

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -6,7 +6,10 @@
   },
   "description": "Seamless integration between Rollup and TypeScript.",
   "license": "MIT",
-  "repository": "rollup/plugins",
+  "repository": {
+    "url": "rollup/plugins",
+    "directory": "packages/typescript"
+  },
   "author": "Oskar Segersvärd",
   "homepage": "https://github.com/rollup/plugins/tree/master/packages/typescript/#readme",
   "bugs": "https://github.com/rollup/plugins/issues",

--- a/packages/url/package.json
+++ b/packages/url/package.json
@@ -6,7 +6,10 @@
   },
   "description": "Import files as data-URIs or ES Modules",
   "license": "MIT",
-  "repository": "rollup/plugins",
+  "repository": {
+    "url": "rollup/plugins",
+    "directory": "packages/url"
+  },
   "author": "Arpad Borsos <arpad.borsos@googlemail.com>",
   "homepage": "https://github.com/rollup/plugins/tree/master/packages/url/#readme",
   "bugs": "https://github.com/rollup/plugins/issues",

--- a/packages/virtual/package.json
+++ b/packages/virtual/package.json
@@ -6,7 +6,10 @@
   },
   "description": "Load virtual modules from memory",
   "license": "MIT",
-  "repository": "rollup/plugins",
+  "repository": {
+    "url": "rollup/plugins",
+    "directory": "packages/virtual"
+  },
   "author": "Rich Harris",
   "homepage": "https://github.com/rollup/plugins/tree/master/packages/virtual#readme",
   "bugs": "https://github.com/rollup/rollup-plugin-virtual/issues",

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -6,7 +6,10 @@
   },
   "description": "Import WebAssembly code with Rollup",
   "license": "MIT",
-  "repository": "rollup/plugins",
+  "repository": {
+    "url": "rollup/plugins",
+    "directory": "packages/wasm"
+  },
   "author": "Jamen Marz <jamenmarz+gh@gmail.com>",
   "homepage": "https://github.com/rollup/plugins/tree/master/packages/wasm/#readme",
   "bugs": "https://github.com/rollup/plugins/issues",

--- a/packages/yaml/package.json
+++ b/packages/yaml/package.json
@@ -6,7 +6,10 @@
   },
   "description": "Convert YAML files to ES6 modules",
   "license": "MIT",
-  "repository": "rollup/plugins",
+  "repository": {
+    "url": "rollup/plugins",
+    "directory": "packages/yaml"
+  },
   "author": "rollup",
   "homepage": "https://github.com/rollup/plugins/tree/master/packages/yaml/#readme",
   "bugs": "https://github.com/rollup/plugins/issues",


### PR DESCRIPTION
## Rollup Plugin Name: (all plugins)

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?

- [ ] yes
- [x] no (non-functional change)

Breaking Changes?

- [ ] yes
- [x] no

### Description

This is a trivial thing, but every time I search for a Rollup plugin, the top results are npm package listing pages. That's great, but of the two sidebar links, one points to the plugins repo itself, whereas the other points to the package's README. This uses npm's [repository.directory package.json field](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#:~:text=you%20can%20specify%20the%20directory%20in%20which%20it%20lives) to make them both point to the correct location (see [npm cli source](https://github.com/npm/cli/blob/8806015fdd025f73ccf4001472370eafd3c5a856/lib/repo.js#L35-L48) that confirms the logic).