### PR TITLE
fix(wasm): Reference atob polyfill in browser wasm test

### DIFF
--- a/packages/wasm/test/fixtures/async.js
+++ b/packages/wasm/test/fixtures/async.js
@@ -1,6 +1,9 @@
 import fixture from './sample.wasm';
 
 // eslint-disable-next-line no-undef
+globalThis.atob = (str) => Buffer.from(str, 'base64').toString('binary');
+
+// eslint-disable-next-line no-undef
 result = (async () => {
   const module = await fixture();
   let { instance } = await fixture({ env: {} });


### PR DESCRIPTION
The "target environment browser" test invoked the bundled output, which
leads to an undefined error on node 14 as [`atob` was introduced in node
16][0].

This commit uses the same atob polyfill that was introduced in #334

[0]: https://developer.mozilla.org/en-US/docs/Web/API/atob#browser_compatibility

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `wasm`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

Addresses the release github action breakage as reported in #1132

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
