### PR TITLE
fix(typescript): fix declaration file generation for single file outputs

### DIFF
--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -304,7 +304,7 @@ export default {
   output: {
     file: 'dist/index.mjs'
   },
-  plugins: [typescript({ tsconfig: './tsconfig.json' })]
+  plugins: [typescript()]
 };
 ```
 
@@ -320,7 +320,7 @@ And accompanying `tsconfig.json` file:
 }
 ```
 
-This setup will produce `dist/index.mjs` and `dist/dist/index.d.ts`. To correctly place the declaration file, add an `exclude` setting in `tsconfig` and modify the `declarationDir` setting in `compilerOptions` to resemble:
+This setup will produce `dist/index.mjs` and `dist/src/index.d.ts`. To correctly place the declaration file, add an `exclude` setting in `tsconfig` and modify the `declarationDir` setting in `compilerOptions` to resemble:
 
 ```json
 {

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -137,7 +137,11 @@ export default function typescript(options: RollupTypescriptOptions = {}): Plugi
         const output = findTypescriptOutput(ts, parsedOptions, fileName, emittedFiles, tsCache);
         output.declarations.forEach((id) => {
           const code = getEmittedFile(id, emittedFiles, tsCache);
-          let baseDir = outputOptions.dir;
+          let baseDir =
+            outputOptions.dir ||
+            (parsedOptions.options.declaration
+              ? parsedOptions.options.declarationDir || parsedOptions.options.outDir
+              : null);
           if (!baseDir && tsconfig) {
             baseDir = tsconfig.substring(0, tsconfig.lastIndexOf('/'));
           }


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `typescript`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

Previously, type declaration files were only emitted if `outputOptions.dir` was
used and not `outputOptions.file` or, as a side effect, if the tsconfig file was
specified via a qualified path. This commit fixes that, such that types are
also emitted for single file builds.