### PR TITLE
feat(commonjs): make defaultIsModuleExports as funtion to config defaultIsModuleExports for each source

### DIFF
--- a/packages/commonjs/src/index.js
+++ b/packages/commonjs/src/index.js
@@ -47,6 +47,7 @@ export default function commonjs(options = {}) {
     ignoreGlobal,
     ignoreDynamicRequires,
     requireReturnsDefault: requireReturnsDefaultOption,
+    defaultIsModuleExports: defaultIsModuleExportsOption,
     esmExternals
   } = options;
   const getRequireReturnsDefault =
@@ -60,8 +61,11 @@ export default function commonjs(options = {}) {
       : Array.isArray(esmExternals)
       ? ((esmExternalIds = new Set(esmExternals)), (id) => esmExternalIds.has(id))
       : () => esmExternals;
-  const defaultIsModuleExports =
-    typeof options.defaultIsModuleExports === 'boolean' ? options.defaultIsModuleExports : 'auto';
+  const getDefaultIsModuleExports =
+    typeof defaultIsModuleExportsOption === 'function'
+      ? defaultIsModuleExportsOption
+      : () =>
+          typeof defaultIsModuleExportsOption === 'boolean' ? defaultIsModuleExportsOption : 'auto';
 
   const { dynamicRequireModuleSet, dynamicRequireModuleDirPaths } = getDynamicRequirePaths(
     options.dynamicRequireTargets
@@ -150,7 +154,7 @@ export default function commonjs(options = {}) {
       disableWrap,
       commonDir,
       ast,
-      defaultIsModuleExports
+      getDefaultIsModuleExports(id)
     );
   }
 

--- a/packages/commonjs/types/index.d.ts
+++ b/packages/commonjs/types/index.d.ts
@@ -2,6 +2,7 @@ import { FilterPattern } from '@rollup/pluginutils';
 import { Plugin } from 'rollup';
 
 type RequireReturnsDefaultOption = boolean | 'auto' | 'preferred' | 'namespace';
+type DefaultIsModuleExportsOption = boolean | 'auto';
 
 interface RollupCommonJSOptions {
   /**
@@ -161,6 +162,13 @@ interface RollupCommonJSOptions {
   requireReturnsDefault?:
     | RequireReturnsDefaultOption
     | ((id: string) => RequireReturnsDefaultOption);
+
+  /**
+   * @default "auto"
+   */
+  defaultIsModuleExports?:
+    | DefaultIsModuleExportsOption
+    | ((id: string) => DefaultIsModuleExportsOption);
   /**
    * Some modules contain dynamic `require` calls, or require modules that
    * contain circular dependencies, which are not handled well by static


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `commonjs`

This PR contains:

- [x] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

Fix https://github.com/rollup/plugins/issues/1046 with configration like

```ts
commonjs({
  defaultIsModuleExports: (id: string) => {
      if (/react-datetime/.exec(id)) {
        return false
      }
      return "auto"
  },
})
```
