### PR TITLE
fix(sucrase): use bare specifier to obtain SucraseOptions type

### DIFF
--- a/packages/sucrase/package.json
+++ b/packages/sucrase/package.json
@@ -23,13 +23,14 @@
     "ci:coverage": "nyc pnpm test && nyc report --reporter=text-lcov > coverage.lcov",
     "ci:lint": "pnpm build && pnpm lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
-    "ci:test": "pnpm test -- --verbose",
+    "ci:test": "pnpm test -- --verbose && pnpm test:ts",
     "prebuild": "del-cli dist",
     "prepare": "if [ ! -d 'dist' ]; then pnpm build; fi",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",
     "release": "pnpm plugin:release --workspace-root -- --pkg $npm_package_name",
-    "test": "ava"
+    "test": "ava",
+    "test:ts": "tsc types/index.d.ts test/types.ts --noEmit"
   },
   "files": [
     "dist",

--- a/packages/sucrase/types/index.d.ts
+++ b/packages/sucrase/types/index.d.ts
@@ -1,6 +1,6 @@
 import { FilterPattern } from '@rollup/pluginutils';
 import { Plugin } from 'rollup';
-import { Options as SucraseOptions } from 'sucrase/dist/Options';
+import { Options as SucraseOptions } from 'sucrase';
 
 interface RollupSucraseOptions
   extends Pick<


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `sucrase`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes
- [x] no (existing tests break after updating sucrase to 3.21.0)

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

When typechecking a TS project importing this plugin with `skipLibCheck: false`, a type error is thrown:

```
.yarn/__virtual__/@rollup-plugin-sucrase-virtual-7e2c8dc7a4/0/cache/@rollup-plugin-sucrase-npm-4.0.3-5d2d589
3b4-0f8a729c1b.zip/node_modules/@rollup/plugin-sucrase/types/index.d.ts:3:43 - error TS7016: Could not find 
a declaration file for module 'sucrase/dist/Options'. '/Users/.../.yarn/cache/sucrase-npm-3.21.0-78b7f0f024-
d686f255af.zip/node_modules/sucrase/dist/Options.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/sucrase` if it exists or add a new declaration (.d.ts) file containing `decla
re module 'sucrase/dist/Options';`

3 import { Options as SucraseOptions } from 'sucrase/dist/Options';
                                            ~~~~~~~~~~~~~~~~~~~~~~
```

Sucrase v3.21.0 refactored its internal structure so that types are located apart from `dist`. I'm not sure why this specifier was chosen since Sucrase has always had this export available from the root specifier: [@alangpierce/sucrase@`ce0ec25...a2956ca` (diff)](https://github.com/alangpierce/sucrase/compare/ce0ec25b2204fcc0330023e0ef9d392c6efe19c4...a2956ca4cfb6b46ad9337e1f7e29cfa394ca53a7#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80)