### PR TITLE
fix: exclude external imports

### DIFF
--- a/packages/dynamic-import-vars/src/dynamic-import-to-glob.js
+++ b/packages/dynamic-import-vars/src/dynamic-import-to-glob.js
@@ -63,7 +63,7 @@ function expressionToGlob(node) {
 
 export function dynamicImportToGlob(node, sourceString) {
   let glob = expressionToGlob(node);
-  if (!glob.includes('*') || glob.startsWith('data:')) {
+  if (!glob.includes('*') || glob.startsWith('data:') || glob.startsWith('https')) {
     return null;
   }
   glob = glob.replace(/\*\*/g, '*');

--- a/packages/dynamic-import-vars/src/dynamic-import-to-glob.js
+++ b/packages/dynamic-import-vars/src/dynamic-import-to-glob.js
@@ -61,9 +61,23 @@ function expressionToGlob(node) {
   }
 }
 
+function isUrl(what) {
+  try {
+    return new URL(what);
+  } catch (_) {
+    return false;
+  }
+}
+
+function shouldIgnore(g) {
+  const url = isUrl(g);
+  return url && url.protocol.match(/^(data|http|https):(.+)?/);
+}
+
 export function dynamicImportToGlob(node, sourceString) {
   let glob = expressionToGlob(node);
-  if (!glob.includes('*') || glob.startsWith('data:') || glob.startsWith('http')) {
+
+  if (!glob.includes('*') || shouldIgnore(glob)) {
     return null;
   }
   glob = glob.replace(/\*\*/g, '*');

--- a/packages/dynamic-import-vars/src/dynamic-import-to-glob.js
+++ b/packages/dynamic-import-vars/src/dynamic-import-to-glob.js
@@ -63,7 +63,7 @@ function expressionToGlob(node) {
 
 export function dynamicImportToGlob(node, sourceString) {
   let glob = expressionToGlob(node);
-  if (!glob.includes('*') || glob.startsWith('data:') || glob.startsWith('https')) {
+  if (!glob.includes('*') || glob.startsWith('data:') || glob.startsWith('http')) {
     return null;
   }
   glob = glob.replace(/\*\*/g, '*');

--- a/packages/dynamic-import-vars/test/src/dynamic-import-to-glob.test.js
+++ b/packages/dynamic-import-vars/test/src/dynamic-import-to-glob.test.js
@@ -26,6 +26,15 @@ test('external', (t) => {
   t.is(glob, null);
 });
 
+test('external - leaves bare module specifiers starting with https in tact', (t) => {
+  const ast = CustomParser.parse('import("http_utils");', {
+    sourceType: 'module'
+  });
+
+  const glob = dynamicImportToGlob(ast.body[0].expression.arguments[0]);
+  t.is(glob, null);
+});
+
 test('data uri', (t) => {
   const ast = CustomParser.parse('import(`data:${bar}`);', {
     sourceType: 'module'

--- a/packages/dynamic-import-vars/test/src/dynamic-import-to-glob.test.js
+++ b/packages/dynamic-import-vars/test/src/dynamic-import-to-glob.test.js
@@ -17,6 +17,15 @@ test('template literal with variable filename', (t) => {
   t.is(glob, './foo/*.js');
 });
 
+test('external', (t) => {
+  const ast = CustomParser.parse('import(`https://some.cdn.com/package/${version}/index.js`);', {
+    sourceType: 'module'
+  });
+
+  const glob = dynamicImportToGlob(ast.body[0].expression.arguments[0]);
+  t.is(glob, null);
+});
+
 test('data uri', (t) => {
   const ast = CustomParser.parse('import(`data:${bar}`);', {
     sourceType: 'module'


### PR DESCRIPTION
## Rollup Plugin Name: `dynamic-import-vars`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

Currently the plugin will fail my build when I import something like: 
```
import(`https://some.cdn.com/package/${version}/index.js`);
```

Since this import is 'external', and doesn't need to look on the filesystem, these kind of imports should be allowed to pass through and go untouched by the plugin.
