### PR TITLE
fix(run): normalize paths for string comparison

### DIFF
--- a/packages/run/src/index.ts
+++ b/packages/run/src/index.ts
@@ -51,7 +51,7 @@ export default function run(opts: RollupRunOptions = {}): Plugin {
       const dir = outputOptions.dir || dirname(outputOptions.file!);
       const entryFileName = Object.keys(bundle).find((fileName) => {
         const chunk = bundle[fileName] as RenderedChunk;
-        return chunk.isEntry && chunk.facadeModuleId === input;
+        return chunk.isEntry && resolve(chunk.facadeModuleId) === resolve(input);
       });
 
       if (entryFileName) {


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `run`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no
  - NOTE: I tried running the existing tests but received errors upon doing so. I am not familiar with `pnpm`, and do not have time to debug an unfamiliar tool chain.

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

Fixes the following issue:
```log
[run] @rollup/plugin-run could not find output chunk
error during build:
Error: @rollup/plugin-run could not find output chunk
    at error (C:\SomeProject\node_modules\rollup\dist\shared\rollup.js:151:30)
    at throwPluginError (C:\SomeProject\node_modules\rollup\dist\shared\rollup.js:19340:12)
    at Object.error (C:\SomeProject\node_modules\rollup\dist\shared\rollup.js:19992:20)
    at Object.writeBundle (C:\SomeProject\node_modules\@rollup\plugin-run\dist\index.js:63:22)
    at C:\SomeProject\node_modules\rollup\dist\shared\rollup.js:20197:25
    at async Promise.all (index 1)
    at async handleGenerateWrite (C:\SomeProject\node_modules\rollup\dist\shared\rollup.js:21022:9)
    at async doBuild (C:\SomeProject\node_modules\vite\dist\node\chunks\dep-c1a9de64.js:51659:26)
    at async build (C:\SomeProject\node_modules\vite\dist\node\chunks\dep-c1a9de64.js:51488:16)
    at async CAC.<anonymous> (C:\SomeProject\node_modules\vite\dist\node\cli.js:13999:9)
```

I discovered the cause of the issue by executing some `console.log` statements in `packages/run/src/index.ts`. I noticed that `console.log({chunk:chunk.facadeModuleId, input})` returned the following result, which shows that the path strings were being compared with different separators.
```ts
{
  chunk: 'C:/SomeProject/src/index.ts',
  input: 'C:\\SomeProject\\src\\index.ts'
}
```

Wrapping these values with `path.resolve` ensures that they are both using the system-specific path separator, which prevents erroneous string comparisons.