### PR TITLE
fix(typescript): allow explicity compilerOptions

### DIFF
--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -58,7 +58,7 @@ The plugin loads any [`compilerOptions`](http://www.typescriptlang.org/docs/hand
 export default {
   input: './main.ts',
   plugins: [
-      typescript({lib: ["es5", "es6", "dom"], target: "es5"})
+      typescript({ compilerOptions: {lib: ["es5", "es6", "dom"], target: "es5"}})
   ]
 }
 ```
@@ -252,7 +252,7 @@ import commonjs from '@rollup/plugin-commonjs';
 export default {
   input: './main.ts',
   plugins: [
-    typescript({ module: 'CommonJS' }),
+    typescript({ compilerOptions: { module: 'CommonJS' } }),
     commonjs({ extensions: ['.js', '.ts'] }) // the ".ts" extension is required
   ]
 };
@@ -282,7 +282,7 @@ import typescript from '@rollup/plugin-typescript';
 export default {
   // … other options …
   acornInjectPlugins: [jsx()],
-  plugins: [typescript({ jsx: 'preserve' })]
+  plugins: [typescript({ compilerOptions: { jsx: 'preserve' } })]
 };
 ```
 

--- a/packages/typescript/src/options/plugin.ts
+++ b/packages/typescript/src/options/plugin.ts
@@ -24,7 +24,9 @@ export const getPluginOptions = (options: RollupTypescriptOptions) => {
     tslib,
     typescript,
     outputToFilesystem,
-    ...compilerOptions
+    compilerOptions,
+    // previously was compilerOptions
+    ...extra
   } = options;
 
   return {
@@ -33,7 +35,7 @@ export const getPluginOptions = (options: RollupTypescriptOptions) => {
     exclude,
     filterRoot,
     tsconfig,
-    compilerOptions: compilerOptions as PartialCompilerOptions,
+    compilerOptions: { ...extra, ...compilerOptions } as PartialCompilerOptions,
     typescript: typescript || defaultTs,
     tslib: tslib || getTsLibPath(),
     transformers,

--- a/packages/typescript/test/test.js
+++ b/packages/typescript/test/test.js
@@ -28,6 +28,20 @@ test.serial('runs code through typescript', async (t) => {
   t.false(code.includes('const'), code);
 });
 
+test.serial('runs code through typescript with compilerOptions', async (t) => {
+  const bundle = await rollup({
+    input: 'fixtures/basic/main.ts',
+    plugins: [
+      typescript({ tsconfig: 'fixtures/basic/tsconfig.json', compilerOptions: { target: 'es5' } })
+    ],
+    onwarn
+  });
+  const code = await getCode(bundle, outputOptions);
+
+  t.false(code.includes('number'), code);
+  t.false(code.includes('const'), code);
+});
+
 test.serial('ensures outDir is located in Rollup output dir', async (t) => {
   const bundle = await rollup({
     input: 'fixtures/basic/main.ts',

--- a/packages/typescript/types/index.d.ts
+++ b/packages/typescript/types/index.d.ts
@@ -79,6 +79,10 @@ export interface RollupTypescriptPluginOptions {
    * If not set, will default to true with a warning.
    */
   outputToFilesystem?: boolean;
+  /**
+   * Pass additional compiler options to the plugin.
+   */
+  compilerOptions?: PartialCompilerOptions;
 }
 
 export interface FlexibleCompilerOptions extends CompilerOptions {


### PR DESCRIPTION
## Rollup Plugin Name: `typescript`

This PR contains:

- [ ] bugfix
- [ ] feature
- [x] refactor
- [x] documentation
- [ ] other

Are tests included?

- [x] yes
- [ ] no

Breaking Changes?

- [x] yes
- [ ] no

List any relevant issue numbers:

### Description
Allow explicitly setting compiler options instead of using rest syntax. This is less confusing in documentation and rollup config. It is also less fragile.

An alternative (see rollup-plugin-typescript2) would be to pull all tsconfig overrides out.

```js
{
...
tsconfigOverrides: {
    compilerOptions: {},
    include: [...]
  }
}
```