### PR TITLE
fix(node-resolve): prevent passing invalid argument to fs.stat.

### DIFF
--- a/packages/node-resolve/src/index.js
+++ b/packages/node-resolve/src/index.js
@@ -199,7 +199,7 @@ export function nodeResolve(opts = {}) {
       browserMapCache.set(location, packageBrowserField);
     }
 
-    if (hasPackageEntry && !preserveSymlinks) {
+    if (hasPackageEntry && !preserveSymlinks && location) {
       const exists = await fileExists(location);
       if (exists) {
         location = await realpath(location);
@@ -221,7 +221,7 @@ export function nodeResolve(opts = {}) {
       }
     }
 
-    if (options.modulesOnly && (await fileExists(location))) {
+    if (options.modulesOnly && location && (await fileExists(location))) {
       const code = await readFile(location, 'utf-8');
       if (isModule(code)) {
         return {


### PR DESCRIPTION
Can't figure out why `undefined` is passed by, just undertake it.

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: node-resolve

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description
![2021-11-26 (2)](https://user-images.githubusercontent.com/7849435/143600430-79ffc0b2-6f33-46e2-95a4-76231e01d333.png)



