### PR TITLE
fix(inject,replace): add types for `sourceMap` option

### DIFF
--- a/packages/inject/index.d.ts
+++ b/packages/inject/index.d.ts
@@ -7,7 +7,11 @@ export interface RollupInjectOptions {
    * All other options are treated as `string: injectment` injectrs,
    * or `string: (id) => injectment` functions.
    */
-  [str: string]: Injectment | RollupInjectOptions['include'] | RollupInjectOptions['modules'];
+  [str: string]:
+    | Injectment
+    | RollupInjectOptions['include']
+    | RollupInjectOptions['sourceMap']
+    | RollupInjectOptions['modules'];
 
   /**
    * A minimatch pattern, or array of patterns, of files that should be
@@ -19,6 +23,12 @@ export interface RollupInjectOptions {
    * Files that should be excluded, if `include` is otherwise too permissive.
    */
   exclude?: string | RegExp | ReadonlyArray<string | RegExp> | null;
+
+  /**
+   * If false, skips source map generation. This will improve performance.
+   * @default true
+   */
+  sourceMap?: boolean;
 
   /**
    * You can separate values to inject from other options.

--- a/packages/replace/types/index.d.ts
+++ b/packages/replace/types/index.d.ts
@@ -24,6 +24,11 @@ export interface RollupReplaceOptions {
    */
   exclude?: FilterPattern;
   /**
+   * If false, skips source map generation. This will improve performance.
+   * @default true
+   */
+  sourceMap?: boolean;
+  /**
    * To replace every occurrence of `<@foo@>` instead of every occurrence
    * of `foo`, supply delimiters
    */


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `replace`, `inject`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

### Description

This PR adds types for the `sourceMap` option which is respected by both plugins but not currently included in the typing.

* replace: https://github.com/rollup/plugins/blob/93cf0a73aa9c386005923fcb45c6cf85d58d4a1b/packages/replace/src/index.js#L106-L108
* inject: https://github.com/rollup/plugins/blob/cfb45553566265b27f82570b717a7f3c8f91eea6/packages/inject/src/index.js#L82