### PR TITLE
fix(node-resolve): support `node:` protocol

### DIFF
--- a/packages/node-resolve/package.json
+++ b/packages/node-resolve/package.json
@@ -57,8 +57,8 @@
   "dependencies": {
     "@rollup/pluginutils": "^3.1.0",
     "@types/resolve": "1.17.1",
-    "builtin-modules": "^3.1.0",
     "deepmerge": "^4.2.2",
+    "is-builtin-module": "^3.1.0",
     "is-module": "^1.0.0",
     "resolve": "^1.19.0"
   },

--- a/packages/node-resolve/src/index.js
+++ b/packages/node-resolve/src/index.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-param-reassign, no-shadow, no-undefined */
 import { dirname, normalize, resolve, sep } from 'path';
 
-import builtinList from 'builtin-modules';
+import isBuiltinModule from 'is-builtin-module';
 import deepMerge from 'deepmerge';
 import isModule from 'is-module';
 
@@ -13,7 +13,6 @@ import { fileExists, readFile, realpath } from './fs';
 import resolveImportSpecifiers from './resolveImportSpecifiers';
 import { getMainFields, getPackageName, normalizeInput } from './util';
 
-const builtins = new Set(builtinList);
 const ES6_BROWSER_EMPTY = '\0node-resolve:empty.js';
 const deepFreeze = (object) => {
   Object.freeze(object);
@@ -166,7 +165,7 @@ export function nodeResolve(opts = {}) {
       ignoreSideEffectsForRoot
     });
 
-    const importeeIsBuiltin = builtins.has(importee);
+    const importeeIsBuiltin = isBuiltinModule(importee);
     const resolved =
       importeeIsBuiltin && preferBuiltins
         ? {

--- a/packages/node-resolve/test/fixtures/node-protocol.js
+++ b/packages/node-resolve/test/fixtures/node-protocol.js
@@ -1,0 +1,1 @@
+import 'node:fs';

--- a/packages/node-resolve/test/prefer-builtins.js
+++ b/packages/node-resolve/test/prefer-builtins.js
@@ -103,3 +103,16 @@ test('does not warn when using a builtin module when there is no local version, 
 
   t.is(warning, null);
 });
+
+test('detects builtins imported with node: protocol', async (t) => {
+  const warnings = [];
+  await rollup({
+    input: 'node-protocol.js',
+    onwarn({ message }) {
+      warnings.push(message);
+    },
+    plugins: [nodeResolve()]
+  });
+
+  t.is(warnings.length, 0);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,18 +99,6 @@ importers:
       rollup: 2.67.3
       typescript: 4.1.2
 
-  packages/auto-install/test/fixtures/pnpm:
-    specifiers:
-      node-noop: ^1.0.0
-    dependencies:
-      node-noop: 1.0.0
-
-  packages/auto-install/test/fixtures/pnpm-bare:
-    specifiers:
-      node-noop: ^1.0.0
-    dependencies:
-      node-noop: 1.0.0
-
   packages/babel:
     specifiers:
       '@babel/core': ^7.10.5
@@ -388,9 +376,9 @@ importers:
       '@rollup/plugin-json': ^4.1.0
       '@rollup/pluginutils': ^3.1.0
       '@types/resolve': 1.17.1
-      builtin-modules: ^3.1.0
       deepmerge: ^4.2.2
       es5-ext: ^0.10.53
+      is-builtin-module: ^3.1.0
       is-module: ^1.0.0
       resolve: ^1.19.0
       rollup: ^2.67.3
@@ -399,8 +387,8 @@ importers:
     dependencies:
       '@rollup/pluginutils': 3.1.0_rollup@2.67.3
       '@types/resolve': 1.17.1
-      builtin-modules: 3.1.0
       deepmerge: 4.2.2
+      is-builtin-module: 3.1.0
       is-module: 1.0.0
       resolve: 1.19.0
     devDependencies:
@@ -5300,6 +5288,13 @@ packages:
       call-bind: 1.0.2
     dev: true
 
+  /is-builtin-module/3.1.0:
+    resolution: {integrity: sha512-OV7JjAgOTfAFJmHZLvpSTb4qi0nIILDV1gWPYDnDJUTNFM5aGlRAhk4QcT8i7TuAleeEV5Fdkqn3t4mS+Q11fg==}
+    engines: {node: '>=6'}
+    dependencies:
+      builtin-modules: 3.1.0
+    dev: false
+
   /is-callable/1.2.2:
     resolution: {integrity: sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==}
     engines: {node: '>= 0.4'}
@@ -6181,6 +6176,7 @@ packages:
 
   /node-noop/1.0.0:
     resolution: {integrity: sha1-R6Pn2Az/qmRYNkvSLthcqzMHvnk=}
+    dev: true
 
   /node-preload/0.2.1:
     resolution: {integrity: sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `node-resolve`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

#1120

### Description

Imports with the [`node:` protocol](https://nodejs.org/api/esm.html#node-imports) are currently undetected by this plugin.

Switch to using [is-builtin-module](https://github.com/sindresorhus/is-builtin-module), which handles this protocol and also submodule imports like `fs/promises`.  Functionality is otherwise identical.

I confirmed the added test fails without the other changes in this PR.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
