### PR TITLE
Fix incremental typescript cache

### DIFF
--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -150,7 +150,9 @@ export default function typescript(options: RollupTypescriptOptions = {}): Plugi
         const tsBuildInfoSource = emittedFiles.get(tsBuildInfoPath);
         // https://github.com/rollup/plugins/issues/681
         if (tsBuildInfoSource) {
-          fs.writeFileSync(normalizePath(tsBuildInfoPath), tsBuildInfoSource);
+          const normalizedTsBuildInfoPath = normalizePath(tsBuildInfoPath);
+          fs.mkdirSync(path.dirname(normalizedTsBuildInfoPath), { recursive: true });
+          fs.writeFileSync(normalizedTsBuildInfoPath, tsBuildInfoSource);
         }
       }
     }

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -1,5 +1,7 @@
 import * as path from 'path';
 
+import fs from 'fs';
+
 import { Plugin, RollupOptions, SourceDescription } from 'rollup';
 import type { Watch } from 'typescript';
 
@@ -148,11 +150,7 @@ export default function typescript(options: RollupTypescriptOptions = {}): Plugi
         const tsBuildInfoSource = emittedFiles.get(tsBuildInfoPath);
         // https://github.com/rollup/plugins/issues/681
         if (tsBuildInfoSource) {
-          this.emitFile({
-            type: 'asset',
-            fileName: normalizePath(path.relative(outputOptions.dir!, tsBuildInfoPath)),
-            source: tsBuildInfoSource
-          });
+          fs.writeFileSync(normalizePath(tsBuildInfoPath), tsBuildInfoSource);
         }
       }
     }

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -87,7 +87,7 @@ export default function typescript(options: RollupTypescriptOptions = {}): Plugi
 
     renderStart(outputOptions) {
       validateSourceMap(this, parsedOptions.options, outputOptions, parsedOptions.autoSetSourceMap);
-      validatePaths(ts, this, parsedOptions.options, outputOptions);
+      validatePaths(this, parsedOptions.options, outputOptions);
     },
 
     resolveId(importee, importer) {

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -25,7 +25,8 @@ export default function typescript(options: RollupTypescriptOptions = {}): Plugi
     transformers,
     tsconfig,
     tslib,
-    typescript: ts
+    typescript: ts,
+    outputToFilesystem
   } = getPluginOptions(options);
   const tsCache = new TSCache(cacheDir);
   const emittedFiles = new Map<string, string>();
