### PR TITLE
fix(dynamic-import-vars): allow ./${var}.suffix.js

### DIFF
--- a/packages/dynamic-import-vars/src/dynamic-import-to-glob.js
+++ b/packages/dynamic-import-vars/src/dynamic-import-to-glob.js
@@ -86,10 +86,14 @@ export function dynamicImportToGlob(node, sourceString) {
     );
   }
 
-  if (glob.startsWith('./*.')) {
+  // Disallow ./*.ext
+  const ownDirectoryStarExtension = /^\.\/\*\.[\w]+$/;
+  if (ownDirectoryStarExtension.test(glob)) {
     throw new VariableDynamicImportError(
-      `${`invalid import "${sourceString}". Variable imports cannot import their own directory, ` +
-        'place imports in a separate directory or make the import filename more specific. '}${example}`
+      `${
+        `invalid import "${sourceString}". Variable imports cannot import their own directory, ` +
+        'place imports in a separate directory or make the import filename more specific. '
+      }${example}`
     );
   }
 

--- a/packages/dynamic-import-vars/test/src/dynamic-import-to-glob.test.js
+++ b/packages/dynamic-import-vars/test/src/dynamic-import-to-glob.test.js
@@ -17,6 +17,15 @@ test('template literal with variable filename', (t) => {
   t.is(glob, './foo/*.js');
 });
 
+test('template literal with dot-prefixed suffix', (t) => {
+  const ast = CustomParser.parse('import(`./${bar}.entry.js`);', {
+    sourceType: 'module'
+  });
+
+  const glob = dynamicImportToGlob(ast.body[0].expression.arguments[0]);
+  t.is(glob, './*.entry.js');
+});
+
 test('template literal with variable directory', (t) => {
   const ast = CustomParser.parse('import(`./foo/${bar}/x.js`);', {
     sourceType: 'module'


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `dynamic-import-vars`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

Allow dynamically importing files in the same directory with an extra suffix before the extension.

My motivating example is trying to import a library generated with [Stencil](https://stenciljs.com/docs/introduction). It generates a dynamic import that looks like this:
```
return import(
    /* webpackInclude: /\.entry\.js$/ */
    /* webpackExclude: /\.system\.entry\.js$/ */
    /* webpackMode: "lazy" */
    `./${bundleId}.entry.js${ ''}`)
```

My interpretation of the [README](https://github.com/rollup/plugins/blob/master/packages/dynamic-import-vars/README.md) suggests this should be possible. I changed the assertion for ["Imports to your own directory must specify a filename pattern"](https://github.com/rollup/plugins/blob/master/packages/dynamic-import-vars/README.md#imports-to-your-own-directory-must-specify-a-filename-pattern) to a stricter regex. I'm happy to change the implementation if regexes aren't desired.

Thanks!