### PR TITLE
fix(beep): ensure types are exported in npm pkg

### DIFF
--- a/packages/beep/package.json
+++ b/packages/beep/package.json
@@ -42,6 +42,7 @@
     "rollup": "^2.23.0",
     "strip-ansi": "^6.0.0"
   },
+  "types": "types/index.d.ts",
   "ava": {
     "babel": {
       "compileEnhancements": false

--- a/packages/beep/package.json
+++ b/packages/beep/package.json
@@ -26,6 +26,7 @@
   },
   "files": [
     "lib/",
+    "types/",
     "README.md",
     "LICENSE"
   ],


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `beep`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

### Description

The typings were not exported for `beep` plugin even though they existed in the package.
