### PR TITLE
feat(node-resolve): dedupe preferBuiltins protocol

### DIFF
--- a/packages/node-resolve/README.md
+++ b/packages/node-resolve/README.md
@@ -126,10 +126,12 @@ Specifies the properties to scan within a `package.json`, used to determine the 
 
 ### `preferBuiltins`
 
-Type: `Boolean`<br>
+Type: `Boolean | 'prefer-protocol' | 'prefer-no-protocol'`<br>
 Default: `true` (with warnings if a builtin module is used over a local version. Set to `true` to disable warning.)
 
 If `true`, the plugin will prefer built-in modules (e.g. `fs`, `path`). If `false`, the plugin will look for locally installed modules of the same name.
+
+When set to `true`, `prefer-protocol` and `prefer-no-protocol` can also be used to deduplicate, e.g. `fs` and `node:fs`, as the same module. The final import path would be `node:fs` for `prefer-protocol` or `fs` for `prefer-no-protocol`.
 
 ### `modulesOnly`
 

--- a/packages/node-resolve/src/index.js
+++ b/packages/node-resolve/src/index.js
@@ -51,7 +51,7 @@ export function nodeResolve(opts = {}) {
   const idToPackageInfo = new Map();
   const mainFields = getMainFields(options);
   const useBrowserOverrides = mainFields.indexOf('browser') !== -1;
-  const isPreferBuiltinsSet = options.preferBuiltins === true || options.preferBuiltins === false;
+  const isPreferBuiltinsSet = options.preferBuiltins != null;
   const preferBuiltins = isPreferBuiltinsSet ? options.preferBuiltins : true;
   const rootDir = resolve(options.rootDir || process.cwd());
   let { dedupe } = options;
@@ -214,7 +214,21 @@ export function nodeResolve(opts = {}) {
             `preferring built-in module '${importee}' over local alternative at '${resolvedWithoutBuiltins.location}', pass 'preferBuiltins: false' to disable this behavior or 'preferBuiltins: true' to disable this warning`
           );
         }
-        return false;
+        if (preferBuiltins === true) {
+          return false;
+        } else if (preferBuiltins === 'prefer-protocol') {
+          if (!importee.startsWith('node:')) {
+            importee = `node:${importee}`;
+          }
+          return { id: importee, external: true };
+        } else if (preferBuiltins === 'prefer-no-protocol') {
+          if (importee.startsWith('node:')) {
+            importee = importee.slice(5);
+          }
+          return { id: importee, external: true };
+        } else {
+          return false;
+        }
       } else if (jail && location.indexOf(normalize(jail.trim(sep))) !== 0) {
         return null;
       }

--- a/packages/node-resolve/src/index.js
+++ b/packages/node-resolve/src/index.js
@@ -226,8 +226,6 @@ export function nodeResolve(opts = {}) {
             importee = importee.slice(5);
           }
           return { id: importee, external: true };
-        } else {
-          return false;
         }
       } else if (jail && location.indexOf(normalize(jail.trim(sep))) !== 0) {
         return null;

--- a/packages/node-resolve/test/fixtures/node-dedupe-protocol.js
+++ b/packages/node-resolve/test/fixtures/node-dedupe-protocol.js
@@ -1,0 +1,2 @@
+import 'fs';
+import 'node:fs';

--- a/packages/node-resolve/test/prefer-builtins.js
+++ b/packages/node-resolve/test/prefer-builtins.js
@@ -116,3 +116,39 @@ test('detects builtins imported with node: protocol', async (t) => {
 
   t.is(warnings.length, 0);
 });
+
+test('dedupe builtins for prefer-protocol', async (t) => {
+  const warnings = [];
+  const bundle = await rollup({
+    input: 'node-dedupe-protocol.js',
+    onwarn: (warning) => warnings.push(warning),
+    plugins: [
+      nodeResolve({
+        preferBuiltins: 'prefer-protocol'
+      })
+    ]
+  });
+
+  const imports = await getImports(bundle);
+
+  t.is(warnings.length, 0);
+  t.deepEqual(imports, ['node:fs']);
+});
+
+test('dedupe builtins for prefer-no-protocol', async (t) => {
+  const warnings = [];
+  const bundle = await rollup({
+    input: 'node-dedupe-protocol.js',
+    onwarn: (warning) => warnings.push(warning),
+    plugins: [
+      nodeResolve({
+        preferBuiltins: 'prefer-no-protocol'
+      })
+    ]
+  });
+
+  const imports = await getImports(bundle);
+
+  t.is(warnings.length, 0);
+  t.deepEqual(imports, ['fs']);
+});

--- a/packages/node-resolve/types/index.d.ts
+++ b/packages/node-resolve/types/index.d.ts
@@ -72,9 +72,13 @@ export interface RollupNodeResolveOptions {
   /**
    * If `true`, the plugin will prefer built-in modules (e.g. `fs`, `path`). If `false`,
    * the plugin will look for locally installed modules of the same name.
+   *
+   * When set to `true`, `prefer-protocol` and `prefer-no-protocol` can also be used to
+   * deduplicate, e.g. `fs` and `node:fs`, as the same module. The final import path would
+   * be `node:fs` for `prefer-protocol` or `fs` for `prefer-no-protocol`.
    * @default true
    */
-  preferBuiltins?: boolean;
+  preferBuiltins?: boolean | 'prefer-protocol' | 'prefer-no-protocol';
 
   /**
    * An `Array` which instructs the plugin to limit module resolution to those whose


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `node-resolve`

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

When bundling a library that uses both `node:fs` and `fs`, it can be deduped as a single `node:fs` or `fs` import instead, slightly reducing the bundle size. This can often happen when using third-party libraries.

To enable this optimization, `preferBuiltins` now also accepts `prefer-protocol` or `prefer-no-protocol` to dedupe to either `node:fs` or `fs`, depending on the users node target version that supports it.