### PR TITLE
fix(sucrase): Pass `disableESTransforms` option and make types match options we support

### DIFF
--- a/packages/sucrase/src/index.js
+++ b/packages/sucrase/src/index.js
@@ -38,6 +38,7 @@ module.exports = function sucrase(opts = {}) {
         enableLegacyTypeScriptModuleInterop: opts.enableLegacyTypeScriptModuleInterop,
         enableLegacyBabel5ModuleInterop: opts.enableLegacyBabel5ModuleInterop,
         production: opts.production,
+        disableESTransforms: opts.disableESTransforms,
         filePath: id,
         sourceMapOptions: {
           compiledFilename: id

--- a/packages/sucrase/test/types.ts
+++ b/packages/sucrase/test/types.ts
@@ -17,6 +17,7 @@ const config: RollupOptions = {
       jsxFragmentPragma: 'React.fragment',
       jsxPragma: 'React',
       production: true,
+      disableESTransforms: true,
       transforms: ['jsx']
     })
   ]

--- a/packages/sucrase/types/index.d.ts
+++ b/packages/sucrase/types/index.d.ts
@@ -2,7 +2,17 @@ import { FilterPattern } from '@rollup/pluginutils';
 import { Plugin } from 'rollup';
 import { Options as SucraseOptions } from 'sucrase/dist/Options';
 
-interface RollupSucraseOptions extends Omit<SucraseOptions, 'filePath' | 'sourceMapOptions'> {
+interface RollupSucraseOptions
+  extends Pick<
+    SucraseOptions,
+    | 'transforms'
+    | 'jsxPragma'
+    | 'jsxFragmentPragma'
+    | 'enableLegacyTypeScriptModuleInterop'
+    | 'enableLegacyBabel5ModuleInterop'
+    | 'production'
+    | 'disableESTransforms'
+  > {
   /**
    * A minimatch pattern, or array of patterns, which specifies the files in the build the plugin
    * should operate on.


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.
-->
  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR. **(I believe the correct command is `pnpm lint`, it failed though before I made changes)**
  * Please update the documentation in `/docs` where necessary **(Couldn’t find a “/docs” folder.)**
<!--
  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `sucrase`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [ ] no
- [x] I’d expect TypeScript in this repo to be set up to catch misspellings. If you want a test you’d have to guide me how to do it.

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers: none

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

The `disableESTransforms` option was added in [Sucrase 3.19.0].

The TypeScript types that ship with `@rollup/plugin-sucrase` says that `disableESTransforms` is a valid option, but supplying it makes no difference.

This passes the option on to Sucrase.

[Sucrase 3.19.0]: https://github.com/alangpierce/sucrase/blob/c15268c2cd1ef4d613f41978478a8061c483aaae/CHANGELOG.md#3190-2021-06-23