### PR TITLE
fix: restart watch program on each build

### DIFF
--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -50,6 +50,10 @@ export default function typescript(options: RollupTypescriptOptions = {}): Plugi
       preflight({ config: parsedOptions, context: this, rollupOptions, tslib });
 
       // Fixes a memory leak https://github.com/rollup/plugins/issues/322
+      if (this.meta.watchMode !== true) {
+        // eslint-disable-next-line
+        program?.close();
+      }
       if (!program) {
         program = createWatchProgram(ts, this, {
           formatHost,


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `@rollup/plugin-typescript`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers: #860 

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

ts watch program needs to restart on each build, otherwise the emitted assets won't change, `emittedFiles` will cache the first build all the time
