### PR TITLE
feat(commonjs): Restore support for Node 10 after #1038

### DIFF
--- a/packages/commonjs/package.json
+++ b/packages/commonjs/package.json
@@ -20,7 +20,7 @@
     "import": "./dist/es/index.js"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">= 10.0.0"
   },
   "scripts": {
     "build": "rollup -c",


### PR DESCRIPTION
## Rollup Plugin Name: `commonjs`

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no, but #1038 added good test coverage

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

### Description

#1038 raised the required Node version of the `commonjs` plugin from 8 to 12, mentioning:

> * minimum Node version raised to 12. This allows us to use "async await" (though 10 would have been enough for that...)

Since `rollup` itself is still usable with Node 10, it makes some sense to stick with 10 as long as reasonably convenient.