### PR TITLE
test(node-resolve): add tests for mixing custom `exportConditions` with `browser: true`

### DIFF
--- a/packages/node-resolve/test/fixtures/exports-only-worker-condition-with-browser-field.js
+++ b/packages/node-resolve/test/fixtures/exports-only-worker-condition-with-browser-field.js
@@ -1,0 +1,3 @@
+import sample from 'exports-only-worker-condition-with-browser-field';
+
+export default sample;

--- a/packages/node-resolve/test/fixtures/exports-worker-condition-with-browser-field.js
+++ b/packages/node-resolve/test/fixtures/exports-worker-condition-with-browser-field.js
@@ -1,0 +1,3 @@
+import sample from 'exports-worker-condition-with-browser-field';
+
+export default sample;

--- a/packages/node-resolve/test/fixtures/node_modules/exports-only-worker-condition-with-browser-field/browser-field-entry.js
+++ b/packages/node-resolve/test/fixtures/node_modules/exports-only-worker-condition-with-browser-field/browser-field-entry.js
@@ -1,0 +1,1 @@
+export default "FROM BROWSER FIELD";

--- a/packages/node-resolve/test/fixtures/node_modules/exports-only-worker-condition-with-browser-field/package.json
+++ b/packages/node-resolve/test/fixtures/node_modules/exports-only-worker-condition-with-browser-field/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "exports-only-worker-condition-with-browser-field",
+  "exports": {
+    "webworker": "./webworker-condition-entry.js"
+  },
+  "browser": "./browser-field-entry.js"
+}

--- a/packages/node-resolve/test/fixtures/node_modules/exports-only-worker-condition-with-browser-field/webworker-condition-entry.js
+++ b/packages/node-resolve/test/fixtures/node_modules/exports-only-worker-condition-with-browser-field/webworker-condition-entry.js
@@ -1,0 +1,1 @@
+export default "FROM WEBWORKER CONDITION";

--- a/packages/node-resolve/test/fixtures/node_modules/exports-worker-condition-with-browser-field/browser-condition-entry.js
+++ b/packages/node-resolve/test/fixtures/node_modules/exports-worker-condition-with-browser-field/browser-condition-entry.js
@@ -1,0 +1,1 @@
+export default "FROM BROWSER CONDITION";

--- a/packages/node-resolve/test/fixtures/node_modules/exports-worker-condition-with-browser-field/browser-field-entry.js
+++ b/packages/node-resolve/test/fixtures/node_modules/exports-worker-condition-with-browser-field/browser-field-entry.js
@@ -1,0 +1,1 @@
+export default "FROM BROWSER FIELD";

--- a/packages/node-resolve/test/fixtures/node_modules/exports-worker-condition-with-browser-field/package.json
+++ b/packages/node-resolve/test/fixtures/node_modules/exports-worker-condition-with-browser-field/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "exports-worker-condition-with-browser-field",
+  "exports": {
+    "webworker": "./webworker-condition-entry.js",
+    "browser": "./browser-condition-entry.js"
+  },
+  "browser": "./browser-field-entry.js"
+}

--- a/packages/node-resolve/test/fixtures/node_modules/exports-worker-condition-with-browser-field/webworker-condition-entry.js
+++ b/packages/node-resolve/test/fixtures/node_modules/exports-worker-condition-with-browser-field/webworker-condition-entry.js
@@ -1,0 +1,1 @@
+export default "FROM WEBWORKER CONDITION";

--- a/packages/node-resolve/test/package-entry-points.js
+++ b/packages/node-resolve/test/package-entry-points.js
@@ -380,3 +380,23 @@ test('does not warn when resolving typescript imports with fallback', async (t) 
     a: 'A'
   });
 });
+
+test('custom condition takes precedence over browser field and condition with `browser: true`', async (t) => {
+  const bundle = await rollup({
+    input: 'exports-worker-condition-with-browser-field.js',
+    plugins: [nodeResolve({ exportConditions: ['browser', 'webworker'], browser: true })]
+  });
+  const { module } = await testBundle(t, bundle);
+
+  t.deepEqual(module.exports, 'FROM WEBWORKER CONDITION');
+});
+
+test('custom condition takes precedence over browser field with `browser: true`', async (t) => {
+  const bundle = await rollup({
+    input: 'exports-only-worker-condition-with-browser-field.js',
+    plugins: [nodeResolve({ exportConditions: ['browser', 'webworker'], browser: true })]
+  });
+  const { module } = await testBundle(t, bundle);
+
+  t.deepEqual(module.exports, 'FROM WEBWORKER CONDITION');
+});


### PR DESCRIPTION
## Rollup Plugin Name: `@rollup/plugin-node-resolve`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes
- [x] no

### Description

I was wondering if this would work correctly - I've figured out that the quickest way to found out would be to check the test suite but I couldn't find **any** `exportConditions`-related test. The only place where "exportCondition:" string appears in the codebase is this type test:
https://github.com/rollup/plugins/blob/53776ee3fc59587fe5ff0c756216185f48372507/packages/node-resolve/test/types.ts#L14

Since it felt like such tests are missing, I've decided to just add them 😉 