### PR TITLE
refactor(alias): avoid resolving customResolver every time handling resolveId

### DIFF
--- a/packages/alias/src/index.ts
+++ b/packages/alias/src/index.ts
@@ -1,8 +1,6 @@
-import { PartialResolvedId, Plugin } from 'rollup';
+import { Plugin } from 'rollup';
 
-import { Alias, ResolverFunction, RollupAliasOptions } from '../types';
-
-const noop = () => null;
+import { ResolvedAlias, ResolverFunction, ResolverObject, RollupAliasOptions } from '../types';
 
 function matches(pattern: string | RegExp, importee: string) {
   if (pattern instanceof RegExp) {
@@ -14,46 +12,42 @@ function matches(pattern: string | RegExp, importee: string) {
   if (importee === pattern) {
     return true;
   }
-  const importeeStartsWithKey = importee.indexOf(pattern) === 0;
-  const importeeHasSlashAfterKey = importee.substring(pattern.length)[0] === '/';
-  return importeeStartsWithKey && importeeHasSlashAfterKey;
+  // eslint-disable-next-line prefer-template
+  return importee.startsWith(pattern + '/');
 }
 
-function normalizeId(id: string): string;
-function normalizeId(id: string | undefined): string | undefined;
-function normalizeId(id: string | undefined) {
-  return id;
-}
-
-function getEntries({ entries }: RollupAliasOptions): readonly Alias[] {
+function getEntries({ entries, customResolver }: RollupAliasOptions): readonly ResolvedAlias[] {
   if (!entries) {
     return [];
   }
 
+  const resolverFunctionFromOptions = resolveCustomResolver(customResolver);
+
   if (Array.isArray(entries)) {
-    return entries;
+    return entries.map((entry) => {
+      return {
+        find: entry.find,
+        replacement: entry.replacement,
+        resolverFunction: resolveCustomResolver(entry.customResolver) || resolverFunctionFromOptions
+      };
+    });
   }
 
   return Object.entries(entries).map(([key, value]) => {
-    return { find: key, replacement: value };
+    return { find: key, replacement: value, resolverFunction: resolverFunctionFromOptions };
   });
 }
 
-function getCustomResolver(
-  { customResolver }: Alias,
-  options: RollupAliasOptions
+function resolveCustomResolver(
+  customResolver: ResolverFunction | ResolverObject | null | undefined
 ): ResolverFunction | null {
-  if (typeof customResolver === 'function') {
-    return customResolver;
-  }
-  if (customResolver && typeof customResolver.resolveId === 'function') {
-    return customResolver.resolveId;
-  }
-  if (typeof options.customResolver === 'function') {
-    return options.customResolver;
-  }
-  if (options.customResolver && typeof options.customResolver.resolveId === 'function') {
-    return options.customResolver.resolveId;
+  if (customResolver) {
+    if (typeof customResolver === 'function') {
+      return customResolver;
+    }
+    if (typeof customResolver.resolveId === 'function') {
+      return customResolver.resolveId;
+    }
   }
   return null;
 }
@@ -64,56 +58,42 @@ export default function alias(options: RollupAliasOptions = {}): Plugin {
   if (entries.length === 0) {
     return {
       name: 'alias',
-      resolveId: noop
+      resolveId: () => null
     };
   }
 
   return {
     name: 'alias',
-    buildStart(inputOptions) {
-      return Promise.all(
-        [...entries, options].map(
+    async buildStart(inputOptions) {
+      await Promise.all(
+        [...(Array.isArray(options.entries) ? options.entries : []), options].map(
           ({ customResolver }) =>
             customResolver &&
             typeof customResolver === 'object' &&
             typeof customResolver.buildStart === 'function' &&
             customResolver.buildStart.call(this, inputOptions)
         )
-      ).then(() => {
-        // enforce void return value
-      });
+      );
     },
-    resolveId(importee, importer, resolveOptions) {
-      const importeeId = normalizeId(importee);
-      const importerId = normalizeId(importer);
-
+    resolveId(importee, importer) {
+      if (!importer) {
+        return null;
+      }
       // First match is supposed to be the correct one
-      const matchedEntry = entries.find((entry) => matches(entry.find, importeeId));
-      if (!matchedEntry || !importerId) {
+      const matchedEntry = entries.find((entry) => matches(entry.find, importee));
+      if (!matchedEntry) {
         return null;
       }
 
-      const updatedId = normalizeId(
-        importeeId.replace(matchedEntry.find, matchedEntry.replacement)
-      );
+      const updatedId = importee.replace(matchedEntry.find, matchedEntry.replacement);
 
-      const customResolver = getCustomResolver(matchedEntry, options);
-      if (customResolver) {
-        return customResolver.call(this, updatedId, importerId, resolveOptions);
+      if (matchedEntry.resolverFunction) {
+        return matchedEntry.resolverFunction.call(this, updatedId, importer, {});
       }
 
-      return this.resolve(
-        updatedId,
-        importer,
-        Object.assign({ skipSelf: true }, resolveOptions)
-      ).then((resolved) => {
-        let finalResult: PartialResolvedId | null = resolved;
-        if (!finalResult) {
-          finalResult = { id: updatedId };
-        }
-
-        return finalResult;
-      });
+      return this.resolve(updatedId, importer, { skipSelf: true }).then(
+        (resolved) => resolved || { id: updatedId }
+      );
     }
   };
 }

--- a/packages/alias/src/index.ts
+++ b/packages/alias/src/index.ts
@@ -75,7 +75,7 @@ export default function alias(options: RollupAliasOptions = {}): Plugin {
         )
       );
     },
-    resolveId(importee, importer) {
+    resolveId(importee, importer, resolveOptions) {
       if (!importer) {
         return null;
       }
@@ -88,12 +88,14 @@ export default function alias(options: RollupAliasOptions = {}): Plugin {
       const updatedId = importee.replace(matchedEntry.find, matchedEntry.replacement);
 
       if (matchedEntry.resolverFunction) {
-        return matchedEntry.resolverFunction.call(this, updatedId, importer, {});
+        return matchedEntry.resolverFunction.call(this, updatedId, importer, resolveOptions);
       }
 
-      return this.resolve(updatedId, importer, { skipSelf: true }).then(
-        (resolved) => resolved || { id: updatedId }
-      );
+      return this.resolve(
+        updatedId,
+        importer,
+        Object.assign({ skipSelf: true }, resolveOptions)
+      ).then((resolved) => resolved || { id: updatedId });
     }
   };
 }

--- a/packages/alias/test/test.js
+++ b/packages/alias/test/test.js
@@ -32,10 +32,8 @@ function resolveWithRollup(plugins, tests) {
               // The buildStart hook is the first to have access to this.resolve
               // We map the tests to an array of resulting ids
               Promise.all(
-                tests.map(({ source, importer, options }) =>
-                  this.resolve(source, importer, options).then((result) =>
-                    result ? result.id : null
-                  )
+                tests.map(({ source, importer }) =>
+                  this.resolve(source, importer).then((result) => (result ? result.id : null))
                 )
               )
             );
@@ -440,94 +438,36 @@ test('Alias + rollup-plugin-node-resolve', (t) =>
         );
     }));
 
-test('Forwards isEntry and custom options to a custom resolver', (t) => {
-  const resolverCalls = [];
+test('CustomResolver plugin-like object with buildStart', (t) => {
+  const count = {
+    entry: 0,
+    option: 0
+  };
   return resolveAliasWithRollup(
     {
-      entries: {
-        entry: 'entry-point',
-        nonEntry: 'non-entry-point'
-      },
-      customResolver: (...args) => {
-        resolverCalls.push(args);
-        return args[0];
+      entries: [
+        {
+          find: 'this',
+          replacement: path.resolve('./that.jsx'),
+          customResolver: {
+            resolveId: () => 'custom Resolver',
+            buildStart: () => (count.entry += 1)
+          }
+        },
+        {
+          find: 'that',
+          replacement: ''
+        }
+      ],
+      customResolver: {
+        buildStart: () => (count.option += 1)
       }
     },
-    [
-      { source: 'entry', importer: '/src/importer.js', options: { isEntry: true } },
-      {
-        source: 'nonEntry',
-        importer: '/src/importer.js',
-        options: { isEntry: false, custom: { test: 42 } }
-      }
-    ]
-  ).then((result) => {
-    t.deepEqual(resolverCalls, [
-      [
-        'entry-point',
-        '/src/importer.js',
-        {
-          custom: void 0,
-          isEntry: true
-        }
-      ],
-      [
-        'non-entry-point',
-        '/src/importer.js',
-        {
-          custom: { test: 42 },
-          isEntry: false
-        }
-      ]
-    ]);
-    t.deepEqual(result, ['entry-point', 'non-entry-point']);
-  });
-});
-
-test('Forwards isEntry and custom options to other plugins', (t) => {
-  const resolverCalls = [];
-  return resolveWithRollup(
-    [
-      alias({
-        entries: {
-          entry: 'entry-point',
-          nonEntry: 'non-entry-point'
-        }
-      }),
-      {
-        name: 'test',
-        resolveId(...args) {
-          resolverCalls.push(args);
-        }
-      }
-    ],
-    [
-      { source: 'entry', importer: '/src/importer.js', options: { isEntry: true } },
-      {
-        source: 'nonEntry',
-        importer: '/src/importer.js',
-        options: { isEntry: false, custom: { test: 42 } }
-      }
-    ]
-  ).then((result) => {
-    t.deepEqual(resolverCalls, [
-      [
-        'entry-point',
-        '/src/importer.js',
-        {
-          custom: void 0,
-          isEntry: true
-        }
-      ],
-      [
-        'non-entry-point',
-        '/src/importer.js',
-        {
-          custom: { test: 42 },
-          isEntry: false
-        }
-      ]
-    ]);
-    t.deepEqual(result, ['entry-point', 'non-entry-point']);
-  });
+    []
+  ).then(() =>
+    t.deepEqual(count, {
+      entry: 1,
+      option: 1
+    })
+  );
 });

--- a/packages/alias/types/index.d.ts
+++ b/packages/alias/types/index.d.ts
@@ -13,6 +13,12 @@ export interface Alias {
   customResolver?: ResolverFunction | ResolverObject | null;
 }
 
+export interface ResolvedAlias {
+  find: string | RegExp;
+  replacement: string;
+  resolverFunction: ResolverFunction | null;
+}
+
 export interface RollupAliasOptions {
   /**
    * Instructs the plugin to use an alternative resolving algorithm,


### PR DESCRIPTION
## Rollup Plugin Name: `@rollup/plugin-alias`

This PR contains:

- [ ] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

### Description

This PR removes useless functions and avoid resolving customResolver every time handling resolved.

The previous one (#1000 ) contains a bug that was not detected by the tests (https://github.com/rollup/plugins/pull/1000#issuecomment-946898964). This PR fixes the bug and adds a test for it.

/cc @shellscape I'm very sorry for the trouble I caused.