### PR TITLE
fix: add types to the exports map

### DIFF
--- a/packages/commonjs/package.json
+++ b/packages/commonjs/package.json
@@ -16,6 +16,7 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
+    "types": "./types/index.d.ts",
     "require": "./dist/cjs/index.js",
     "import": "./dist/es/index.js"
   },

--- a/packages/commonjs/package.json
+++ b/packages/commonjs/package.json
@@ -16,7 +16,10 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": "./types/index.d.ts",
+    "types": {
+      "import": "./types/index.d.mts",
+      "require": "./types/index.d.ts"
+    },
     "require": "./dist/cjs/index.js",
     "import": "./dist/es/index.js"
   },

--- a/packages/commonjs/types/index.d.mts
+++ b/packages/commonjs/types/index.d.mts
@@ -1,0 +1,233 @@
+import { FilterPattern } from '@rollup/pluginutils';
+import { Plugin } from 'rollup';
+
+type RequireReturnsDefaultOption = boolean | 'auto' | 'preferred' | 'namespace';
+type DefaultIsModuleExportsOption = boolean | 'auto';
+
+interface RollupCommonJSOptions {
+  /**
+   * A minimatch pattern, or array of patterns, which specifies the files in
+   * the build the plugin should operate on. By default, all files with
+   * extension `".cjs"` or those in `extensions` are included, but you can
+   * narrow this list by only including specific files. These files will be
+   * analyzed and transpiled if either the analysis does not find ES module
+   * specific statements or `transformMixedEsModules` is `true`.
+   * @default undefined
+   */
+  include?: FilterPattern;
+  /**
+   * A minimatch pattern, or array of patterns, which specifies the files in
+   * the build the plugin should _ignore_. By default, all files with
+   * extensions other than those in `extensions` or `".cjs"` are ignored, but you
+   * can exclude additional files. See also the `include` option.
+   * @default undefined
+   */
+  exclude?: FilterPattern;
+  /**
+   * For extensionless imports, search for extensions other than .js in the
+   * order specified. Note that you need to make sure that non-JavaScript files
+   * are transpiled by another plugin first.
+   * @default [ '.js' ]
+   */
+  extensions?: ReadonlyArray<string>;
+  /**
+   * If true then uses of `global` won't be dealt with by this plugin
+   * @default false
+   */
+  ignoreGlobal?: boolean;
+  /**
+   * If false, skips source map generation for CommonJS modules. This will
+   * improve performance.
+   * @default true
+   */
+  sourceMap?: boolean;
+  /**
+   * Some `require` calls cannot be resolved statically to be translated to
+   * imports.
+   * When this option is set to `false`, the generated code will either
+   * directly throw an error when such a call is encountered or, when
+   * `dynamicRequireTargets` is used, when such a call cannot be resolved with a
+   * configured dynamic require target.
+   * Setting this option to `true` will instead leave the `require` call in the
+   * code or use it as a fallback for `dynamicRequireTargets`.
+   * @default false
+   */
+  ignoreDynamicRequires?: boolean;
+  /**
+   * Instructs the plugin whether to enable mixed module transformations. This
+   * is useful in scenarios with modules that contain a mix of ES `import`
+   * statements and CommonJS `require` expressions. Set to `true` if `require`
+   * calls should be transformed to imports in mixed modules, or `false` if the
+   * `require` expressions should survive the transformation. The latter can be
+   * important if the code contains environment detection, or you are coding
+   * for an environment with special treatment for `require` calls such as
+   * ElectronJS. See also the `ignore` option.
+   * @default false
+   */
+  transformMixedEsModules?: boolean;
+  /**
+   * By default, this plugin will try to hoist `require` statements as imports
+   * to the top of each file. While this works well for many code bases and
+   * allows for very efficient ESM output, it does not perfectly capture
+   * CommonJS semantics as the order of side effects like log statements may
+   * change. But it is especially problematic when there are circular `require`
+   * calls between CommonJS modules as those often rely on the lazy execution of
+   * nested `require` calls.
+   *
+   * Setting this option to `true` will wrap all CommonJS files in functions
+   * which are executed when they are required for the first time, preserving
+   * NodeJS semantics. Note that this can have an impact on the size and
+   * performance of the generated code.
+   *
+   * The default value of `"auto"` will only wrap CommonJS files when they are
+   * part of a CommonJS dependency cycle, e.g. an index file that is required by
+   * many of its dependencies. All other CommonJS files are hoisted. This is the
+   * recommended setting for most code bases.
+   *
+   * `false` will entirely prevent wrapping and hoist all files. This may still
+   * work depending on the nature of cyclic dependencies but will often cause
+   * problems.
+   *
+   * You can also provide a minimatch pattern, or array of patterns, to only
+   * specify a subset of files which should be wrapped in functions for proper
+   * `require` semantics.
+   *
+   * `"debug"` works like `"auto"` but after bundling, it will display a warning
+   * containing a list of ids that have been wrapped which can be used as
+   * minimatch pattern for fine-tuning.
+   * @default "auto"
+   */
+  strictRequires?: boolean | FilterPattern;
+  /**
+   * Sometimes you have to leave require statements unconverted. Pass an array
+   * containing the IDs or a `id => boolean` function.
+   * @default []
+   */
+  ignore?: ReadonlyArray<string> | ((id: string) => boolean);
+  /**
+   * In most cases, where `require` calls are inside a `try-catch` clause,
+   * they should be left unconverted as it requires an optional dependency
+   * that may or may not be installed beside the rolled up package.
+   * Due to the conversion of `require` to a static `import` - the call is
+   * hoisted to the top of the file, outside of the `try-catch` clause.
+   *
+   * - `true`: All `require` calls inside a `try` will be left unconverted.
+   * - `false`: All `require` calls inside a `try` will be converted as if the
+   *   `try-catch` clause is not there.
+   * - `remove`: Remove all `require` calls from inside any `try` block.
+   * - `string[]`: Pass an array containing the IDs to left unconverted.
+   * - `((id: string) => boolean|'remove')`: Pass a function that control
+   *   individual IDs.
+   *
+   * @default false
+   */
+  ignoreTryCatch?:
+    | boolean
+    | 'remove'
+    | ReadonlyArray<string>
+    | ((id: string) => boolean | 'remove');
+  /**
+   * Controls how to render imports from external dependencies. By default,
+   * this plugin assumes that all external dependencies are CommonJS. This
+   * means they are rendered as default imports to be compatible with e.g.
+   * NodeJS where ES modules can only import a default export from a CommonJS
+   * dependency.
+   *
+   * If you set `esmExternals` to `true`, this plugins assumes that all
+   * external dependencies are ES modules and respect the
+   * `requireReturnsDefault` option. If that option is not set, they will be
+   * rendered as namespace imports.
+   *
+   * You can also supply an array of ids to be treated as ES modules, or a
+   * function that will be passed each external id to determine if it is an ES
+   * module.
+   * @default false
+   */
+  esmExternals?: boolean | ReadonlyArray<string> | ((id: string) => boolean);
+  /**
+   * Controls what is returned when requiring an ES module from a CommonJS file.
+   * When using the `esmExternals` option, this will also apply to external
+   * modules. By default, this plugin will render those imports as namespace
+   * imports i.e.
+   *
+   * ```js
+   * // input
+   * const foo = require('foo');
+   *
+   * // output
+   * import * as foo from 'foo';
+   * ```
+   *
+   * However there are some situations where this may not be desired.
+   * For these situations, you can change Rollup's behaviour either globally or
+   * per module. To change it globally, set the `requireReturnsDefault` option
+   * to one of the following values:
+   *
+   * - `false`: This is the default, requiring an ES module returns its
+   *   namespace. This is the only option that will also add a marker
+   *   `__esModule: true` to the namespace to support interop patterns in
+   *   CommonJS modules that are transpiled ES modules.
+   * - `"namespace"`: Like `false`, requiring an ES module returns its
+   *   namespace, but the plugin does not add the `__esModule` marker and thus
+   *   creates more efficient code. For external dependencies when using
+   *   `esmExternals: true`, no additional interop code is generated.
+   * - `"auto"`: This is complementary to how `output.exports: "auto"` works in
+   *   Rollup: If a module has a default export and no named exports, requiring
+   *   that module returns the default export. In all other cases, the namespace
+   *   is returned. For external dependencies when using `esmExternals: true`, a
+   *   corresponding interop helper is added.
+   * - `"preferred"`: If a module has a default export, requiring that module
+   *   always returns the default export, no matter whether additional named
+   *   exports exist. This is similar to how previous versions of this plugin
+   *   worked. Again for external dependencies when using `esmExternals: true`,
+   *   an interop helper is added.
+   * - `true`: This will always try to return the default export on require
+   *   without checking if it actually exists. This can throw at build time if
+   *   there is no default export. This is how external dependencies are handled
+   *   when `esmExternals` is not used. The advantage over the other options is
+   *   that, like `false`, this does not add an interop helper for external
+   *   dependencies, keeping the code lean.
+   *
+   * To change this for individual modules, you can supply a function for
+   * `requireReturnsDefault` instead. This function will then be called once for
+   * each required ES module or external dependency with the corresponding id
+   * and allows you to return different values for different modules.
+   * @default false
+   */
+  requireReturnsDefault?:
+    | RequireReturnsDefaultOption
+    | ((id: string) => RequireReturnsDefaultOption);
+
+  /**
+   * @default "auto"
+   */
+  defaultIsModuleExports?:
+    | DefaultIsModuleExportsOption
+    | ((id: string) => DefaultIsModuleExportsOption);
+  /**
+   * Some modules contain dynamic `require` calls, or require modules that
+   * contain circular dependencies, which are not handled well by static
+   * imports. Including those modules as `dynamicRequireTargets` will simulate a
+   * CommonJS (NodeJS-like)  environment for them with support for dynamic
+   * dependencies. It also enables `strictRequires` for those modules.
+   *
+   * Note: In extreme cases, this feature may result in some paths being
+   * rendered as absolute in the final bundle. The plugin tries to avoid
+   * exposing paths from the local machine, but if you are `dynamicRequirePaths`
+   * with paths that are far away from your project's folder, that may require
+   * replacing strings like `"/Users/John/Desktop/foo-project/"` -> `"/"`.
+   */
+  dynamicRequireTargets?: string | ReadonlyArray<string>;
+  /**
+   * To avoid long paths when using the `dynamicRequireTargets` option, you can use this option to specify a directory
+   * that is a common parent for all files that use dynamic require statements. Using a directory higher up such as `/`
+   * may lead to unnecessarily long paths in the generated code and may expose directory names on your machine like your
+   * home directory name. By default it uses the current working directory.
+   */
+  dynamicRequireRoot?: string;
+}
+
+/**
+ * Convert CommonJS modules to ES6, so they can be included in a Rollup bundle
+ */
+export default function commonjs(options?: RollupCommonJSOptions): Plugin;

