### PR TITLE
fix(typescript): allow lowercase drive letters

### DIFF
--- a/packages/typescript/src/tscache.ts
+++ b/packages/typescript/src/tscache.ts
@@ -16,7 +16,7 @@ export default class TSCache {
 
   /** Returns the path to the cached file */
   cachedFilename(fileName: string): string {
-    return path.join(this._cacheFolder, fileName.replace(/^([A-Z]+):/, '$1'));
+    return path.join(this._cacheFolder, fileName.replace(/^([A-Z]+):/i, '$1'));
   }
 
   /** Emits a file in the cache folder */


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `{typescript}`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

- #1133.

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

The regex that converts drive letters is now transforming lower case drive letters as well.
I'm aware that bugfixes should normally receive tests, however tests for this case cannot easily be build, as this occurrence of this bug depends on operating system configuration and the shell being used.