@@ -152,9 +153,16 @@ export default function typescript(options: RollupTypescriptOptions = {}): Plugi
         if (tsBuildInfoSource) {
           const fromRollupDirToTs = path.relative(outputOptions.dir!, tsBuildInfoPath);
           if (fromRollupDirToTs.startsWith('..')) {
-            const normalizedTsBuildInfoPath = normalizePath(tsBuildInfoPath);
-            await fs.mkdir(path.dirname(normalizedTsBuildInfoPath), { recursive: true });
-            await fs.writeFile(normalizedTsBuildInfoPath, tsBuildInfoSource);
+            if (outputToFilesystem === undefined) {
+              this.warn(
+                `@rollup/plugin-typescript: outputToFilesystem option is defaulting to true.`
+              );
+            }
+            if (outputToFilesystem !== false) {
+              const normalizedTsBuildInfoPath = normalizePath(tsBuildInfoPath);
+              await fs.mkdir(path.dirname(normalizedTsBuildInfoPath), { recursive: true });
+              await fs.writeFile(normalizedTsBuildInfoPath, tsBuildInfoSource);
+            }
           } else {
             this.emitFile({
               type: 'asset',

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -150,9 +150,18 @@ export default function typescript(options: RollupTypescriptOptions = {}): Plugi
         const tsBuildInfoSource = emittedFiles.get(tsBuildInfoPath);
         // https://github.com/rollup/plugins/issues/681
         if (tsBuildInfoSource) {
-          const normalizedTsBuildInfoPath = normalizePath(tsBuildInfoPath);
-          await fs.mkdir(path.dirname(normalizedTsBuildInfoPath), { recursive: true });
-          await fs.writeFile(normalizedTsBuildInfoPath, tsBuildInfoSource);
+          const fromRollupDirToTs = path.relative(outputOptions.dir!, tsBuildInfoPath);
+          if (fromRollupDirToTs.startsWith('..')) {
+            const normalizedTsBuildInfoPath = normalizePath(tsBuildInfoPath);
+            await fs.mkdir(path.dirname(normalizedTsBuildInfoPath), { recursive: true });
+            await fs.writeFile(normalizedTsBuildInfoPath, tsBuildInfoSource);
+          } else {
+            this.emitFile({
+              type: 'asset',
+              fileName: normalizePath(fromRollupDirToTs),
+              source: tsBuildInfoSource
+            });
+          }
         }
       }
     }

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 
-import fs from 'fs';
+import { promises as fs } from 'fs';
 
 import { Plugin, RollupOptions, SourceDescription } from 'rollup';
 import type { Watch } from 'typescript';
@@ -126,7 +126,7 @@ export default function typescript(options: RollupTypescriptOptions = {}): Plugi
       return output.code != null ? (output as SourceDescription) : null;
     },
 
-    generateBundle(outputOptions) {
+    async generateBundle(outputOptions) {
       parsedOptions.fileNames.forEach((fileName) => {
         const output = findTypescriptOutput(ts, parsedOptions, fileName, emittedFiles, tsCache);
         output.declarations.forEach((id) => {
@@ -151,8 +151,8 @@ export default function typescript(options: RollupTypescriptOptions = {}): Plugi
         // https://github.com/rollup/plugins/issues/681
         if (tsBuildInfoSource) {
           const normalizedTsBuildInfoPath = normalizePath(tsBuildInfoPath);
-          fs.mkdirSync(path.dirname(normalizedTsBuildInfoPath), { recursive: true });
-          fs.writeFileSync(normalizedTsBuildInfoPath, tsBuildInfoSource);
+          await fs.mkdir(path.dirname(normalizedTsBuildInfoPath), { recursive: true });
+          await fs.writeFile(normalizedTsBuildInfoPath, tsBuildInfoSource);
         }
       }
     }

--- a/packages/typescript/src/options/plugin.ts
+++ b/packages/typescript/src/options/plugin.ts
@@ -23,6 +23,7 @@ export const getPluginOptions = (options: RollupTypescriptOptions) => {
     tsconfig,
     tslib,
     typescript,
+    outputToFilesystem,
     ...compilerOptions
   } = options;
 
@@ -35,6 +36,7 @@ export const getPluginOptions = (options: RollupTypescriptOptions) => {
     compilerOptions: compilerOptions as PartialCompilerOptions,
     typescript: typescript || defaultTs,
     tslib: tslib || getTsLibPath(),
-    transformers
+    transformers,
+    outputToFilesystem
   };
 };

--- a/packages/typescript/src/options/validate.ts
+++ b/packages/typescript/src/options/validate.ts
@@ -37,7 +37,6 @@ export function validateSourceMap(
  * @param outputOptions Rollup output options.
  */
 export function validatePaths(
-  ts: typeof import('typescript'),
   context: PluginContext,
   compilerOptions: CompilerOptions,
   outputOptions: OutputOptions
@@ -61,23 +60,6 @@ export function validatePaths(
           `@rollup/plugin-typescript: Path of Typescript compiler option '${dirProperty}' must be located inside Rollup 'dir' option.`
         );
       }
-    }
-  }
-
-  const tsBuildInfoPath = ts.getTsBuildInfoEmitOutputFilePath(compilerOptions);
-  if (tsBuildInfoPath && compilerOptions.incremental) {
-    if (!outputOptions.dir) {
-      context.error(
-        `@rollup/plugin-typescript: Rollup 'dir' option must be used when Typescript compiler options 'tsBuildInfoFile' or 'incremental' are specified.`
-      );
-    }
-
-    // Checks if the given path lies within Rollup output dir
-    const fromRollupDirToTs = relative(outputOptions.dir, tsBuildInfoPath);
-    if (fromRollupDirToTs.startsWith('..')) {
-      context.error(
-        `@rollup/plugin-typescript: Path of Typescript compiler option 'tsBuildInfoFile' must be located inside Rollup 'dir' option.`
-      );
     }
   }
 

--- a/packages/typescript/src/outputFile.ts
+++ b/packages/typescript/src/outputFile.ts
@@ -88,9 +88,12 @@ export async function emitFile(
   filePath: string,
   fileSource: string
 ) {
-  const fromRollupOutputDirToFile = path.relative(outputOptions.dir!, filePath);
+  // TODO: this is confusing, change
+  const fromRollupOutputDirToFile = outputOptions.dir
+    ? path.relative(outputOptions.dir, filePath)
+    : '..';
   if (fromRollupOutputDirToFile.startsWith('..')) {
-    if (outputToFilesystem === undefined) {
+    if (outputToFilesystem == null) {
       context.warn(`@rollup/plugin-typescript: outputToFilesystem option is defaulting to true.`);
     }
     if (outputToFilesystem !== false) {

--- a/packages/typescript/test/fixtures/incremental-single/main.ts
+++ b/packages/typescript/test/fixtures/incremental-single/main.ts
@@ -1,0 +1,6 @@
+type AnswerToQuestion = string | undefined;
+
+const answer: AnswerToQuestion = '42';
+
+// eslint-disable-next-line no-console
+console.log(`the answer is ${answer}`);

--- a/packages/typescript/test/fixtures/incremental-single/tsconfig.json
+++ b/packages/typescript/test/fixtures/incremental-single/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "incremental": true,
+  }
+}

--- a/packages/typescript/test/test.js
+++ b/packages/typescript/test/test.js
@@ -655,6 +655,26 @@ test.serial('supports incremental rebuild', async (t) => {
   t.true(fs.existsSync('dist/.tsbuildinfo'));
 });
 
+test.serial('supports incremental build for single file output', async (t) => {
+  process.chdir('fixtures/incremental-single');
+  // clean up artefacts from earlier builds
+  forceRmSync('tsconfig.tsbuildinfo');
+  forceRmSync('index.js');
+
+  const bundle = await rollup({
+    input: 'main.ts',
+    plugins: [typescript()],
+    onwarn
+  });
+  const output = await getCode(bundle, { format: 'esm', file: 'main.js' }, true);
+
+  t.deepEqual(
+    output.map((out) => out.fileName),
+    ['main.js']
+  );
+  t.true(fs.existsSync('tsconfig.tsbuildinfo'));
+});
+
 test.serial('supports consecutive incremental rebuilds', async (t) => {
   process.chdir('fixtures/incremental');
   // clean up artefacts from earlier builds

--- a/packages/typescript/test/test.js
+++ b/packages/typescript/test/test.js
@@ -615,7 +615,7 @@ test.serial('supports optional chaining', async (t) => {
 test.serial('supports incremental build', async (t) => {
   process.chdir('fixtures/basic');
   // clean up artefacts from earlier builds
-  forceRmSync('tsconfig.tsbuildinfo');
+  await forceRemove('tsconfig.tsbuildinfo');
 
   const bundle = await rollup({
     input: 'main.ts',
@@ -639,7 +639,7 @@ test.serial('supports incremental build', async (t) => {
 test.serial('supports incremental rebuild', async (t) => {
   process.chdir('fixtures/incremental');
   // clean up artefacts from earlier builds
-  forceRmSync('dist/.tsbuildinfo');
+  await forceRemove('dist/.tsbuildinfo');
 
   const bundle = await rollup({
     input: 'main.ts',
@@ -658,8 +658,8 @@ test.serial('supports incremental rebuild', async (t) => {
 test.serial('supports incremental build for single file output', async (t) => {
   process.chdir('fixtures/incremental-single');
   // clean up artefacts from earlier builds
-  forceRmSync('tsconfig.tsbuildinfo');
-  forceRmSync('index.js');
+  await forceRemove('tsconfig.tsbuildinfo');
+  await forceRemove('index.js');
 
   const bundle = await rollup({
     input: 'main.ts',
@@ -678,7 +678,7 @@ test.serial('supports incremental build for single file output', async (t) => {
 test.serial('supports consecutive incremental rebuilds', async (t) => {
   process.chdir('fixtures/incremental');
   // clean up artefacts from earlier builds
-  forceRmSync('dist/.tsbuildinfo');
+  await forceRemove('dist/.tsbuildinfo');
 
   const firstBundle = await rollup({
     input: 'main.ts',
@@ -709,7 +709,7 @@ test.serial('supports consecutive incremental rebuilds', async (t) => {
 // https://github.com/rollup/plugins/issues/681
 test.serial('supports incremental rebuilds with no change to cache', async (t) => {
   process.chdir('fixtures/incremental-output-cache');
-  const cleanup = () => {
+  const cleanup = async () => {
     let files;
     try {
       files = fs.readdirSync('dist');
@@ -718,10 +718,10 @@ test.serial('supports incremental rebuilds with no change to cache', async (t) =
       throw error;
     }
     files.forEach((file) => fs.unlinkSync(path.join('dist', file)));
-    forceRmSync('dist/.tsbuildinfo');
+    await forceRemove('dist/.tsbuildinfo');
   };
 
-  cleanup();
+  await cleanup();
 
   const firstBundle = await rollup({
     input: 'main.ts',
@@ -755,7 +755,7 @@ test.serial('supports incremental rebuilds with no change to cache', async (t) =
   t.is(tsBuildInfoStats2.ctimeMs, tsBuildInfoStats.ctimeMs);
   t.is(tsBuildInfoStats2.birthtimeMs, tsBuildInfoStats.birthtimeMs);
 
-  cleanup();
+  await cleanup();
 });
 
 test.serial.skip('supports project references', async (t) => {
@@ -1098,9 +1098,9 @@ function waitForWatcherEvent(watcher, eventCode) {
   });
 }
 
-function forceRmSync(filePath) {
+async function forceRemove(filePath) {
   try {
-    fs.unlinkSync(filePath);
+    await fs.promises.unlink(filePath);
   } catch {
     // ignore non existant file
   }

--- a/packages/typescript/types/index.d.ts
+++ b/packages/typescript/types/index.d.ts
@@ -69,6 +69,11 @@ export interface RollupTypescriptPluginOptions {
    * TypeScript custom transformers
    */
   transformers?: CustomTransformerFactories;
+  /**
+   * When set to false, force non-cached files to always be emitted in the output directory.output
+   * If not set, will default to true with a warning.
+   */
+  outputToFilesystem?: boolean;
 }
 
 export interface FlexibleCompilerOptions extends CompilerOptions {


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

Typescript

## Rollup Plugin Name: `Typescript`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [ ] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:
https://github.com/rollup/plugins/issues/698

### Description
After removing the validation, I get an error that rollup should not be emitting files outside of the `outDir` directory.

This seems strange as the typescript incremental cache file is not a user facing file. I removed the usage of rollup's `emitFile` and replaced it with how `TsCache` writes their files, which should be the closest equivalent.