--- a/packages/node-resolve/package.json
+++ b/packages/node-resolve/package.json
@@ -17,6 +17,7 @@
   "module": "./dist/es/index.js",
   "type": "commonjs",
   "exports": {
+    "types": "./types/index.d.ts",
     "require": "./dist/cjs/index.js",
     "import": "./dist/es/index.js"
   },

--- a/packages/node-resolve/package.json
+++ b/packages/node-resolve/package.json
@@ -17,7 +17,10 @@
   "module": "./dist/es/index.js",
   "type": "commonjs",
   "exports": {
-    "types": "./types/index.d.ts",
+    "types": {
+      "import": "./types/index.d.mts",
+      "require": "./types/index.d.ts"
+    },
     "require": "./dist/cjs/index.js",
     "import": "./dist/es/index.js"
   },

--- a/packages/node-resolve/types/index.d.mts
+++ b/packages/node-resolve/types/index.d.mts
@@ -1,0 +1,98 @@
+import { Plugin } from 'rollup';
+
+export const DEFAULTS: {
+  customResolveOptions: {};
+  dedupe: [];
+  extensions: ['.mjs', '.js', '.json', '.node'];
+  resolveOnly: [];
+};
+
+export interface RollupNodeResolveOptions {
+  /**
+   * Additional conditions of the package.json exports field to match when resolving modules.
+   * By default, this plugin looks for the `'default', 'module', 'import']` conditions when resolving imports.
+   *
+   * When using `@rollup/plugin-commonjs` v16 or higher, this plugin will use the
+   * `['default', 'module', 'import']` conditions when resolving require statements.
+   *
+   * Setting this option will add extra conditions on top of the default conditions.
+   * See https://nodejs.org/api/packages.html#packages_conditional_exports for more information.
+   */
+  exportConditions?: string[];
+
+  /**
+   * If `true`, instructs the plugin to use the `"browser"` property in `package.json`
+   * files to specify alternative files to load for bundling. This is useful when
+   * bundling for a browser environment. Alternatively, a value of `'browser'` can be
+   * added to the `mainFields` option. If `false`, any `"browser"` properties in
+   * package files will be ignored. This option takes precedence over `mainFields`.
+   * @default false
+   */
+  browser?: boolean;
+
+  /**
+   * One or more directories in which to recursively look for modules.
+   * @default ['node_modules']
+   */
+  moduleDirectories?: string[];
+
+  /**
+   * An `Array` of modules names, which instructs the plugin to force resolving for the
+   * specified modules to the root `node_modules`. Helps to prevent bundling the same
+   * package multiple times if package is imported from dependencies.
+   */
+  dedupe?: string[] | ((importee: string) => boolean);
+
+  /**
+   * Specifies the extensions of files that the plugin will operate on.
+   * @default [ '.mjs', '.js', '.json', '.node' ]
+   */
+  extensions?: readonly string[];
+
+  /**
+   * Locks the module search within specified path (e.g. chroot). Modules defined
+   * outside this path will be marked as external.
+   * @default '/'
+   */
+  jail?: string;
+
+  /**
+   * Specifies the properties to scan within a `package.json`, used to determine the
+   * bundle entry point.
+   * @default ['module', 'main']
+   */
+  mainFields?: readonly string[];
+
+  /**
+   * If `true`, inspect resolved files to assert that they are ES2015 modules.
+   * @default false
+   */
+  modulesOnly?: boolean;
+
+  /**
+   * If `true`, the plugin will prefer built-in modules (e.g. `fs`, `path`). If `false`,
+   * the plugin will look for locally installed modules of the same name.
+   * @default true
+   */
+  preferBuiltins?: boolean;
+
+  /**
+   * An `Array` which instructs the plugin to limit module resolution to those whose
+   * names match patterns in the array.
+   * @default []
+   */
+  resolveOnly?: ReadonlyArray<string | RegExp> | null | ((module: string) => boolean);
+
+  /**
+   * Specifies the root directory from which to resolve modules. Typically used when
+   * resolving entry-point imports, and when resolving deduplicated modules.
+   * @default process.cwd()
+   */
+  rootDir?: string;
+}
+
+/**
+ * Locate modules using the Node resolution algorithm, for using third party modules in node_modules
+ */
+export function nodeResolve(options?: RollupNodeResolveOptions): Plugin;
+export default nodeResolve;

