### PR TITLE
clearify plugin-replace delimiters typing

### DIFF
--- a/packages/replace/README.md
+++ b/packages/replace/README.md
@@ -60,7 +60,7 @@ In addition to the properties and values specified for replacement, users may al
 
 ### `delimiters`
 
-Type: `Array[...String, String]`<br>
+Type: `Array[String, String]`<br>
 Default: `['\b', '\b(?!\.)']`
 
 Specifies the boundaries around which strings will be replaced. By default, delimiters are [word boundaries](https://www.regular-expressions.info/wordboundaries.html) and also prevent replacements of instances with nested access. See [Word Boundaries](#word-boundaries) below for more information.


### PR DESCRIPTION
delimiters accept only pair of string. array of 3 or more element won't make any sense.

https://github.com/rollup/plugins/blob/00e16d9ef314ae252ed7ecaf429097675a107352/packages/replace/src/index.js#L44-L49

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `replace`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
