### PR TITLE
fix(commonjs)!: use safe default value for ignoreTryCatch

### DIFF
--- a/packages/commonjs/README.md
+++ b/packages/commonjs/README.md
@@ -123,7 +123,7 @@ Sometimes you have to leave require statements unconverted. Pass an array contai
 ### `ignoreTryCatch`
 
 Type: `boolean | 'remove' | string[] | ((id: string) => boolean)`<br>
-Default: `false`
+Default: `true`
 
 In most cases, where `require` calls are inside a `try-catch` clause, they should be left unconverted as it requires an optional dependency that may or may not be installed beside the rolled up package.
 Due to the conversion of `require` to a static `import` - the call is hoisted to the top of the file, outside of the `try-catch` clause.

--- a/packages/commonjs/src/index.js
+++ b/packages/commonjs/src/index.js
@@ -88,7 +88,9 @@ export default function commonjs(options = {}) {
         ? options.ignoreTryCatch(id)
         : Array.isArray(options.ignoreTryCatch)
         ? options.ignoreTryCatch.includes(id)
-        : options.ignoreTryCatch || false;
+        : typeof options.ignoreTryCatch !== 'undefined'
+        ? options.ignoreTryCatch
+        : true;
 
     return {
       canConvertRequire: mode !== 'remove' && mode !== true,


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `@rollup/plugin-commonjs`

This PR contains:

- [X] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [X] no

Breaking Changes?

- [X] yes (_breaking changes will not be merged unless absolutely necessary_)
- [ ] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers: https://github.com/rollup/plugins/issues/1004

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
There's a warning for this value in the docs saying it should normally be set to `true`, so it seems like the current default of `false` might not be a very good one