### PR TITLE
refactor(html): function signature of html updated

### DIFF
--- a/packages/html/types/index.d.ts
+++ b/packages/html/types/index.d.ts
@@ -25,4 +25,4 @@ export function makeHtmlAttributes(attributes: Record<string, string>): string;
  * @param options - Plugin options.
  * @returns Plugin instance.
  */
-export default function html(options: RollupHtmlOptions): Plugin;
+export default function html(options?: RollupHtmlOptions): Plugin;


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `html`

This PR contains:

- [ ] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:
#974 
### Description

When using a `rollup.config.ts` file I am seeing a linting error when using the plugin in the prescribed way (with no arguments). Given the function definition uses a default, I think the type declaration can be amended to list the options argument as optional. This way, people do not get linting errors/have to add a redundant default argument: eg.`html({})`.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

EDIT: Added `html` to name and a fixed typo.