### PR TITLE
fix(alias): paths for aliases across multiple Windows drives

### DIFF
--- a/packages/alias/src/index.ts
+++ b/packages/alias/src/index.ts
@@ -1,12 +1,6 @@
-import { platform } from 'os';
-
 import { PartialResolvedId, Plugin } from 'rollup';
-import slash from 'slash';
 
 import { Alias, ResolverFunction, RollupAliasOptions } from '../types';
-
-const VOLUME = /^([A-Z]:)/i;
-const IS_WINDOWS = platform() === 'win32';
 
 const noop = () => null;
 
@@ -28,9 +22,6 @@ function matches(pattern: string | RegExp, importee: string) {
 function normalizeId(id: string): string;
 function normalizeId(id: string | undefined): string | undefined;
 function normalizeId(id: string | undefined) {
-  if (typeof id === 'string' && (IS_WINDOWS || VOLUME.test(id))) {
-    return slash(id.replace(VOLUME, ''));
-  }
   return id;
 }
 

--- a/packages/alias/test/test.js
+++ b/packages/alias/test/test.js
@@ -2,14 +2,13 @@ import path, { posix } from 'path';
 
 import test from 'ava';
 import { rollup } from 'rollup';
-import slash from 'slash';
 
 // eslint-disable-next-line import/no-unresolved, import/extensions
 import nodeResolvePlugin from '@rollup/plugin-node-resolve';
 
 import alias from '../dist';
 
-const normalizePath = (pathToNormalize) => slash(pathToNormalize.replace(/^([A-Z]:)/, ''));
+const normalizePath = (pathToNormalize) => pathToNormalize;
 const DIRNAME = normalizePath(__dirname);
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -256,7 +256,7 @@ importers:
       rollup: ^2.23.0
       typescript: ^4.1.2
     dependencies:
-      '@rollup/pluginutils': 4.1.0_rollup@2.32.1
+      '@rollup/pluginutils': 4.1.1
       eslint: 7.30.0
     devDependencies:
       '@rollup/plugin-node-resolve': 9.0.0_rollup@2.32.1
@@ -273,7 +273,7 @@ importers:
       graphql-tag: ^2.2.2
       rollup: ^2.23.0
     dependencies:
-      '@rollup/pluginutils': 4.1.0_rollup@2.32.1
+      '@rollup/pluginutils': 4.1.1
       graphql-tag: 2.11.0_graphql@14.7.0
     devDependencies:
       '@rollup/plugin-buble': 0.21.3_rollup@2.32.1
@@ -350,7 +350,7 @@ importers:
       del-cli: ^3.0.1
       rollup: ^2.23.0
     dependencies:
-      '@rollup/pluginutils': 4.1.0_rollup@2.32.1
+      '@rollup/pluginutils': 4.1.1
     devDependencies:
       '@rollup/plugin-buble': 0.21.3_rollup@2.32.1
       del-cli: 3.0.1
@@ -2295,17 +2295,6 @@ packages:
       picomatch: 2.2.2
       rollup: 2.47.0
 
-  /@rollup/pluginutils/4.1.0_rollup@2.32.1:
-    resolution: {integrity: sha512-TrBhfJkFxA+ER+ew2U2/fHbebhLT/l/2pRk0hfj9KusXUuRXd2v0R58AfaZK9VXDQ4TogOSEmICVrQAA3zFnHQ==}
-    engines: {node: '>= 8.0.0'}
-    peerDependencies:
-      rollup: ^1.20.0||^2.0.0
-    dependencies:
-      estree-walker: 2.0.1
-      picomatch: 2.3.0
-      rollup: 2.32.1
-    dev: false
-
   /@rollup/pluginutils/4.1.1:
     resolution: {integrity: sha512-clDjivHqWGXi7u+0d2r2sBi4Ie6VLEAzWMIkvJLnDmxoOhBYOTfzGbOQBA32THHm11/LiJbd01tJUpJsbshSWQ==}
     engines: {node: '>= 8.0.0'}
@@ -3419,7 +3408,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       slice-ansi: 3.0.0
-      string-width: 4.2.0
+      string-width: 4.2.2
     dev: true
 
   /cliui/6.0.0:
@@ -3552,7 +3541,7 @@ packages:
       js-string-escape: 1.0.1
       lodash: 4.17.21
       md5-hex: 3.0.1
-      semver: 7.3.2
+      semver: 7.3.5
       well-known-symbols: 2.0.0
     dev: true
 


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `alias`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

We ran into an issue where we had aliases to paths on another Windows drive which was not working. After some investigation, I found out that this is because the drive letter is being removed in the alias plugin. Removing that piece of code made the alias work properly across multiple Windows drives.

Questions:
- I also removed usage of the `slash` library as it's not actually needed to work properly. Do you want me to remove the library entirely?
- The normalize functions are doing nothing more than just returning the `id` and `path` straight away, so they could technically be removed entirely. Do you want me to take care of that?