### PR TITLE
node-resolve: add support for useResolveModule option

### DIFF
--- a/packages/node-resolve/README.md
+++ b/packages/node-resolve/README.md
@@ -168,6 +168,11 @@ rootDir: path.join(process.cwd(), '..')
 
 If you use the `sideEffects` property in the package.json, by default this is respected for files in the root package. Set to `true` to ignore the `sideEffects` configuration for the root package.
 
+### `useResolveModule`
+
+By default modules are loaded by looking in package.json. With this option classic behaviour is configured by using resolve module rather then looking
+in package.json.
+
 ## Preserving symlinks
 
 This plugin honours the rollup [`preserveSymlinks`](https://rollupjs.org/guide/en/#preservesymlinks) option.

--- a/packages/node-resolve/src/index.js
+++ b/packages/node-resolve/src/index.js
@@ -36,7 +36,8 @@ const defaults = {
   extensions: ['.mjs', '.js', '.json', '.node'],
   resolveOnly: [],
   moduleDirectories: ['node_modules'],
-  ignoreSideEffectsForRoot: false
+  ignoreSideEffectsForRoot: false,
+  useResolveModule: false,
 };
 export const DEFAULTS = deepFreeze(deepMerge({}, defaults));
 
@@ -44,7 +45,7 @@ export function nodeResolve(opts = {}) {
   const { warnings } = handleDeprecatedOptions(opts);
 
   const options = { ...defaults, ...opts };
-  const { extensions, jail, moduleDirectories, ignoreSideEffectsForRoot } = options;
+  const { extensions, jail, moduleDirectories, ignoreSideEffectsForRoot, useResolveModule } = options;
   const conditionsEsm = [...baseConditionsEsm, ...(options.exportConditions || [])];
   const conditionsCjs = [...baseConditionsCjs, ...(options.exportConditions || [])];
   const packageInfoCache = new Map();
@@ -168,7 +169,8 @@ export function nodeResolve(opts = {}) {
       baseDir,
       moduleDirectories,
       rootDir,
-      ignoreSideEffectsForRoot
+      ignoreSideEffectsForRoot,
+      useResolveModule
     });
 
     const importeeIsBuiltin = isBuiltinModule(importee);

--- a/packages/node-resolve/src/resolveImportSpecifiers.js
+++ b/packages/node-resolve/src/resolveImportSpecifiers.js
@@ -276,30 +276,34 @@ export default async function resolveImportSpecifiers({
   baseDir,
   moduleDirectories,
   rootDir,
-  ignoreSideEffectsForRoot
+  ignoreSideEffectsForRoot,
+  useResolveModule
 }) {
-  try {
-    const exportMapRes = await resolveWithExportMap({
-      importer,
-      importSpecifier: importSpecifierList[0],
-      exportConditions,
-      packageInfoCache,
-      extensions,
-      mainFields,
-      preserveSymlinks,
-      useBrowserOverrides,
-      baseDir,
-      moduleDirectories,
-      rootDir,
-      ignoreSideEffectsForRoot
-    });
-    if (exportMapRes) return exportMapRes;
-  } catch (error) {
-    if (error instanceof ResolveError) {
-      warn(error);
-      return null;
+  if (!useResolveModule)
+    try {
+      const exportMapRes = await resolveWithExportMap({
+        importer,
+        importSpecifier: importSpecifierList[0],
+        exportConditions,
+        packageInfoCache,
+        extensions,
+        mainFields,
+        preserveSymlinks,
+        useBrowserOverrides,
+        baseDir,
+        moduleDirectories,
+        rootDir,
+        ignoreSideEffectsForRoot,
+        useResolveModule
+      });
+      if (exportMapRes) return exportMapRes;
+    } catch (error) {
+      if (error instanceof ResolveError) {
+        warn(error);
+        return null;
+      }
+      throw error;
     }
-    throw error;
   }
 
   // package has no imports or exports, use classic node resolve

--- a/packages/node-resolve/src/resolveImportSpecifiers.js
+++ b/packages/node-resolve/src/resolveImportSpecifiers.js
@@ -279,7 +279,7 @@ export default async function resolveImportSpecifiers({
   ignoreSideEffectsForRoot,
   useResolveModule
 }) {
-  if (!useResolveModule)
+  if (!useResolveModule) {
     try {
       const exportMapRes = await resolveWithExportMap({
         importer,

--- a/packages/node-resolve/src/resolveImportSpecifiers.js
+++ b/packages/node-resolve/src/resolveImportSpecifiers.js
@@ -293,8 +293,7 @@ export default async function resolveImportSpecifiers({
         baseDir,
         moduleDirectories,
         rootDir,
-        ignoreSideEffectsForRoot,
-        useResolveModule
+        ignoreSideEffectsForRoot
       });
       if (exportMapRes) return exportMapRes;
     } catch (error) {


### PR DESCRIPTION
In 3d60158f21e0b6a5a8a53d9977928e2e148cb885 the way modules were resolved was changed. This change has broken how some repos load modules for example gerrit (code review).

doing:

```
import {customElement, property, query, state} from 'lit/decorators';
```

does not work where as doing:

```
import {customElement, property, query, state} from 'lit/decorators.js';
```

does but then you loose typechecking in visual studio code editor.

It looks in package.json and finds:

```
  "exports": {
    ".": {
      "development": "./development/reactive-element.js",
      "default": "./reactive-element.js"
    },
    ....
    "./decorators.js": {
      "development": "./development/decorators.js",
      "default": "./decorators.js"
    },
    ....
  },
```

but ./decorators does not equal ./decorators.js.

We fix this by allowing a option to configure to use the resolve module directory and not look at package.json.

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `{name}`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [ ] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
