### PR TITLE
fix: support .mts and .cts out of the box

### DIFF
--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -17,6 +17,9 @@ import { preflight } from './preflight';
 import createWatchProgram, { WatchProgramHelper } from './watchProgram';
 import TSCache from './tscache';
 
+/**
+ * The glob pattern used to test if a given file extension corresponds to a TypeScript file.
+ */
 const defaultTsExtensionsGlob = '?(m|c)ts+(|x)';
 
 export default function typescript(options: RollupTypescriptOptions = {}): Plugin {

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import { createFilter } from '@rollup/pluginutils';
 
 import { Plugin, RollupOptions, SourceDescription } from 'rollup';
-import type { Watch } from 'typescript';
+import type { ResolvedModuleFull, Watch } from 'typescript';
 
 import { RollupTypescriptOptions } from '../types';
 
@@ -119,8 +119,7 @@ export default function typescript(options: RollupTypescriptOptions = {}): Plugi
       const resolved = resolveModule(importee, containingFile);
 
       if (resolved) {
-        if (resolved.extension.startsWith('.d.') && resolved.extension.match(/\./g)?.length === 2)
-          return null;
+        if (isTypeDeclarationFile(resolved)) return null;
         return path.normalize(resolved.resolvedFileName);
       }
 
@@ -182,4 +181,17 @@ export default function typescript(options: RollupTypescriptOptions = {}): Plugi
       }
     }
   };
+}
+
+/**
+ * Check if the given resolved TypeScript module is a type declaration.
+ */
+function isTypeDeclarationFile(resolved: ResolvedModuleFull) {
+  const lastDotDDot = resolved.extension.lastIndexOf('.d.');
+  if (lastDotDDot < 0) return false;
+
+  const lastDot = resolved.extension.lastIndexOf('.');
+
+  // Ensure the dot is the second one in `.d.`
+  return lastDot === lastDotDDot + 2;
 }

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -17,6 +17,8 @@ import { preflight } from './preflight';
 import createWatchProgram, { WatchProgramHelper } from './watchProgram';
 import TSCache from './tscache';
 
+const defaultTsExtensionsGlob = '?(m|c)ts+(|x)';
+
 export default function typescript(options: RollupTypescriptOptions = {}): Plugin {
   const {
     cacheDir,
@@ -36,9 +38,13 @@ export default function typescript(options: RollupTypescriptOptions = {}): Plugi
   const watchProgramHelper = new WatchProgramHelper();
 
   const parsedOptions = parseTypescriptConfig(ts, tsconfig, compilerOptions, noForceEmit);
-  const filter = createFilter(include || ['*.ts+(|x)', '**/*.ts+(|x)'], exclude, {
-    resolve: filterRoot ?? parsedOptions.options.rootDir
-  });
+  const filter = createFilter(
+    include || [`*.${defaultTsExtensionsGlob}`, `**/*.${defaultTsExtensionsGlob}`],
+    exclude,
+    {
+      resolve: filterRoot ?? parsedOptions.options.rootDir
+    }
+  );
   parsedOptions.fileNames = parsedOptions.fileNames.filter(filter);
 
   const formatHost = createFormattingHost(ts, parsedOptions.options);
@@ -110,7 +116,8 @@ export default function typescript(options: RollupTypescriptOptions = {}): Plugi
       const resolved = resolveModule(importee, containingFile);
 
       if (resolved) {
-        if (resolved.extension === '.d.ts') return null;
+        if (resolved.extension.startsWith('.d.') && resolved.extension.match(/\./g)?.length === 2)
+          return null;
         return path.normalize(resolved.resolvedFileName);
       }
 

--- a/packages/typescript/test/fixtures/cts/main.mts
+++ b/packages/typescript/test/fixtures/cts/main.mts
@@ -1,0 +1,3 @@
+const answer = 42;
+// eslint-disable-next-line no-console
+console.log(`the answer is ${answer}`);

--- a/packages/typescript/test/fixtures/cts/tsconfig.json
+++ b/packages/typescript/test/fixtures/cts/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16"
+  }
+}

