### PR TITLE
bug(commonjs): Missing Types for the defaultIsModuleExports option

### DIFF
--- a/packages/commonjs/types/index.d.ts
+++ b/packages/commonjs/types/index.d.ts
@@ -175,6 +175,18 @@ interface RollupCommonJSOptions {
    * replacing strings like `"/Users/John/Desktop/foo-project/"` -> `"/"`.
    */
   dynamicRequireTargets?: string | ReadonlyArray<string>;
+  /**
+	 * Controls what is the default export when importing a CommonJS file from an ES module.
+	 * - `true`: The value of the default export is module.exports. This currently matches the
+	 *   behavior of Node.js when importing a CommonJS file.
+	 * - `false`: The value of the default export is exports.default.
+	 * - `"auto"`: The value of the default export is exports.default if the CommonJS file has
+	 *   an `exports.__esModule === true` property; otherwise it's module.exports. This makes it
+	 *   possible to import the default export of ES modules compiled to CommonJS as if they
+	 *   were not compiled.
+	 * @default "auto"
+	 */
+	defaultIsModuleExports?: boolean | "auto";
 }
 
 /**


### PR DESCRIPTION
Add:  defaultIsModuleExports option

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `commonjs`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other (Types)

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description
Added missing types for a commonjs plugin option. defaultIsModuleExports
<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
