### PR TITLE
feat(commonjs): Add JSDOC Type Annotations to the helpers that get bundled with the code that allows TypeScript to infer the correct type on usage if you bundle a lib 

### DIFF
--- a/packages/commonjs/src/helpers.js
+++ b/packages/commonjs/src/helpers.js
@@ -22,18 +22,22 @@ export const HELPERS_ID = '\0commonjsHelpers.js';
 const HELPERS = `
 export var commonjsGlobal = typeof globalThis !== 'undefined' ? globalThis : typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {};
 
+/** @param {{ [x: string]: any; }} x */
 export function getDefaultExportFromCjs (x) {
 	return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
 }
 
+/** @param {{ [n: string]: any; }} n */
 export function getDefaultExportFromNamespaceIfPresent (n) {
 	return n && Object.prototype.hasOwnProperty.call(n, 'default') ? n['default'] : n;
 }
 
+/** @param {{ [n: string]: any; }} n */
 export function getDefaultExportFromNamespaceIfNotNamed (n) {
 	return n && Object.prototype.hasOwnProperty.call(n, 'default') && Object.keys(n).length === 1 ? n['default'] : n;
 }
 
+/** @param {{ [n: string]: any; }} n */
 export function getAugmentedNamespace(n) {
 	if (n.__esModule) return n;
 	var a = Object.defineProperty({}, '__esModule', {value: true});


### PR DESCRIPTION
This makes TypeScript happy if some one uses it to check the resulting js files

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `commonjs`

This PR contains:

- [x] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers: #1093


### Description
This makes all rollup builds that use the commonjs plugin type save
Add JSDOC Type Annotations to the helpers that get bundled with the code that allows TypeScript to infer the correct type on usage if you bundle a lib