### PR TITLE
fix(run): compatability with `commonjs` plugin

### DIFF
--- a/packages/run/src/index.ts
+++ b/packages/run/src/index.ts
@@ -1,12 +1,12 @@
 import { ChildProcess, fork } from 'child_process';
-import { resolve, join, dirname } from 'path';
+import { join, dirname } from 'path';
 
-import { Plugin, RenderedChunk } from 'rollup';
+import { Plugin, RenderedChunk, ResolvedId } from 'rollup';
 
 import { RollupRunOptions } from '../types';
 
 export default function run(opts: RollupRunOptions = {}): Plugin {
-  let input: string;
+  let input: ResolvedId | null;
   let proc: ChildProcess;
 
   const args = opts.args || [];
@@ -33,7 +33,7 @@ export default function run(opts: RollupRunOptions = {}): Plugin {
         throw new Error(`@rollup/plugin-run only works with a single entry point`);
       }
 
-      input = await this.resolve(inputs[0], undefined, {isEntry: true});
+      input = await this.resolve(inputs[0], undefined, { isEntry: true });
     },
 
     generateBundle(_outputOptions, _bundle, isWrite) {
@@ -51,7 +51,7 @@ export default function run(opts: RollupRunOptions = {}): Plugin {
       const dir = outputOptions.dir || dirname(outputOptions.file!);
       const entryFileName = Object.keys(bundle).find((fileName) => {
         const chunk = bundle[fileName] as RenderedChunk;
-        return chunk.isEntry;
+        return chunk.modules && input && Object.keys(chunk.modules).includes(input.id);
       });
 
       if (entryFileName) {

--- a/packages/run/src/index.ts
+++ b/packages/run/src/index.ts
@@ -18,7 +18,7 @@ export default function run(opts: RollupRunOptions = {}): Plugin {
   return {
     name: 'run',
 
-    buildStart(options) {
+    async buildStart(options) {
       let inputs = options.input;
 
       if (typeof inputs === 'string') {
@@ -33,7 +33,7 @@ export default function run(opts: RollupRunOptions = {}): Plugin {
         throw new Error(`@rollup/plugin-run only works with a single entry point`);
       }
 
-      input = resolve(inputs[0]);
+      input = await this.resolve(inputs[0], undefined, {isEntry: true});
     },
 
     generateBundle(_outputOptions, _bundle, isWrite) {
@@ -51,7 +51,7 @@ export default function run(opts: RollupRunOptions = {}): Plugin {
       const dir = outputOptions.dir || dirname(outputOptions.file!);
       const entryFileName = Object.keys(bundle).find((fileName) => {
         const chunk = bundle[fileName] as RenderedChunk;
-        return chunk.isEntry && chunk.facadeModuleId === input;
+        return chunk.isEntry;
       });
 
       if (entryFileName) {


### PR DESCRIPTION
## Rollup Plugin Name: `run`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

The `facadeModuleId` variable includes `?commonjs` suffix breaking `chank.facadeModuleId === input`