### PR TITLE
fix(node-resolve): Respect if other plugins resolve the resolution to a different id

### DIFF
--- a/.github/workflows/node-windows.yml
+++ b/.github/workflows/node-windows.yml
@@ -36,7 +36,7 @@ jobs:
           node-version: ${{ matrix.node }}
 
       - name: install pnpm
-        run: npm install pnpm -g
+        run: npm install pnpm@6 -g
 
       - name: pnpm install
         run: pnpm install --ignore-scripts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Install pnpm
         run: |
-          npm install pnpm -g;
+          npm install pnpm@6 -g;
           echo node `pnpm -v`;
 
       - name: Set Git Config

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -34,7 +34,7 @@ jobs:
         run: git branch -f master origin/master
 
       - name: Install pnpm
-        run: npm install pnpm -g
+        run: npm install pnpm@6 -g
 
       - name: Sanity Check
         run: |

--- a/packages/node-resolve/src/index.js
+++ b/packages/node-resolve/src/index.js
@@ -281,6 +281,11 @@ export function nodeResolve(opts = {}) {
           if (resolvedResolved.external) {
             return false;
           }
+          // Allow other plugins to take over resolution. Rollup core will not
+          // change the id if it corresponds to an existing file
+          if (resolvedResolved.id !== resolved.id) {
+            return resolvedResolved;
+          }
           // Pass on meta information added by other plugins
           return { ...resolved, meta: resolvedResolved.meta };
         }


### PR DESCRIPTION

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `node-resolve`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:
Solves an issue mentioned in https://github.com/rollup/plugins/issues/1169#issuecomment-1114070764

### Description
Currently, node-resolve is very eager to take over resolution meaning that any resolver placed after the node-resolve plugin may at most resolve ids starting with `\0`. That is mostly fine except when plugins really want to do some proxying as mentioned later in rollup/plugins#1169.

This modifies the logic so that when node-resolve "re-resolves" the resolved id, it not only checks if a plugin marks the id as external, but also checks if a plugin would change the id. That is something that rollup core should never do if the file exists and has an extension.

In that case, node-resolve returns the different resolution, also not messing with e.g. `moduleSideEffects` as now the resolution effectively refers to a different file.

That should allow plugins to replace or proxy any file even when they are placed after node-resolve.