### PR TITLE
fix(alias): pass on isEntry flag and custom options

### DIFF
--- a/packages/alias/package.json
+++ b/packages/alias/package.json
@@ -54,7 +54,7 @@
     "@rollup/plugin-node-resolve": "^8.4.0",
     "@rollup/plugin-typescript": "^5.0.2",
     "del-cli": "^3.0.1",
-    "rollup": "^2.23.0",
+    "rollup": "^2.58.0",
     "typescript": "^4.1.2"
   },
   "types": "types/index.d.ts",

--- a/packages/alias/src/index.ts
+++ b/packages/alias/src/index.ts
@@ -83,7 +83,7 @@ export default function alias(options: RollupAliasOptions = {}): Plugin {
         // enforce void return value
       });
     },
-    resolveId(importee, importer) {
+    resolveId(importee, importer, resolveOptions) {
       const importeeId = normalizeId(importee);
       const importerId = normalizeId(importer);
 
@@ -99,10 +99,14 @@ export default function alias(options: RollupAliasOptions = {}): Plugin {
 
       const customResolver = getCustomResolver(matchedEntry, options);
       if (customResolver) {
-        return customResolver.call(this, updatedId, importerId, {});
+        return customResolver.call(this, updatedId, importerId, resolveOptions);
       }
 
-      return this.resolve(updatedId, importer, { skipSelf: true }).then((resolved) => {
+      return this.resolve(
+        updatedId,
+        importer,
+        Object.assign({ skipSelf: true }, resolveOptions)
+      ).then((resolved) => {
         let finalResult: PartialResolvedId | null = resolved;
         if (!finalResult) {
           finalResult = { id: updatedId };

--- a/packages/alias/test/test.js
+++ b/packages/alias/test/test.js
@@ -32,8 +32,10 @@ function resolveWithRollup(plugins, tests) {
               // The buildStart hook is the first to have access to this.resolve
               // We map the tests to an array of resulting ids
               Promise.all(
-                tests.map(({ source, importer }) =>
-                  this.resolve(source, importer).then((result) => (result ? result.id : null))
+                tests.map(({ source, importer, options }) =>
+                  this.resolve(source, importer, options).then((result) =>
+                    result ? result.id : null
+                  )
                 )
               )
             );
@@ -437,3 +439,95 @@ test('Alias + rollup-plugin-node-resolve', (t) =>
           )
         );
     }));
+
+test('Forwards isEntry and custom options to a custom resolver', (t) => {
+  const resolverCalls = [];
+  return resolveAliasWithRollup(
+    {
+      entries: {
+        entry: 'entry-point',
+        nonEntry: 'non-entry-point'
+      },
+      customResolver: (...args) => {
+        resolverCalls.push(args);
+        return args[0];
+      }
+    },
+    [
+      { source: 'entry', importer: '/src/importer.js', options: { isEntry: true } },
+      {
+        source: 'nonEntry',
+        importer: '/src/importer.js',
+        options: { isEntry: false, custom: { test: 42 } }
+      }
+    ]
+  ).then((result) => {
+    t.deepEqual(resolverCalls, [
+      [
+        'entry-point',
+        '/src/importer.js',
+        {
+          custom: void 0,
+          isEntry: true
+        }
+      ],
+      [
+        'non-entry-point',
+        '/src/importer.js',
+        {
+          custom: { test: 42 },
+          isEntry: false
+        }
+      ]
+    ]);
+    t.deepEqual(result, ['entry-point', 'non-entry-point']);
+  });
+});
+
+test('Forwards isEntry and custom options to other plugins', (t) => {
+  const resolverCalls = [];
+  return resolveWithRollup(
+    [
+      alias({
+        entries: {
+          entry: 'entry-point',
+          nonEntry: 'non-entry-point'
+        }
+      }),
+      {
+        name: 'test',
+        resolveId(...args) {
+          resolverCalls.push(args);
+        }
+      }
+    ],
+    [
+      { source: 'entry', importer: '/src/importer.js', options: { isEntry: true } },
+      {
+        source: 'nonEntry',
+        importer: '/src/importer.js',
+        options: { isEntry: false, custom: { test: 42 } }
+      }
+    ]
+  ).then((result) => {
+    t.deepEqual(resolverCalls, [
+      [
+        'entry-point',
+        '/src/importer.js',
+        {
+          custom: void 0,
+          isEntry: true
+        }
+      ],
+      [
+        'non-entry-point',
+        '/src/importer.js',
+        {
+          custom: { test: 42 },
+          isEntry: false
+        }
+      ]
+    ]);
+    t.deepEqual(result, ['entry-point', 'non-entry-point']);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,16 +71,16 @@ importers:
       '@rollup/plugin-node-resolve': ^8.4.0
       '@rollup/plugin-typescript': ^5.0.2
       del-cli: ^3.0.1
-      rollup: ^2.23.0
+      rollup: ^2.58.0
       slash: ^3.0.0
       typescript: ^4.1.2
     dependencies:
       slash: 3.0.0
     devDependencies:
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.32.1
-      '@rollup/plugin-typescript': 5.0.2_rollup@2.32.1+typescript@4.1.2
+      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.58.0
+      '@rollup/plugin-typescript': 5.0.2_rollup@2.58.0+typescript@4.1.2
       del-cli: 3.0.1
-      rollup: 2.32.1
+      rollup: 2.58.0
       typescript: 4.1.2
 
   packages/auto-install:
@@ -2197,6 +2197,22 @@ packages:
       rollup: 2.39.0
     dev: true
 
+  /@rollup/plugin-node-resolve/8.4.0_rollup@2.58.0:
+    resolution: {integrity: sha512-LFqKdRLn0ShtQyf6SBYO69bGE1upV6wUhBX0vFOUnLAyzx5cwp8svA0eHUnu8+YU57XOkrMtfG63QOpQx25pHQ==}
+    engines: {node: '>= 8.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0
+    dependencies:
+      '@rollup/pluginutils': 3.1.0_rollup@2.58.0
+      '@types/resolve': 1.17.1
+      builtin-modules: 3.1.0
+      deep-freeze: 0.0.1
+      deepmerge: 4.2.2
+      is-module: 1.0.0
+      resolve: 1.20.0
+      rollup: 2.58.0
+    dev: true
+
   /@rollup/plugin-node-resolve/9.0.0_rollup@2.32.1:
     resolution: {integrity: sha512-gPz+utFHLRrd41WMP13Jq5mqqzHL3OXrfj3/MkSyB6UBIcuNt9j60GCbarzMzdf1VHFpOxfQh/ez7wyadLMqkg==}
     engines: {node: '>= 10.0.0'}
@@ -2238,6 +2254,20 @@ packages:
       resolve: 1.20.0
       rollup: 2.32.1
       typescript: 4.2.4
+    dev: true
+
+  /@rollup/plugin-typescript/5.0.2_rollup@2.58.0+typescript@4.1.2:
+    resolution: {integrity: sha512-CkS028Itwjqm1uLbFVfpJgtVtnNvZ+og/m6UlNRR5wOOnNTWPcVQzOu5xGdEX+WWJxdvWIqUq2uR/RBt2ZipWg==}
+    engines: {node: '>=8.0.0'}
+    peerDependencies:
+      rollup: ^2.14.0
+      tslib: '*'
+      typescript: '>=3.4.0'
+    dependencies:
+      '@rollup/pluginutils': 3.1.0_rollup@2.58.0
+      resolve: 1.20.0
+      rollup: 2.58.0
+      typescript: 4.1.2
     dev: true
 
   /@rollup/plugin-typescript/6.1.0_rollup@2.32.1+typescript@4.1.2:
@@ -2294,6 +2324,18 @@ packages:
       estree-walker: 1.0.1
       picomatch: 2.2.2
       rollup: 2.47.0
+
+  /@rollup/pluginutils/3.1.0_rollup@2.58.0:
+    resolution: {integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==}
+    engines: {node: '>= 8.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0
+    dependencies:
+      '@types/estree': 0.0.39
+      estree-walker: 1.0.1
+      picomatch: 2.2.2
+      rollup: 2.58.0
+    dev: true
 
   /@rollup/pluginutils/4.1.1:
     resolution: {integrity: sha512-clDjivHqWGXi7u+0d2r2sBi4Ie6VLEAzWMIkvJLnDmxoOhBYOTfzGbOQBA32THHm11/LiJbd01tJUpJsbshSWQ==}
@@ -7346,6 +7388,14 @@ packages:
 
   /rollup/2.54.0:
     resolution: {integrity: sha512-RHzvstAVwm9A751NxWIbGPFXs3zL4qe/eYg+N7WwGtIXVLy1cK64MiU37+hXeFm1jqipK6DGgMi6Z2hhPuCC3A==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
+  /rollup/2.58.0:
+    resolution: {integrity: sha512-NOXpusKnaRpbS7ZVSzcEXqxcLDOagN6iFS8p45RkoiMqPHDLwJm758UF05KlMoCRbLBTZsPOIa887gZJ1AiXvw==}
     engines: {node: '>=10.0.0'}
     hasBin: true
     optionalDependencies:


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `alias`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description
This is similar to #1016 but this time for the "alias" plugin. It will forward both the "isEntry" flag and the "custom" option on other plugins for further resolving.