### PR TITLE
feat(pluginutils): support bigint and symbol in dataToEsm

### DIFF
--- a/packages/pluginutils/src/dataToEsm.ts
+++ b/packages/pluginutils/src/dataToEsm.ts
@@ -50,10 +50,9 @@ function serialize(obj: unknown, indent: Indent, baseIndent: string): string {
   if (typeof obj === 'bigint') return `${obj}n`;
   if (typeof obj === 'symbol') {
     const key = Symbol.keyFor(obj);
-    if (key === undefined) throw TypeError('dataToEsm can not serialize symbol');
-    return `Symbol.for(${stringify(key)})`;
+    return key === undefined ? 'undefined' : `Symbol.for(${stringify(key)})`;
   }
-  if (typeof obj === 'function') throw TypeError('dataToEsm can not serialize function');
+  if (typeof obj === 'function') return 'undefined';
   return stringify(obj);
 }
 

--- a/packages/pluginutils/src/dataToEsm.ts
+++ b/packages/pluginutils/src/dataToEsm.ts
@@ -4,7 +4,7 @@ import makeLegalIdentifier from './makeLegalIdentifier';
 
 export type Indent = string | null | undefined;
 
-function stringify(val: boolean | number | string): string {
+function stringify(val: unknown): string {
   return JSON.stringify(val).replace(
     /[\u2028\u2029]/g,
     (char) => `\\u${`000${char.charCodeAt(0).toString(16)}`.slice(-4)}`

--- a/packages/pluginutils/src/dataToEsm.ts
+++ b/packages/pluginutils/src/dataToEsm.ts
@@ -4,8 +4,8 @@ import makeLegalIdentifier from './makeLegalIdentifier';
 
 export type Indent = string | null | undefined;
 
-function stringify(val: unknown): string {
-  return JSON.stringify(val).replace(
+function stringify(obj: unknown): string {
+  return JSON.stringify(obj).replace(
     /[\u2028\u2029]/g,
     (char) => `\\u${`000${char.charCodeAt(0).toString(16)}`.slice(-4)}`
   );

--- a/packages/pluginutils/src/dataToEsm.ts
+++ b/packages/pluginutils/src/dataToEsm.ts
@@ -38,7 +38,7 @@ function serializeObject(obj: object, indent: Indent, baseIndent: string): strin
 }
 
 function serialize(obj: unknown, indent: Indent, baseIndent: string): string {
-  if (typpeof obj === 'object' && obj !== null) {
+  if (typeof obj === 'object' && obj !== null) {
     if (Array.isArray(obj)) return serializeArray(obj, indent, baseIndent);
     if (obj instanceof Date) return `new Date(${obj.getTime()})`;
     if (obj instanceof RegExp) return obj.toString();

--- a/packages/pluginutils/src/dataToEsm.ts
+++ b/packages/pluginutils/src/dataToEsm.ts
@@ -42,7 +42,7 @@ function serialize(obj: unknown, indent: Indent, baseIndent: string): string {
     if (Array.isArray(obj)) return serializeArray(obj, indent, baseIndent);
     if (obj instanceof Date) return `new Date(${obj.getTime()})`;
     if (obj instanceof RegExp) return obj.toString();
-    return serializeObject(obj!, indent, baseIndent);
+    return serializeObject(obj, indent, baseIndent);
   }
   if (typeof obj === 'number') {
     if (obj === Infinity) return 'Infinity';

--- a/packages/pluginutils/test/dataToEsm.ts
+++ b/packages/pluginutils/test/dataToEsm.ts
@@ -12,7 +12,7 @@ test('support bigint', (t) => {
 test('support symbol', (t) => {
   t.is(
     dataToEsm({ normal: Symbol.for('key'), empty: Symbol.for('') }),
-    'export var normal = Symbol.for("key");\nexport var symbol = Symbol.for("");\nexport default {\n\tnormal: normal,\n\tempty: empty\n};\n'
+    'export var normal = Symbol.for("key");\nexport var empty = Symbol.for("");\nexport default {\n\tnormal: normal,\n\tempty: empty\n};\n'
   );
 });
 

--- a/packages/pluginutils/test/dataToEsm.ts
+++ b/packages/pluginutils/test/dataToEsm.ts
@@ -2,6 +2,13 @@ import test from 'ava';
 
 import { dataToEsm } from '../';
 
+test('support bigint and symbol', (t) => {
+  t.is(
+    dataToEsm({ bigint: 0, symbol: Symbol.for('') }),
+    'export var bigint = 0n;\nexport var symbol = Symbol.for("");\nexport default {\n\tbigint: bigint,\n\tsymbol: symbol\n};\n'
+  );
+});
+
 test('outputs treeshakeable data', (t) => {
   t.is(
     dataToEsm({ some: 'data', another: 'data' }),

--- a/packages/pluginutils/test/dataToEsm.ts
+++ b/packages/pluginutils/test/dataToEsm.ts
@@ -4,15 +4,15 @@ import { dataToEsm } from '../';
 
 test('support bigint', (t) => {
   t.is(
-    dataToEsm({ bigint: 0n }),
-    'export var bigint = 0n;\nexport default {\n\tbigint: bigint\n};\n'
+    dataToEsm({ positive: 0n, negative: -1n }),
+    'export var positive = 0n;\nexport var negative = -1n;\nexport default {\n\tpositive: positive,\n\tnegative: negative\n};\n'
   );
 });
 
 test('support symbol', (t) => {
   t.is(
-    dataToEsm({ symbol: Symbol.for('') }),
-    'export var symbol = Symbol.for("");\nexport default {\n\tsymbol: symbol\n};\n'
+    dataToEsm({ normal: Symbol.for('key'), empty: Symbol.for('') }),
+    'export var normal = Symbol.for("key");\nexport var symbol = Symbol.for("");\nexport default {\n\tnormal: normal,\n\tempty: empty\n};\n'
   );
 });
 

--- a/packages/pluginutils/test/dataToEsm.ts
+++ b/packages/pluginutils/test/dataToEsm.ts
@@ -2,10 +2,17 @@ import test from 'ava';
 
 import { dataToEsm } from '../';
 
-test('support bigint and symbol', (t) => {
+test('support bigint', (t) => {
   t.is(
-    dataToEsm({ bigint: 0, symbol: Symbol.for('') }),
-    'export var bigint = 0n;\nexport var symbol = Symbol.for("");\nexport default {\n\tbigint: bigint,\n\tsymbol: symbol\n};\n'
+    dataToEsm({ bigint: 0n }),
+    'export var bigint = 0n;\nexport default {\n\tbigint: bigint\n};\n'
+  );
+});
+
+test('support symbol', (t) => {
+  t.is(
+    dataToEsm({ symbol: Symbol.for('') }),
+    'export var symbol = Symbol.for("");\nexport default {\n\tsymbol: symbol\n};\n'
   );
 });
 

--- a/packages/pluginutils/test/dataToEsm.ts
+++ b/packages/pluginutils/test/dataToEsm.ts
@@ -4,7 +4,7 @@ import { dataToEsm } from '../';
 
 test('support bigint', (t) => {
   t.is(
-    dataToEsm({ positive: 0n, negative: -1n }),
+    dataToEsm({ positive: BigInt('0'), negative: BigInt('-1') }),
     'export var positive = 0n;\nexport var negative = -1n;\nexport default {\n\tpositive: positive,\n\tnegative: negative\n};\n'
   );
 });


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

## Rollup Plugin Name: `pluginutils`

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

|data|oldEsm|newEsm|
|---|---|---|
|`bigint`|`undefined`|`bigint`|
|`Symbol.for()`|`undefined`|`Symbol.for()`|
