### PR TITLE
feat(graphql): support .graphqls files

### DIFF
--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -9,7 +9,7 @@
 
 # @rollup/plugin-graphql
 
-🍣 A Rollup plugin which Converts .gql/.graphql files to ES6 modules.
+🍣 A Rollup plugin which Converts .gql/.graphql(s) files to ES6 modules.
 
 ## Requirements
 

--- a/packages/graphql/src/index.js
+++ b/packages/graphql/src/index.js
@@ -6,8 +6,8 @@ import { toESModules } from './toESModules';
 export default function graphql({ include, exclude } = {}) {
   // path filter
   const filter = createFilter(include, exclude);
-  // only .graphql and .gql files
-  const filterExt = /\.(graphql|gql)$/i;
+  // only .graphql, .graphqls (schema), and .gql files
+  const filterExt = /\.(graphqls?|gql)$/i;
 
   return {
     name: 'graphql',

--- a/packages/graphql/test/fixtures/graphqls/index.js
+++ b/packages/graphql/test/fixtures/graphqls/index.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export { default as doc } from './schema.graphqls';

--- a/packages/graphql/test/fixtures/graphqls/schema.graphqls
+++ b/packages/graphql/test/fixtures/graphqls/schema.graphqls
@@ -1,0 +1,4 @@
+type Hero {
+  id: ID!
+  name: String!
+}

--- a/packages/graphql/test/test.js
+++ b/packages/graphql/test/test.js
@@ -50,3 +50,15 @@ test('should support multi-imports', async (t) => {
   t.is(module.exports.GetHeros.kind, 'Document');
   t.is(module.exports.GetHeros.definitions[0].name.value, 'GetHeros');
 });
+
+test('should support graphqls schema files', async (t) => {
+  const bundle = await rollup({
+    input: 'fixtures/graphqls/index.js',
+    plugins: [graphql()]
+  });
+
+  const { module } = await testBundle(t, bundle);
+
+  t.truthy('doc' in module.exports);
+  t.is(module.exports.doc.kind, 'Document');
+});


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `plugin-graphql`

This PR contains:

- [ ] bugfix
- [X] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [X] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [X] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

Closes #1027

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

This PR adds automatic support for `.graphqls` files, which are used by some tools (gqlgen, spring, maybe others) as schema definition files.  It didn't seem worthwhile to make this user-configurable, but I could if desired.  