### PR TITLE
fix(typescript): add precise file/line/column in warning message

### DIFF
--- a/packages/typescript/src/diagnostics/toWarning.ts
+++ b/packages/typescript/src/diagnostics/toWarning.ts
@@ -21,12 +21,15 @@ export default function diagnosticToWarning(
   if (diagnostic.file) {
     // Add information about the file location
     const { line, character } = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start!);
+    const { fileName } = diagnostic.file;
 
     warning.loc = {
       column: character + 1,
       line: line + 1,
-      file: diagnostic.file.fileName
+      file: fileName
     };
+
+    warning.message = `${fileName} (${line + 1},${character + 1}): ${warning.message}`;
 
     if (host) {
       // Extract a code frame from Typescript

--- a/packages/typescript/test/test.js
+++ b/packages/typescript/test/test.js
@@ -253,7 +253,9 @@ test.serial('reports diagnostics and throws if errors occur during transpilation
     })
   );
 
-  t.is(caughtError.message, '@rollup/plugin-typescript TS1110: Type expected.');
+  const messagePrefix = `${caughtError.loc.file} (${caughtError.loc.line},${caughtError.loc.column}):`;
+
+  t.is(caughtError.message, `${messagePrefix} @rollup/plugin-typescript TS1110: Type expected.`);
   t.is(caughtError.pluginCode, 'TS1110');
 });
 
@@ -267,6 +269,7 @@ test.serial('ignore type errors if noEmitOnError is false', async (t) => {
     }
   });
   const code = await getCode(bundle, outputOptions);
+  const messagePrefix = `${warnings[0].loc.file} (${warnings[0].loc.line},${warnings[0].loc.column}):`;
 
   t.true(code.includes(`console.log('hello world')`));
 
@@ -275,7 +278,7 @@ test.serial('ignore type errors if noEmitOnError is false', async (t) => {
   t.is(warnings[0].code, 'PLUGIN_WARNING');
   t.is(warnings[0].plugin, 'typescript');
   t.is(warnings[0].pluginCode, 'TS1110');
-  t.is(warnings[0].message, '@rollup/plugin-typescript TS1110: Type expected.');
+  t.is(warnings[0].message, `${messagePrefix} @rollup/plugin-typescript TS1110: Type expected.`);
 
   t.is(warnings[0].loc.line, 1);
   t.is(warnings[0].loc.column, 8);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `typescript`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

I reimplemented #1040 as it seems abandoned. I fixed linting errors and modified tests that were missing from the initial PR.
<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
