### PR TITLE
Add resolve options to typescript plugin

### DIFF
--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -79,6 +79,15 @@ Default: `null`
 
 A [minimatch pattern](https://github.com/isaacs/minimatch), or array of patterns, which specifies the files in the build the plugin should operate on. By default all `.ts` and `.tsx` files are targeted.
 
+### `resolveRoot`
+
+Type: `String` | `Boolean`<br>
+Default: `true`
+
+Sets the `resolve` parameter for [createFilter](https://github.com/rollup/plugins/tree/master/packages/pluginutils#createfilter). By default, it will resolve against the `rootDir` set in the TS config file however you can set this to change which files are filtered out by the plugin.
+
+This can fix `Error: Unexpected token (Note that you need plugins to import files that are not JavaScript)` TypeScript error when targeting files outside the current working directory (`process.cwd()`).
+
 ### `tsconfig`
 
 Type: `String` | `Boolean`<br>

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -1,5 +1,7 @@
 import * as path from 'path';
 
+import { createFilter } from '@rollup/pluginutils';
+
 import { Plugin, RollupOptions, SourceDescription } from 'rollup';
 import type { Watch } from 'typescript';
 
@@ -19,10 +21,12 @@ export default function typescript(options: RollupTypescriptOptions = {}): Plugi
   const {
     cacheDir,
     compilerOptions,
-    filter,
     transformers,
     tsconfig,
     tslib,
+    include,
+    exclude,
+    resolveRoot,
     typescript: ts
   } = getPluginOptions(options);
   const tsCache = new TSCache(cacheDir);
@@ -30,6 +34,9 @@ export default function typescript(options: RollupTypescriptOptions = {}): Plugi
   const watchProgramHelper = new WatchProgramHelper();
 
   const parsedOptions = parseTypescriptConfig(ts, tsconfig, compilerOptions);
+  const filter = createFilter(include || ['*.ts+(|x)', '**/*.ts+(|x)'], exclude, {
+    resolve: resolveRoot ?? compilerOptions.rootDir
+  });
   parsedOptions.fileNames = parsedOptions.fileNames.filter(filter);
 
   const formatHost = createFormattingHost(ts, parsedOptions.options);

--- a/packages/typescript/src/options/plugin.ts
+++ b/packages/typescript/src/options/plugin.ts
@@ -1,4 +1,3 @@
-import { createFilter } from '@rollup/pluginutils';
 import * as defaultTs from 'typescript';
 
 import { RollupTypescriptOptions, PartialCompilerOptions } from '../../types';
@@ -19,6 +18,7 @@ export const getPluginOptions = (options: RollupTypescriptOptions) => {
     cacheDir,
     exclude,
     include,
+    resolveRoot,
     transformers,
     tsconfig,
     tslib,
@@ -26,11 +26,11 @@ export const getPluginOptions = (options: RollupTypescriptOptions) => {
     ...compilerOptions
   } = options;
 
-  const filter = createFilter(include || ['*.ts+(|x)', '**/*.ts+(|x)'], exclude);
-
   return {
     cacheDir,
-    filter,
+    include,
+    exclude,
+    resolveRoot,
     tsconfig,
     compilerOptions: compilerOptions as PartialCompilerOptions,
     typescript: typescript || defaultTs,

--- a/packages/typescript/types/index.d.ts
+++ b/packages/typescript/types/index.d.ts
@@ -52,6 +52,11 @@ export interface RollupTypescriptPluginOptions {
    */
   exclude?: FilterPattern;
   /**
+   * Sets the `resolve` value for the underlying filter function.  If not set will use the `rootDir` property
+   * @see {@link https://github.com/rollup/plugins/tree/master/packages/pluginutils#createfilter} @rollup/pluginutils `createFilter`
+   */
+  resolveRoot?: string | false;
+  /**
    * When set to false, ignores any options specified in the config file.
    * If set to a string that corresponds to a file path, the specified file
    * will be used as config file.


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `typescript`

This PR contains:

- [x] bugfix
- [x] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:
#287 

### Description
When targeting files outside of the current working directory of the process, the plugin fails because if filters out all files not inside `process.cwd()`.  This adds the default value to look at the resolved TS config `rootDir` option while adding an additional option to control it `resolveRoot` which is passed to `resolve` in the `createFilter`.  This fixes (at least my issue) seeing `Error: Unexpected token (Note that you need plugins to import files that are not JavaScript)` in a monorepo.
