### PR TITLE
Add ability to disable NodeJS support for Wasm plugin

### DIFF
--- a/packages/wasm/src/index.ts
+++ b/packages/wasm/src/index.ts
@@ -27,7 +27,7 @@ export function wasm(options: RollupWasmOptions = {}): Plugin {
 
     load(id) {
       if (id === HELPERS_ID) {
-        return getHelpersModule();
+        return getHelpersModule(options.disableNodeSupport);
       }
 
       if (!/\.wasm$/.test(id)) {

--- a/packages/wasm/types/index.d.ts
+++ b/packages/wasm/types/index.d.ts
@@ -15,6 +15,11 @@ export interface RollupWasmOptions {
    * A string which will be added in front of filenames when they are not inlined but are copied.
    */
   publicPath?: string;
+  /**
+   * If set to `true`, support for NodeJS will not be included.  This will prevent `require('fs')` and `require('path')` from getting generated
+   * in the generated code and can fix errors with some bundlers like Webpack v5.
+   */
+  disableNodeSupport?: boolean;
 }
 
 /**


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `wasm`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

### Description

The Wasm plugin by default emits code that handles loading WebAssembly in a NodeJS environment.  That code contains calls to `require('fs')` and `require('path')`.

When importing libraries that were built using the Wasm plugin from Webpack v5 in projects targeting the browser, Webpack throws build-time errors due to those not being available in the browser.

This change adds an optional flag to the Wasm plugin options which disables that Node.JS support code from being emitted at all.  It prevents the Webpack error, and all browser-targeted Wasm loading support is retained.
