### PR TITLE
fix(pluginutils): fix path normalisation for createFilter

### DIFF
--- a/packages/pluginutils/src/createFilter.ts
+++ b/packages/pluginutils/src/createFilter.ts
@@ -9,7 +9,7 @@ import normalizePath from './normalizePath';
 
 function getMatcherString(id: string, resolutionBase: string | false | null | undefined) {
   if (resolutionBase === false || isAbsolute(id) || id.startsWith('*')) {
-    return id;
+    return normalizePath(id);
   }
 
   // resolve('') is valid and will default to process.cwd()
@@ -20,7 +20,7 @@ function getMatcherString(id: string, resolutionBase: string | false | null | un
   // 1. the basePath has been normalized to use /
   // 2. the incoming glob (id) matcher, also uses /
   // otherwise Node will force backslash (\) on windows
-  return posix.join(basePath, id);
+  return posix.join(basePath, normalizePath(id));
 }
 
 const createFilter: CreateFilter = function createFilter(include?, exclude?, options?) {

--- a/packages/pluginutils/test/createFilter.ts
+++ b/packages/pluginutils/test/createFilter.ts
@@ -134,6 +134,34 @@ test('does not add current working directory when pattern is an absolute path', 
   t.falsy(filter(resolve('..', 'c')));
 });
 
+test('normalizes path when pattern is an absolute path', (t) => {
+  const filterPosix = createFilter([`${resolve('.')}/*`]);
+  const filterWin = createFilter([`${resolve('.')}\\*`]);
+
+  t.truthy(filterPosix(resolve('a')));
+  t.truthy(filterWin(resolve('a')));
+});
+
+test('normalizes path when pattern starts with *', (t) => {
+  const filterPosix = createFilter([`**/a`]);
+  const filterWin = createFilter([`**\\a`]);
+
+  t.truthy(filterPosix(resolve('a')));
+  t.truthy(filterWin(resolve('a')));
+});
+
+test('normalizes path when pattern has resolution base', (t) => {
+  const filterPosix = createFilter([`test/*`], [], {
+    resolve: __dirname
+  });
+  const filterWin = createFilter([`test\\*`], [], {
+    resolve: __dirname
+  });
+
+  t.truthy(filterPosix(resolve('test/a')));
+  t.truthy(filterWin(resolve('test/a')));
+});
+
 test('does not add current working directory when pattern starts with a glob', (t) => {
   const filter = createFilter(['**/*']);
   t.truthy(filter(resolve('a')));


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `pluginutils`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
Discovered in https://github.com/rollup/plugins/pull/1144

### Description

`createFilter` function is not normalizing paths correctly. Everything is expected to be converted to `/` while on windows it may not be the case as it depends on users input.
