### PR TITLE
fix(node-resolve): forward meta-information from other plugins

### DIFF
--- a/packages/node-resolve/src/index.js
+++ b/packages/node-resolve/src/index.js
@@ -6,10 +6,10 @@ import deepMerge from 'deepmerge';
 import isModule from 'is-module';
 
 import { isDirCached, isFileCached, readCachedFile } from './cache';
+import handleDeprecatedOptions from './deprecated-options';
 import { fileExists, readFile, realpath } from './fs';
 import resolveImportSpecifiers from './resolveImportSpecifiers';
 import { getMainFields, getPackageName, normalizeInput } from './util';
-import handleDeprecatedOptions from './deprecated-options';
 
 const builtins = new Set(builtinList);
 const ES6_BROWSER_EMPTY = '\0node-resolve:empty.js';
@@ -223,11 +223,10 @@ export function nodeResolve(opts = {}) {
       }
       return null;
     }
-    const result = {
+    return {
       id: `${location}${importSuffix}`,
       moduleSideEffects: hasModuleSideEffects(location)
     };
-    return result;
   };
 
   return {
@@ -267,9 +266,13 @@ export function nodeResolve(opts = {}) {
           importer,
           Object.assign({ skipSelf: true }, resolveOptions)
         );
-        const isExternal = !!(resolvedResolved && resolvedResolved.external);
-        if (isExternal) {
-          return false;
+        if (resolvedResolved) {
+          // Handle plugins that manually make the result external
+          if (resolvedResolved.external) {
+            return false;
+          }
+          // Pass on meta information added by other plugins
+          return { ...resolved, meta: resolvedResolved.meta };
         }
       }
       return resolved;

--- a/packages/node-resolve/test/test.js
+++ b/packages/node-resolve/test/test.js
@@ -487,13 +487,13 @@ test('passes on "isEntry" flag', async (t) => {
     ]
   });
   t.deepEqual(resolveOptions, [
-    ['other.js', 'main.js', { custom: void 0, isEntry: true }],
-    ['main.js', void 0, { custom: void 0, isEntry: true }],
-    ['dep.js', 'main.js', { custom: void 0, isEntry: false }]
+    ['other.js', 'main.js', { custom: {}, isEntry: true }],
+    ['main.js', void 0, { custom: {}, isEntry: true }],
+    ['dep.js', 'main.js', { custom: {}, isEntry: false }]
   ]);
 });
 
-test.only('passes on custom options', async (t) => {
+test('passes on custom options', async (t) => {
   const resolveOptions = [];
   await rollup({
     input: 'entry/other.js',
@@ -519,4 +519,28 @@ test.only('passes on custom options', async (t) => {
     ['main.js', void 0, { custom: { test: 42 }, isEntry: false }],
     ['other.js', void 0, { custom: {}, isEntry: true }]
   ]);
+});
+
+test('passes on meta information from other plugins', async (t) => {
+  await rollup({
+    input: 'entry/other.js',
+    onwarn: failOnWarn(t),
+    plugins: [
+      nodeResolve(),
+      {
+        name: 'test-meta',
+        resolveId(importee) {
+          return {
+            id: resolve(importee),
+            meta: { test: { 'I am': 'here' } }
+          };
+        },
+
+        load(id) {
+          const info = this.getModuleInfo(id);
+          t.deepEqual(info.meta, { test: { 'I am': 'here' } });
+        }
+      }
+    ]
+  });
 });


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `node-resolve`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:
Resolves #1060 

### Description
While node-resolve was already calling other resolvers to allow them to mark modules as external, meta-information was ignored so far. This fix will make sure that all meta information added by other plugins is preserved (except moduleSideEffects that is).
