### PR TITLE
docs(typescript): readme copy/paste mistake

### DIFF
--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -172,8 +172,8 @@ typescript({
       {
         type: 'typeChecker',
         factory: (typeChecker) => {
-          // Allow the transformer to get a Program reference in it's factory
-          return TypeCheckerRequiringTransformerFactory(program);
+          // Allow the transformer to get a TypeChecker reference in it's factory
+          return TypeCheckerRequiringTransformerFactory(typeChecker);
         }
       }
     ],


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `typescript`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

Fix typescript readme copy/paste mistake.

#### What is Wrong?

1. In the `factory` of `type: 'typeChecker'` I do not see a declaration for the variable `program`, which is passed into the `TypeCheckerRequiringTransformerFactory`.
2. `TypeCheckerRequiringTransformerFactory` seems, to me, to _require_ a `TypeChecker`, however is receiving a `Program`.
3. The `factory`'s parameter `typeChecker` is unused.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
