### PR TITLE
fix(commonjs)!: Correctly infer module name for any separator

### DIFF
--- a/packages/commonjs/src/utils.js
+++ b/packages/commonjs/src/utils.js
@@ -1,6 +1,6 @@
 /* eslint-disable import/prefer-default-export */
 
-import { basename, dirname, extname, sep } from 'path';
+import { basename, dirname, extname } from 'path';
 
 import { makeLegalIdentifier } from '@rollup/pluginutils';
 
@@ -27,8 +27,7 @@ export function getName(id) {
   if (name !== 'index') {
     return name;
   }
-  const segments = dirname(id).split(sep);
-  return makeLegalIdentifier(segments[segments.length - 1]);
+  return makeLegalIdentifier(basename(dirname(id)));
 }
 
 export function normalizePathSlashes(path) {

--- a/packages/commonjs/test/fixtures/samples/module-path-separator/foo/index.js
+++ b/packages/commonjs/test/fixtures/samples/module-path-separator/foo/index.js
@@ -1,0 +1,1 @@
+module.exports.a = 1;

--- a/packages/commonjs/test/fixtures/samples/module-path-separator/main.js
+++ b/packages/commonjs/test/fixtures/samples/module-path-separator/main.js
@@ -1,0 +1,2 @@
+const foo = require("./foo");
+console.log(foo.a);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `commonjs`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [x] yes (_breaking changes will not be merged unless absolutely necessary_)
- [ ] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers: #923

### Description

When a module whose file name is `index.js` is resolved to a module ID containing a directory separator that is different from [`path.sep`](https://nodejs.org/docs/latest/api/path.html#path_path_sep) of the current platform, the commonjs plugin incorrectly infers the base name of the module. This causes the absolute path of the module to be embedded into the bundle, and prevents generating reproducible builds across different machines.

For example, with a module ID of `C:/Users/Phil/Documents/GitHub/test-vite-app/node_modules/react/index.js` on Windows, the plugin generates code like this:
```js
var C__Users_Phil_Documents_GitHub_testViteApp_node_modules_react = { exports: {} };
var react_production_min = {};
```

This PR fixes the problem by using `path.basename()` to extract the final path component instead of splitting the string with `path.sep`.

With the fix, the plugin generates code like this:
```js
var react = { exports: {} };
var react_production_min = {};
```

Closes #923