### PR TITLE
fix(typescript): allow tslib peerDependency to be optional for npm and pnpm

### DIFF
--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -49,6 +49,11 @@
     "tslib": "*",
     "typescript": ">=3.7.0"
   },
+  "peerDependenciesMeta": {
+    "tslib": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "@rollup/pluginutils": "^3.1.0",
     "resolve": "^1.17.0"


### PR DESCRIPTION
## Rollup Plugin Name: `@rollup/plugin-typescript`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Testing this would be akin to testing npm.

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers: 

- #265 

### Description

`tslib` is an optional dependency and in a large set of projects goes completely unused (notably anything compiling with babel or which does not require use of the helpers).

Historically, `yarn` and `npm` would warn for peerDependencies but not error, but as better package managers have fixed this mistake (most notably `pnpm`) and worked their way into being industry defaults this behavior has shifted from minor-nuisance to build-breaking.

This PR uses the spec `peerDependencyMeta` respected by both `npm` and `pnpm` to declare the tslib peerDependency as entirely optional.
