### PR TITLE
chore(pluginutils): correct minimatch to picomatch in TSDoc

### DIFF
--- a/packages/pluginutils/types/index.d.ts
+++ b/packages/pluginutils/types/index.d.ts
@@ -18,7 +18,7 @@ export interface DataToEsmOptions {
 }
 
 /**
- * A valid `minimatch` pattern, or array of patterns.
+ * A valid `picomatch` pattern, or array of patterns.
  */
 export type FilterPattern = ReadonlyArray<string | RegExp> | string | RegExp | null;
 


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `pluginutils`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

`createFilter` uses picomatch, not minimatch

https://github.com/rollup/plugins/blob/02fb349d315f0ffc55970fba5de20e23f8ead881/packages/pluginutils/src/createFilter.ts#L3


