### PR TITLE
chor(pluginutils): fix typings for typescript 4.5+

### DIFF
--- a/packages/pluginutils/package.json
+++ b/packages/pluginutils/package.json
@@ -19,6 +19,7 @@
   "module": "./dist/es/index.js",
   "type": "commonjs",
   "exports": {
+    "types": "./types/index.d.ts",
     "require": "./dist/cjs/index.js",
     "import": "./dist/es/index.js"
   },


### PR DESCRIPTION
chor: fix typings for typescript 4.5+ when used with module resolution nodenext node12

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `{name}`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description
This allows typescript to detect this as a nodenext node12 module so it finds the correct typings.