### PR TITLE
fix(node-resolve): fix "browser" and "exports.browser" field mappings

### DIFF
--- a/packages/node-resolve/rollup.config.js
+++ b/packages/node-resolve/rollup.config.js
@@ -12,7 +12,7 @@ export default {
     throw new Error(warning);
   },
   output: [
-    { file: pkg.main, format: 'cjs', exports: 'named' },
+    { file: pkg.main, format: 'cjs', exports: 'named', sourcemap: true },
     { file: pkg.module, format: 'es', plugins: [emitModulePackageFile()] }
   ]
 };

--- a/packages/node-resolve/src/package/resolvePackageTarget.js
+++ b/packages/node-resolve/src/package/resolvePackageTarget.js
@@ -90,9 +90,13 @@ async function resolvePackageTarget(context, { target, subpath, pattern, interna
     let browserTarget = null;
 
     if (useBrowserOverrides) {
-      for (const [, value] of Object.entries(target)) {
-        if (packageBrowserField[value]) {
-          browserTarget = value;
+      if (Object.keys(target).includes('browser')) {
+        browserTarget = target.browser;
+      } else {
+        for (const [, value] of Object.entries(target)) {
+          if (packageBrowserField[value]) {
+            browserTarget = value;
+          }
         }
       }
     }

--- a/packages/node-resolve/src/package/resolvePackageTarget.js
+++ b/packages/node-resolve/src/package/resolvePackageTarget.js
@@ -86,10 +86,21 @@ async function resolvePackageTarget(context, { target, subpath, pattern, interna
   }
 
   if (target && typeof target === 'object') {
+    const { packageBrowserField, useBrowserOverrides } = context;
+    let browserTarget = null;
+
+    if (useBrowserOverrides) {
+      for (const [, value] of Object.entries(target)) {
+        if (packageBrowserField[value]) {
+          browserTarget = value;
+        }
+      }
+    }
+
     for (const [key, value] of Object.entries(target)) {
       if (key === 'default' || context.conditions.includes(key)) {
         const resolved = await resolvePackageTarget(context, {
-          target: value,
+          target: browserTarget || value,
           subpath,
           pattern,
           internal

--- a/packages/node-resolve/src/resolveImportSpecifiers.js
+++ b/packages/node-resolve/src/resolveImportSpecifiers.js
@@ -92,6 +92,8 @@ async function resolveId({
       importer,
       moduleDirs: moduleDirectories,
       conditions: exportConditions,
+      useBrowserOverrides,
+      packageBrowserField,
       resolveId(id, parent) {
         return resolveId({
           importSpecifier: id,
@@ -103,6 +105,7 @@ async function resolveId({
           mainFields,
           preserveSymlinks,
           useBrowserOverrides,
+          packageBrowserField,
           baseDir,
           moduleDirectories
         });
@@ -127,7 +130,9 @@ async function resolveId({
           moduleDirs: moduleDirectories,
           pkgURL,
           pkgJsonPath,
-          conditions: exportConditions
+          conditions: exportConditions,
+          useBrowserOverrides,
+          packageBrowserField
         };
         const resolvedPackageExport = await resolvePackageExports(
           context,

--- a/packages/node-resolve/test/browser.js
+++ b/packages/node-resolve/test/browser.js
@@ -208,4 +208,24 @@ test('pkg.browser can override the export map result', async (t) => {
   const { module } = await testBundle(t, bundle);
 
   t.is(module.exports, 'browser');
-})
+});
+
+test('exports.browser takes precedence over export map result, when browser:true', async (t) => {
+  const bundle = await rollup({
+    input: 'browser-exports-browser.js',
+    plugins: [nodeResolve({ browser: true }), commonjs()]
+  });
+  const { module } = await testBundle(t, bundle);
+
+  t.is(module.exports, 'browser');
+});
+
+test('exports.browser does not take precedence over export map result, when browser:false', async (t) => {
+  const bundle = await rollup({
+    input: 'browser-exports-browser.js',
+    plugins: [nodeResolve(), commonjs()]
+  });
+  const { module } = await testBundle(t, bundle);
+
+  t.is(module.exports, 'require');
+});

--- a/packages/node-resolve/test/browser.js
+++ b/packages/node-resolve/test/browser.js
@@ -199,3 +199,13 @@ test('pkg.browser with mapping to prevent bundle by specifying a value of false'
 
   t.is(module.exports, 'ok');
 });
+
+test('pkg.browser can override the export map result', async (t) => {
+  const bundle = await rollup({
+    input: 'browser-override-exports.js',
+    plugins: [nodeResolve({ browser: true }), commonjs()]
+  });
+  const { module } = await testBundle(t, bundle);
+
+  t.is(module.exports, 'browser');
+})

--- a/packages/node-resolve/test/fixtures/browser-exports-browser.js
+++ b/packages/node-resolve/test/fixtures/browser-exports-browser.js
@@ -1,0 +1,3 @@
+const b = require('exports-browser');
+
+module.exports = b;

--- a/packages/node-resolve/test/fixtures/browser-override-exports.js
+++ b/packages/node-resolve/test/fixtures/browser-override-exports.js
@@ -1,3 +1,3 @@
-const Nanoid = require('nanoid')
+const Nanoid = require('nanoid');
 
-module.exports = Nanoid
+module.exports = Nanoid;

--- a/packages/node-resolve/test/fixtures/browser-override-exports.js
+++ b/packages/node-resolve/test/fixtures/browser-override-exports.js
@@ -1,0 +1,3 @@
+const Nanoid = require('nanoid')
+
+module.exports = Nanoid

--- a/packages/node-resolve/test/fixtures/node_modules/exports-browser/browser.js
+++ b/packages/node-resolve/test/fixtures/node_modules/exports-browser/browser.js
@@ -1,0 +1,1 @@
+module.exports = 'browser';

--- a/packages/node-resolve/test/fixtures/node_modules/exports-browser/ignored-browser.js
+++ b/packages/node-resolve/test/fixtures/node_modules/exports-browser/ignored-browser.js
@@ -1,0 +1,1 @@
+module.exports = 'ignored-browser';

--- a/packages/node-resolve/test/fixtures/node_modules/exports-browser/import.js
+++ b/packages/node-resolve/test/fixtures/node_modules/exports-browser/import.js
@@ -1,0 +1,1 @@
+module.exports = 'import';

--- a/packages/node-resolve/test/fixtures/node_modules/exports-browser/package.json
+++ b/packages/node-resolve/test/fixtures/node_modules/exports-browser/package.json
@@ -1,0 +1,14 @@
+{
+  "main": "index.cjs",
+  "module": "index.js",
+  "browser": {
+    "./index.js": "./ignored-browser.js"
+  },
+  "exports": {
+    ".": {
+      "require": "./require.js",
+      "import": "./import.js",
+      "browser": "./browser.js"
+    }
+  }
+}

--- a/packages/node-resolve/test/fixtures/node_modules/exports-browser/require.js
+++ b/packages/node-resolve/test/fixtures/node_modules/exports-browser/require.js
@@ -1,0 +1,1 @@
+module.exports = 'require'

--- a/packages/node-resolve/test/fixtures/node_modules/nanoid/index.cjs
+++ b/packages/node-resolve/test/fixtures/node_modules/nanoid/index.cjs
@@ -1,0 +1,1 @@
+module.exports = 'node'

--- a/packages/node-resolve/test/fixtures/node_modules/nanoid/index.js
+++ b/packages/node-resolve/test/fixtures/node_modules/nanoid/index.js
@@ -1,0 +1,1 @@
+module.exports = 'browser'

--- a/packages/node-resolve/test/fixtures/node_modules/nanoid/package.json
+++ b/packages/node-resolve/test/fixtures/node_modules/nanoid/package.json
@@ -1,0 +1,13 @@
+{
+    "main": "index.cjs",
+    "module": "index.js",
+    "browser": {
+      "./index.js": "./index.js"
+    },
+    "exports": {
+      ".": {
+        "require": "./index.cjs",
+        "import": "./index.js"
+      }
+    }
+}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `node-resolve`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

Hey folks, I encountered this error and noticed there was an open PR (#786) related to it that was getting stale. I built on top of that PR and attended to the review comments.

I did not attend to the comments related to the `production` and `development` conditions (https://github.com/rollup/plugins/pull/786#issuecomment-771294449, https://github.com/rollup/plugins/pull/786#issuecomment-771462019) as I believe they are unrelated and I really just want the `browser` fix right now. I'd be happy to take that on as a follow up, but I would love for this or the other PR to be merged sooner, if possible.

Cheers!
