### PR TITLE
refactor(alias): avoid resolving customResolver every time handling resolveId

### DIFF
--- a/packages/alias/src/index.ts
+++ b/packages/alias/src/index.ts
@@ -57,7 +57,8 @@ export default function alias(options: RollupAliasOptions = {}): Plugin {
 
   if (entries.length === 0) {
     return {
-      name: 'alias'
+      name: 'alias',
+      resolveId: () => null
     };
   }
 

--- a/packages/alias/src/index.ts
+++ b/packages/alias/src/index.ts
@@ -1,8 +1,6 @@
-import { PartialResolvedId, Plugin } from 'rollup';
+import { Plugin } from 'rollup';
 
-import { Alias, ResolverFunction, RollupAliasOptions } from '../types';
-
-const noop = () => null;
+import { ResolvedAlias, ResolverFunction, ResolverObject, RollupAliasOptions } from '../types';
 
 function matches(pattern: string | RegExp, importee: string) {
   if (pattern instanceof RegExp) {
@@ -14,46 +12,42 @@ function matches(pattern: string | RegExp, importee: string) {
   if (importee === pattern) {
     return true;
   }
-  const importeeStartsWithKey = importee.indexOf(pattern) === 0;
-  const importeeHasSlashAfterKey = importee.substring(pattern.length)[0] === '/';
-  return importeeStartsWithKey && importeeHasSlashAfterKey;
+  // eslint-disable-next-line prefer-template
+  return importee.startsWith(pattern + '/');
 }
 
-function normalizeId(id: string): string;
-function normalizeId(id: string | undefined): string | undefined;
-function normalizeId(id: string | undefined) {
-  return id;
-}
-
-function getEntries({ entries }: RollupAliasOptions): readonly Alias[] {
+function getEntries({ entries, customResolver }: RollupAliasOptions): readonly ResolvedAlias[] {
   if (!entries) {
     return [];
   }
 
+  const customResolverFromOptions = resolveCustomResolver(customResolver);
+
   if (Array.isArray(entries)) {
-    return entries;
+    return entries.map((entry) => {
+      return {
+        find: entry.find,
+        replacement: entry.replacement,
+        customResolver: resolveCustomResolver(entry.customResolver) || customResolverFromOptions
+      };
+    });
   }
 
   return Object.entries(entries).map(([key, value]) => {
-    return { find: key, replacement: value };
+    return { find: key, replacement: value, customResolver: customResolverFromOptions };
   });
 }
 
-function getCustomResolver(
-  { customResolver }: Alias,
-  options: RollupAliasOptions
+function resolveCustomResolver(
+  customResolver: ResolverFunction | ResolverObject | null | undefined
 ): ResolverFunction | null {
-  if (typeof customResolver === 'function') {
-    return customResolver;
-  }
-  if (customResolver && typeof customResolver.resolveId === 'function') {
-    return customResolver.resolveId;
-  }
-  if (typeof options.customResolver === 'function') {
-    return options.customResolver;
-  }
-  if (options.customResolver && typeof options.customResolver.resolveId === 'function') {
-    return options.customResolver.resolveId;
+  if (customResolver) {
+    if (typeof customResolver === 'function') {
+      return customResolver;
+    }
+    if (typeof customResolver.resolveId === 'function') {
+      return customResolver.resolveId;
+    }
   }
   return null;
 }
@@ -63,15 +57,14 @@ export default function alias(options: RollupAliasOptions = {}): Plugin {
 
   if (entries.length === 0) {
     return {
-      name: 'alias',
-      resolveId: noop
+      name: 'alias'
     };
   }
 
   return {
     name: 'alias',
-    buildStart(inputOptions) {
-      return Promise.all(
+    async buildStart(inputOptions) {
+      await Promise.all(
         [...entries, options].map(
           ({ customResolver }) =>
             customResolver &&
@@ -79,37 +72,27 @@ export default function alias(options: RollupAliasOptions = {}): Plugin {
             typeof customResolver.buildStart === 'function' &&
             customResolver.buildStart.call(this, inputOptions)
         )
-      ).then(() => {
-        // enforce void return value
-      });
+      );
     },
     resolveId(importee, importer) {
-      const importeeId = normalizeId(importee);
-      const importerId = normalizeId(importer);
-
+      if (!importer) {
+        return null;
+      }
       // First match is supposed to be the correct one
-      const matchedEntry = entries.find((entry) => matches(entry.find, importeeId));
-      if (!matchedEntry || !importerId) {
+      const matchedEntry = entries.find((entry) => matches(entry.find, importee));
+      if (!matchedEntry) {
         return null;
       }
 
-      const updatedId = normalizeId(
-        importeeId.replace(matchedEntry.find, matchedEntry.replacement)
-      );
+      const updatedId = importee.replace(matchedEntry.find, matchedEntry.replacement);
 
-      const customResolver = getCustomResolver(matchedEntry, options);
-      if (customResolver) {
-        return customResolver.call(this, updatedId, importerId, {});
+      if (matchedEntry.customResolver) {
+        return matchedEntry.customResolver.call(this, updatedId, importer, {});
       }
 
-      return this.resolve(updatedId, importer, { skipSelf: true }).then((resolved) => {
-        let finalResult: PartialResolvedId | null = resolved;
-        if (!finalResult) {
-          finalResult = { id: updatedId };
-        }
-
-        return finalResult;
-      });
+      return this.resolve(updatedId, importer, { skipSelf: true }).then(
+        (resolved) => resolved || { id: updatedId }
+      );
     }
   };
 }

--- a/packages/alias/types/index.d.ts
+++ b/packages/alias/types/index.d.ts
@@ -13,6 +13,12 @@ export interface Alias {
   customResolver?: ResolverFunction | ResolverObject | null;
 }
 
+export interface ResolvedAlias {
+  find: string | RegExp;
+  replacement: string;
+  customResolver: ResolverFunction | null;
+}
+
 export interface RollupAliasOptions {
   /**
    * Instructs the plugin to use an alternative resolving algorithm,


### PR DESCRIPTION
## Rollup Plugin Name: `@rollup/plugin-alias`

This PR contains:

- [ ] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

### Description

This PR removes useless functions and avoid resolving customResolver every time handling resolveId.