### PR TITLE
docs(virtual): Replace 'entry' with 'input' in readme

### DIFF
--- a/packages/virtual/README.md
+++ b/packages/virtual/README.md
@@ -43,7 +43,7 @@ Create a `rollup.config.js` [configuration file](https://www.rollupjs.org/guide/
 import virtual from '@rollup/plugin-virtual';
 
 export default {
-  entry: 'src/entry.js',
+  input: 'src/entry.js',
   // ...
   plugins: [
     virtual({


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `{name}`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

I have recently tested the code from the [readme.md of plugin-virtual](https://github.com/rollup/plugins/blob/master/packages/virtual/README.md). I am currently using Rollup version 2.67.0. The correct and updated option for providing an entry point when bundling with Rollup is using [`input`](https://rollupjs.org/guide/en/#input)

Considering the possibility that this documentation was created during an earlier version of Rollup, I am open to any corrections if necessary.

I have forked this repository and made the necessary change. This will clear the confusion instated with the said documentation once this pull request is approved.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
