### PR TITLE
fix(typescript): add error location to warnings

### DIFF
--- a/packages/typescript/src/diagnostics/toWarning.ts
+++ b/packages/typescript/src/diagnostics/toWarning.ts
@@ -27,7 +27,11 @@ export default function diagnosticToWarning(
       line: line + 1,
       file: diagnostic.file.fileName
     };
-
+    
+    warning.message += `
+        In ${warning.loc.file}:${warning.loc.line}:${warning.loc.column}
+    `;
+    
     if (host) {
       // Extract a code frame from Typescript
       const formatted = ts.formatDiagnosticsWithColorAndContext([diagnostic], host);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `{name}`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers: closes #1041 

### Description

When running the plugin and running into a typescript error, only the error message appears without the location of the error. This PR adds the location of the error to the logged message so the developer would be able to easily fix the typescript error.
