### PR TITLE
fix(node-resolve): handle browser-mapped paths correctly in nested contexts

### DIFF
--- a/packages/node-resolve/src/index.js
+++ b/packages/node-resolve/src/index.js
@@ -88,7 +88,7 @@ export function nodeResolve(opts = {}) {
         return { id: ES6_BROWSER_EMPTY };
       }
       const browserImportee =
-        browser[importee] ||
+        (importee[0] !== '.' && browser[importee]) ||
         browser[resolvedImportee] ||
         browser[`${resolvedImportee}.js`] ||
         browser[`${resolvedImportee}.json`];

--- a/packages/node-resolve/test/browser.js
+++ b/packages/node-resolve/test/browser.js
@@ -146,7 +146,7 @@ test('allows use of object browser field, resolving nested directories', async (
   t.is(module.exports.test, 43);
 });
 
-test('respects local browser field', async (t) => {
+test('respects local browser field for external dependencies', async (t) => {
   const bundle = await rollup({
     input: 'browser-local.js',
     onwarn: () => t.fail('No warnings were expected'),
@@ -159,6 +159,39 @@ test('respects local browser field', async (t) => {
   const { module } = await testBundle(t, bundle);
 
   t.is(module.exports, 'component-type');
+});
+
+test('respects local browser field for internal dependencies', async (t) => {
+  const bundle = await rollup({
+    input: 'browser-local-relative.js',
+    onwarn: () => t.fail('No warnings were expected'),
+    plugins: [
+      nodeResolve({
+        mainFields: ['browser', 'main']
+      })
+    ]
+  });
+  const { module } = await testBundle(t, bundle);
+
+  t.is(module.exports, 'component-type');
+});
+
+test('does not apply local browser field for matching imports in nested paths', async (t) => {
+  try {
+    await rollup({
+      input: 'nested/browser-local-relative.js',
+      onwarn: () => t.fail('No warnings were expected'),
+      plugins: [
+        nodeResolve({
+          mainFields: ['browser', 'main']
+        })
+      ]
+    });
+  } catch (e) {
+    t.is(e.code, 'UNRESOLVED_IMPORT');
+    return;
+  }
+  t.fail('expecting error');
 });
 
 test('allows use of object browser field, resolving to nested node_modules', async (t) => {

--- a/packages/node-resolve/test/fixtures/browser-local-relative.js
+++ b/packages/node-resolve/test/fixtures/browser-local-relative.js
@@ -1,0 +1,4 @@
+// test browser mapped imports from the main entrypoint
+import s from './dummy-relative';
+
+export default s;

--- a/packages/node-resolve/test/fixtures/nested/browser-local-relative.js
+++ b/packages/node-resolve/test/fixtures/nested/browser-local-relative.js
@@ -1,0 +1,4 @@
+// test browser mapped imports from the main entrypoint
+import s from './dummy-relative';
+
+export default s;

--- a/packages/node-resolve/test/fixtures/package.json
+++ b/packages/node-resolve/test/fixtures/package.json
@@ -8,6 +8,7 @@
   "scripts": {},
   "keywords": [],
   "browser": {
+    "./dummy-relative": "component-type",
     "dummy-module": "component-type"
   }
 }


### PR DESCRIPTION
<!--
  * Please lint your changes by running `npm run lint` before creating a PR.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `node-resolve`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers: #919, eemeli/yaml#291

### Description

For each entry in a package.json `"browser"` object entry, the `browserMapCache` is filled with mapped paths at keys using both the raw source of the path that needs to be remapped, as well as the resolved path. This effectively enables both package name imports (like `"foo"`) as well as relative path imports (like `"./foo"`) to work when `doResolveId` is called. However, this causes a problem when the raw form of a relative import in a sub-path matches a value that's included in the package.json `"browser"` entry.

In other words, if `"browser"` includes `"./foo": "./other.js"`, an import of `"./foo"` in a file `./bar/baz.js` is mapped to `./other.js`, even though it shouldn't; [the spec](https://github.com/defunctzombie/package-browser-field-spec) is pretty clear on this:

> All paths for browser fields are relative to the `package.json` file location (and usually project root as a result).

To fix, only the resolved paths are checked when applying mappings for relative imports.