### PR TITLE
update plugin typescript readme and peerDeps version

### DIFF
--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -13,7 +13,7 @@
 
 ## Requirements
 
-This plugin requires an [LTS](https://github.com/nodejs/Release) Node version (v8.0.0+) and Rollup v1.20.0+. This plugin also requires at least [TypeScript 3.4](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html).
+This plugin requires an [LTS](https://github.com/nodejs/Release) Node version (v8.0.0+) and Rollup v1.20.0+. This plugin also requires at least [TypeScript 3.7](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html).
 
 ## Install
 

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -48,7 +48,7 @@
   "peerDependencies": {
     "rollup": "^2.14.0",
     "tslib": "*",
-    "typescript": ">=3.4.0"
+    "typescript": ">=3.7.0"
   },
   "dependencies": {
     "@rollup/pluginutils": "^3.1.0",


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `@rollup/plugin-typescript`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

plugn-typescript used an API from typescript [ts.getOutputFileNames](https://github.com/rollup/plugins/blob/1602ecb411704651b020f33287b170a9ee51861a/packages/typescript/src/outputFile.ts#L60), which is introduced by [this commit](https://github.com/microsoft/TypeScript/commit/e430f2a81cafb3fe31a32c42321c769a3d084056) in typescript 3.7 beta.



Encounter `ts.getOutputFileNames is not a function` with ts 3.6.4, after upgrading to ts 3.7, the issue was gone.
