### PR TITLE
fix(typescript): Drive letter casing on win32 platforms

### DIFF
--- a/packages/typescript/src/tscache.ts
+++ b/packages/typescript/src/tscache.ts
@@ -16,7 +16,7 @@ export default class TSCache {
 
   /** Returns the path to the cached file */
   cachedFilename(fileName: string): string {
-    return path.join(this._cacheFolder, fileName.replace(/^([A-Z]+):/, '$1'));
+    return path.join(this._cacheFolder, fileName.replace(/^([a-zA-Z]+):/, '$1'));
   }
 
   /** Emits a file in the cache folder */


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `plugin-typescript`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

As in several other places in this code base the regex for matching windows drive letters should be `/^([a-zA-Z]+):/` but one case was missing in the implementation of TSCache.
