### PR TITLE
fix(node-resolve): build before publishing for correct version

### DIFF
--- a/packages/node-resolve/package.json
+++ b/packages/node-resolve/package.json
@@ -31,6 +31,7 @@
     "ci:test": "pnpm test -- --verbose && pnpm test:ts",
     "prebuild": "del-cli dist",
     "prepare": "if [ ! -d 'dist' ]; then pnpm build; fi",
+    "prepublishOnly": "pnpm build",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",
     "release": "pnpm plugin:release --workspace-root -- --pkg $npm_package_name",

--- a/packages/node-resolve/rollup.config.js
+++ b/packages/node-resolve/rollup.config.js
@@ -9,7 +9,7 @@ export default {
   plugins: [json()],
   external: [...Object.keys(pkg.dependencies), 'fs', 'path', 'os', 'util', 'url'],
   onwarn: (warning) => {
-    throw new Error(warning);
+    throw Object.assign(new Error(), warning);
   },
   output: [
     { file: pkg.main, format: 'cjs', exports: 'named' },


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `node-resolve`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [ ] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description
Currently, the version embedded as `version` property into the plugin object is always one version behind. This should fix it by running another build immediately before the package is actually published (which happens after the version has been incremented).