### PR TITLE
fix(pluginutils): remove extraneous peer dependency requirement

### DIFF
--- a/packages/pluginutils/package.json
+++ b/packages/pluginutils/package.json
@@ -50,9 +50,6 @@
     "plugin",
     "utils"
   ],
-  "peerDependencies": {
-    "rollup": "^1.20.0||^2.0.0"
-  },
   "dependencies": {
     "estree-walker": "^2.0.1",
     "picomatch": "^2.2.2"


### PR DESCRIPTION
## Rollup Plugin Name: `pluginutils`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

### Description

As I looked into the codebase, I found that `rollup` isn't actually required by the `pluginutils` package. So the peer dependency requirement is extraneous.

This fixes the unexpected package manager warnings that some projects may depend on the `@rollup/pluginutils` module but don't need the full `rollup` dependency. ()

P.S. the `@rollup/plugin-node-resolve` package doesn't need `rollup` for its functionality either (except for the typing support). Should I remove that peer dependency, too?