### PR TITLE
fix: error types for dynamic-import-vars

### DIFF
--- a/packages/dynamic-import-vars/types/index.d.ts
+++ b/packages/dynamic-import-vars/types/index.d.ts
@@ -1,5 +1,4 @@
 import { FilterPattern } from '@rollup/pluginutils';
-import { walk } from 'estree-walker';
 import { Plugin } from 'rollup';
 
 interface RollupDynamicImportVariablesOptions {
@@ -25,7 +24,10 @@ interface RollupDynamicImportVariablesOptions {
 
 export class VariableDynamicImportError extends Error {}
 
-export function dynamicImportToGlob(...params: Parameters<typeof walk>): null | string;
+export function dynamicImportToGlob(
+  node: import('estree').BaseNode,
+  sourceString: string
+): null | string;
 
 /**
  * Support variables in dynamic imports in Rollup.


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `{dynamic-import-vars}`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

`dynamicImportVariables` export error types.
