### PR TITLE
fix(commonjs): Support JSX and TypeScript

### DIFF
--- a/packages/commonjs/package.json
+++ b/packages/commonjs/package.json
@@ -51,6 +51,7 @@
   },
   "dependencies": {
     "@rollup/pluginutils": "^3.1.0",
+    "acorn-loose": "^8.1.0",
     "commondir": "^1.0.1",
     "estree-walker": "^2.0.1",
     "glob": "^7.1.6",

--- a/packages/commonjs/src/parse.js
+++ b/packages/commonjs/src/parse.js
@@ -1,7 +1,15 @@
+import acornLoose from 'acorn-loose';
+
 export function tryParse(parse, code, id) {
   try {
     return parse(code, { allowReturnOutsideFunction: true });
   } catch (err) {
+    try {
+      return acornLoose.parse(code, { allowReturnOutsideFunction: true, ecmaVersion: 2020 });
+    } catch (err2) {
+      // We ignore this second try and just report the original error
+    }
+
     err.message += ` in ${id}`;
     throw err;
   }

--- a/packages/commonjs/test/fixtures/form/jsx/input.js
+++ b/packages/commonjs/test/fixtures/form/jsx/input.js
@@ -1,0 +1,5 @@
+const React = require("React");
+
+module.exports = function Button(props) {
+  return <button {...props} />;
+}

--- a/packages/commonjs/test/fixtures/form/jsx/output.js
+++ b/packages/commonjs/test/fixtures/form/jsx/output.js
@@ -1,0 +1,12 @@
+import * as commonjsHelpers from "_commonjsHelpers.js";
+import "\u0000React?commonjs-require";
+import require$$0 from "\u0000React?commonjs-proxy";
+
+const React = require$$0;
+
+var input = function Button(props) {
+  return <button {...props} />;
+}
+
+export default input;
+export { input as __moduleExports };

--- a/packages/commonjs/test/fixtures/form/typescript/input.js
+++ b/packages/commonjs/test/fixtures/form/typescript/input.js
@@ -1,0 +1,10 @@
+const React = require("React");
+
+interface ButtonProps {
+  children: React.Children;
+  className: String;
+}
+
+module.exports = function Button(props: ButtonProps) {
+  return <button {...props} />;
+}

--- a/packages/commonjs/test/fixtures/form/typescript/output.js
+++ b/packages/commonjs/test/fixtures/form/typescript/output.js
@@ -1,0 +1,17 @@
+import * as commonjsHelpers from "_commonjsHelpers.js";
+import "\u0000React?commonjs-require";
+import require$$0 from "\u0000React?commonjs-proxy";
+
+const React = require$$0;
+
+interface ButtonProps {
+  children: React.Children;
+  className: String;
+}
+
+var input = function Button(props: ButtonProps) {
+  return <button {...props} />;
+}
+
+export default input;
+export { input as __moduleExports };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,6 +164,7 @@ importers:
       '@rollup/plugin-json': ^4.1.0
       '@rollup/plugin-node-resolve': ^8.4.0
       '@rollup/pluginutils': ^3.1.0
+      acorn-loose: ^8.1.0
       commondir: ^1.0.1
       estree-walker: ^2.0.1
       glob: ^7.1.6
@@ -179,6 +180,7 @@ importers:
       typescript: ^3.9.7
     dependencies:
       '@rollup/pluginutils': 3.1.0_rollup@2.39.0
+      acorn-loose: 8.1.0
       commondir: 1.0.1
       estree-walker: 2.0.1
       glob: 7.1.6
@@ -2815,6 +2817,13 @@ packages:
     dependencies:
       acorn: 7.4.1
 
+  /acorn-loose/8.1.0:
+    resolution: {integrity: sha512-+X1zk54qiOWwIRywGBhfz8sLHFJ/adQRuVqn25m4HuD7/+GTXM1c0b3LH0bWerQ0H97lTk2GyuScGbSiQK9M1g==}
+    engines: {node: '>=0.4.0'}
+    dependencies:
+      acorn: 8.4.1
+    dev: false
+
   /acorn-walk/8.0.2:
     resolution: {integrity: sha512-+bpA9MJsHdZ4bgfDcpk0ozQyhhVct7rzOmO0s1IIr0AGGgKBljss8n2zp11rRP2wid5VGeh04CgeKzgat5/25A==}
     engines: {node: '>=0.4.0'}
@@ -2841,6 +2850,12 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
     dev: true
+
+  /acorn/8.4.1:
+    resolution: {integrity: sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+    dev: false
 
   /aggregate-error/3.1.0:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `commonjs`

This PR contains:

- [x] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers: #622

### Description

It is written in the documentation that the commonjs plugin goes _before_ the babel plugin.
It works fine for most cases. But in some cases, like using TypeScript or JSX; this won't work as the parsing of the source will fail.
One workaround is to do the babel transpilation before, the risk with this approach though is that babel adds helpers (using `import`) and breaks the module detection of `commonjs`

The only safe approach would be to make sure that any syntax close enough to EcmaScript is parsed properly and re-output them identically; `acorn-loose` allows to do this.

__Downside of this solution__:

`acorn-loose` will make a valid AST even from the most broken code. So syntax that shouldn't be valid at all will parse correctly. Is it a problem ? in my opinion no, I think projects use linters or other tools to ensure their code is valid and this shouldn't happen too often.

__Alternatives considered__:

- Changing babel to issue helpers using commonjs syntax; looks complicated to do as this would require to change the TypeScript and swc logic as well
- Adding a first pass of babel to remove JSX, run commonjs, then babel again for the rest; Too complex to advertise, inefficient because the code is parsed again and again, also it won't work with TypeScript and SWC.

