### PR TITLE
feat(graphql): handle gql literals

### DIFF
--- a/packages/graphql/test/fixtures/gql-litteral/index.js
+++ b/packages/graphql/test/fixtures/gql-litteral/index.js
@@ -1,0 +1,12 @@
+import gql from 'graphql-tag';
+
+const doc = gql`
+  query GetHero {
+    hero {
+      id
+      name
+    }
+  }
+`;
+
+export default { doc };

--- a/packages/graphql/test/test.js
+++ b/packages/graphql/test/test.js
@@ -50,3 +50,15 @@ test('should support multi-imports', async (t) => {
   t.is(module.exports.GetHeros.kind, 'Document');
   t.is(module.exports.GetHeros.definitions[0].name.value, 'GetHeros');
 });
+
+test('should parse a simple graphql litteral', async (t) => {
+  const bundle = await rollup({
+    input: 'fixtures/gql-litteral/index.js',
+    plugins: [graphql()]
+  });
+
+  const { module } = await testBundle(t, bundle);
+
+  t.truthy('doc' in module.exports);
+  t.is(module.exports.doc.kind, 'Document');
+});


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `graphql`

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

This change allow the graphql plugin to parse graphql schemas included via `gql` literals. Inspired by https://github.com/gajus/babel-plugin-graphql-tag.

Quoted from [gajus/babel-plugin-graphql-tag](https://github.com/gajus/babel-plugin-graphql-tag)
```markdown
# Motivation
Compiling GraphQL queries at the build time:

reduces the script initialization time; and
removes the graphql-tag dependency
Removing the graphql-tag dependency from the bundle saves approx. 50 KB.

# Implementation
Searches for imports of graphql-tag and removes them.
Searches for tagged template literals with gql identifier and compiles them using graphql-tag.
```
