### PR TITLE
Fix bug where fs.exists is incorrectly promisified

### DIFF
--- a/packages/node-resolve/src/fs.js
+++ b/packages/node-resolve/src/fs.js
@@ -2,8 +2,16 @@ import fs from 'fs';
 
 import { promisify } from 'util';
 
-export const exists = promisify(fs.exists);
+export const access = promisify(fs.access);
 export const readFile = promisify(fs.readFile);
 export const realpath = promisify(fs.realpath);
 export { realpathSync } from 'fs';
 export const stat = promisify(fs.stat);
+export async function exists(filePath) {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: node-resolve

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

Using the node-resolve plugin in a browser where the fs module is mocked fails to find resolve any paths. Upon debugging this issue, it appears to be because `fs.exists` is passed to `util.promisify`. The Node [docs](https://nodejs.org/api/fs.html#fs_fs_exists_path_callback) explicitly call out this function as being non-standard and not following the pattern for `util.promisify` to work correctly.

As far as I can tell, this works on Node because `fs.exists` actually internally already provides a promisified version via: https://nodejs.org/api/util.html#util_custom_promisified_functions

Using stat, which doesn't have this non-standard-ness, works around this issue.

I haven't included tests because this fixes a bug when running in an admittedly quite strange setup that's currently not replicated in tests at all as far as I know.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
