### PR TITLE
fix(eslint): include and exclude options typing allow to be a regex

### DIFF
--- a/packages/eslint/types/index.d.ts
+++ b/packages/eslint/types/index.d.ts
@@ -1,5 +1,6 @@
 import { Plugin } from 'rollup';
 import { CLIEngine } from 'eslint';
+import { CreateFilter } from '@rollup/pluginutils';
 
 export interface RollupEslintOptions extends CLIEngine.Options {
   /**
@@ -24,13 +25,13 @@ export interface RollupEslintOptions extends CLIEngine.Options {
    * A single file, or array of files, to include when linting.
    * @default []
    */
-  include?: string[] | string;
+  include?: Parameters<CreateFilter>[0];
 
   /**
    * A single file, or array of files, to exclude when linting.
    * @default node_modules/**
    */
-  exclude?: string[] | string;
+  exclude?: Parameters<CreateFilter>[1];
 
   /**
    * Custom error formatter or the name of a built-in formatter.


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `eslint`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

ESLint plugin, `exclude` and `include` got a wrong type define. See the screenshot for details, we must cast regex to string for omit the error.

![image](https://user-images.githubusercontent.com/1808990/158521244-55dd2146-7afe-4a67-9d38-00c37bc77171.png)

Actually, those options will pass to [`createFilter` function](https://github.com/rollup/plugins/blob/5363f55aa1933b6c650832b08d6a54cb9ea64539/packages/eslint/src/index.ts#L37), so its typing should follow this function's parameters typing.

https://github.com/rollup/plugins/blob/5363f55aa1933b6c650832b08d6a54cb9ea64539/packages/eslint/src/index.ts#L37

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

