### PR TITLE
fix(node-resolve): fix error when `custom` resolve option missing

### DIFF
--- a/packages/node-resolve/src/index.js
+++ b/packages/node-resolve/src/index.js
@@ -260,7 +260,12 @@ export function nodeResolve(opts = {}) {
         importer = undefined;
       }
 
-      const resolved = await doResolveId(this, importee, importer, resolveOptions.custom);
+      const resolved = await doResolveId(
+        this,
+        importee,
+        importer,
+        resolveOptions && resolveOptions.custom
+      );
       if (resolved) {
         const resolvedResolved = await this.resolve(
           resolved.id,


### PR DESCRIPTION
## Rollup Plugin Name: `node-resolve`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers: fixes #1023

### Description
I think older rollup versions will not provide `custom`, so we should handle it being `undefined`, as we did before https://github.com/rollup/plugins/pull/1016

There is not test for this, but to test it we either need to fake a call or somehow being in an older rollup version for the test.