--- a/packages/typescript/test/fixtures/dcts/main.cts
+++ b/packages/typescript/test/fixtures/dcts/main.cts
@@ -1,0 +1,5 @@
+/* eslint-disable */
+// @ts-ignore
+import { foo } from 'an-import';
+
+foo();

--- a/packages/typescript/test/fixtures/dcts/tsconfig.json
+++ b/packages/typescript/test/fixtures/dcts/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16"
+  }
+}

--- a/packages/typescript/test/fixtures/dmts/main.mts
+++ b/packages/typescript/test/fixtures/dmts/main.mts
@@ -1,0 +1,5 @@
+/* eslint-disable */
+// @ts-ignore
+import { foo } from 'an-import';
+
+foo();

--- a/packages/typescript/test/fixtures/dmts/tsconfig.json
+++ b/packages/typescript/test/fixtures/dmts/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16"
+  }
+}

--- a/packages/typescript/test/fixtures/mts/main.mts
+++ b/packages/typescript/test/fixtures/mts/main.mts
@@ -1,0 +1,3 @@
+const answer = 42;
+// eslint-disable-next-line no-console
+console.log(`the answer is ${answer}`);

--- a/packages/typescript/test/fixtures/mts/tsconfig.json
+++ b/packages/typescript/test/fixtures/mts/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16"
+  }
+}

--- a/packages/typescript/test/test.js
+++ b/packages/typescript/test/test.js
@@ -16,10 +16,34 @@ test.beforeEach(() => process.chdir(__dirname));
 
 const outputOptions = { format: 'esm' };
 
-test.serial('runs code through typescript', async (t) => {
+test.serial('runs ts code through typescript', async (t) => {
   const bundle = await rollup({
     input: 'fixtures/basic/main.ts',
     plugins: [typescript({ tsconfig: 'fixtures/basic/tsconfig.json', target: 'es5' })],
+    onwarn
+  });
+  const code = await getCode(bundle, outputOptions);
+
+  t.false(code.includes('number'), code);
+  t.false(code.includes('const'), code);
+});
+
+test.serial('runs mts code through typescript', async (t) => {
+  const bundle = await rollup({
+    input: 'fixtures/mts/main.ts',
+    plugins: [typescript({ tsconfig: 'fixtures/mts/tsconfig.json', target: 'es5' })],
+    onwarn
+  });
+  const code = await getCode(bundle, outputOptions);
+
+  t.false(code.includes('number'), code);
+  t.false(code.includes('const'), code);
+});
+
+test.serial('runs cts code through typescript', async (t) => {
+  const bundle = await rollup({
+    input: 'fixtures/cts/main.ts',
+    plugins: [typescript({ tsconfig: 'fixtures/cts/tsconfig.json', target: 'es5' })],
     onwarn
   });
   const code = await getCode(bundle, outputOptions);
@@ -368,6 +392,28 @@ test.serial('should not resolve .d.ts files', async (t) => {
   const bundle = await rollup({
     input: 'fixtures/dts/main.ts',
     plugins: [typescript({ tsconfig: 'fixtures/dts/tsconfig.json' })],
+    onwarn,
+    external: ['an-import']
+  });
+  const imports = bundle.cache.modules[0].dependencies;
+  t.deepEqual(imports, ['an-import']);
+});
+
+test.serial('should not resolve .d.cts files', async (t) => {
+  const bundle = await rollup({
+    input: 'fixtures/dts/main.cts',
+    plugins: [typescript({ tsconfig: 'fixtures/dcts/tsconfig.json' })],
+    onwarn,
+    external: ['an-import']
+  });
+  const imports = bundle.cache.modules[0].dependencies;
+  t.deepEqual(imports, ['an-import']);
+});
+
+test.serial('should not resolve .d.mts files', async (t) => {
+  const bundle = await rollup({
+    input: 'fixtures/dts/main.mts',
+    plugins: [typescript({ tsconfig: 'fixtures/dmts/tsconfig.json' })],
     onwarn,
     external: ['an-import']
   });


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `typescript`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

Currently out of the box the `typescript` plugin only supports `.ts` and `.tsx` extensions. This PR adds support for `.mts` and `.cts` as well without the user needing to modify the `includes` option.

Additionally only `.d.ts` were supported as type declaration files, this PR also adds support for `.d.mts` and `.d.cts` files.