--- a/packages/pluginutils/package.json
+++ b/packages/pluginutils/package.json
@@ -19,6 +19,7 @@
   "module": "./dist/es/index.js",
   "type": "commonjs",
   "exports": {
+    "types": "./types/index.d.ts",
     "require": "./dist/cjs/index.js",
     "import": "./dist/es/index.js"
   },

--- a/packages/pluginutils/package.json
+++ b/packages/pluginutils/package.json
@@ -19,7 +19,10 @@
   "module": "./dist/es/index.js",
   "type": "commonjs",
   "exports": {
-    "types": "./types/index.d.ts",
+    "types": {
+      "import": "./types/index.d.mts",
+      "require": "./types/index.d.ts"
+    },
     "require": "./dist/cjs/index.js",
     "import": "./dist/es/index.js"
   },

--- a/packages/pluginutils/types/index.d.mts
+++ b/packages/pluginutils/types/index.d.mts
@@ -1,0 +1,93 @@
+// eslint-disable-next-line import/no-unresolved
+import { BaseNode } from 'estree';
+
+export interface AttachedScope {
+  parent?: AttachedScope;
+  isBlockScope: boolean;
+  declarations: { [key: string]: boolean };
+  addDeclaration(node: BaseNode, isBlockDeclaration: boolean, isVar: boolean): void;
+  contains(name: string): boolean;
+}
+
+export interface DataToEsmOptions {
+  compact?: boolean;
+  indent?: string;
+  namedExports?: boolean;
+  objectShorthand?: boolean;
+  preferConst?: boolean;
+}
+
+/**
+ * A valid `picomatch` glob pattern, or array of patterns.
+ */
+export type FilterPattern = ReadonlyArray<string | RegExp> | string | RegExp | null;
+
+/**
+ * Adds an extension to a module ID if one does not exist.
+ */
+export function addExtension(filename: string, ext?: string): string;
+
+/**
+ * Attaches `Scope` objects to the relevant nodes of an AST.
+ * Each `Scope` object has a `scope.contains(name)` method that returns `true`
+ * if a given name is defined in the current scope or a parent scope.
+ */
+export function attachScopes(ast: BaseNode, propertyName?: string): AttachedScope;
+
+/**
+ * Constructs a filter function which can be used to determine whether or not
+ * certain modules should be operated upon.
+ * @param include If `include` is omitted or has zero length, filter will return `true` by default.
+ * @param exclude ID must not match any of the `exclude` patterns.
+ * @param options Optionally resolves the patterns against a directory other than `process.cwd()`.
+ * If a `string` is specified, then the value will be used as the base directory.
+ * Relative paths will be resolved against `process.cwd()` first.
+ * If `false`, then the patterns will not be resolved against any directory.
+ * This can be useful if you want to create a filter for virtual module names.
+ */
+export function createFilter(
+  include?: FilterPattern,
+  exclude?: FilterPattern,
+  options?: { resolve?: string | false | null }
+): (id: string | unknown) => boolean;
+
+/**
+ * Transforms objects into tree-shakable ES Module imports.
+ * @param data An object to transform into an ES module.
+ */
+export function dataToEsm(data: unknown, options?: DataToEsmOptions): string;
+
+/**
+ * Extracts the names of all assignment targets based upon specified patterns.
+ * @param param An `acorn` AST Node.
+ */
+export function extractAssignedNames(param: BaseNode): string[];
+
+/**
+ * Constructs a bundle-safe identifier from a `string`.
+ */
+export function makeLegalIdentifier(str: string): string;
+
+/**
+ * Converts path separators to forward slash.
+ */
+export function normalizePath(filename: string): string;
+
+export type AddExtension = typeof addExtension;
+export type AttachScopes = typeof attachScopes;
+export type CreateFilter = typeof createFilter;
+export type ExtractAssignedNames = typeof extractAssignedNames;
+export type MakeLegalIdentifier = typeof makeLegalIdentifier;
+export type NormalizePath = typeof normalizePath;
+export type DataToEsm = typeof dataToEsm;
+
+declare const defaultExport: {
+  addExtension: AddExtension;
+  attachScopes: AttachScopes;
+  createFilter: CreateFilter;
+  dataToEsm: DataToEsm;
+  extractAssignedNames: ExtractAssignedNames;
+  makeLegalIdentifier: MakeLegalIdentifier;
+  normalizePath: NormalizePath;
+};
+export default defaultExport;


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `commonjs`, `node-resolve`, and `pluginutils`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

Allows types to be imported when using `"moduleResolution": "Node16"` in TypeScript.

~This PR may need to be modified based on the discussion here: https://github.com/microsoft/TypeScript/issues/49299~ - Updates made.