### PR TITLE
docs(node-resolve): fix readme heading depth

### DIFF
--- a/packages/node-resolve/README.md
+++ b/packages/node-resolve/README.md
@@ -159,7 +159,7 @@ Specifies the root directory from which to resolve modules. Typically used when 
 rootDir: path.join(process.cwd(), '..')
 ```
 
-## `ignoreSideEffectsForRoot`
+### `ignoreSideEffectsForRoot`
 
 If you use the `sideEffects` property in the package.json, by default this is respected for files in the root package. Set to `true` to ignore the `sideEffects` configuration for the root package.
 


### PR DESCRIPTION
## Rollup Plugin Name: `node-resolve`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

### Description
Just noticed the heading depth for the option was wrong when I read it.
