### PR TITLE
feat(dynamic-import-vars): Support bare imports in @rollup/plugin-dynamic-import-vars

### DIFF
--- a/packages/dynamic-import-vars/test/src/dynamic-import-to-glob.test.js
+++ b/packages/dynamic-import-vars/test/src/dynamic-import-to-glob.test.js
@@ -8,140 +8,207 @@ import { dynamicImportToGlob, VariableDynamicImportError } from '../../dist/inde
 
 const CustomParser = Parser.extend(dynamicImport);
 
-test('template literal with variable filename', (t) => {
+const mockRollup = {
+  resolve(id) {
+    return { id };
+  }
+};
+
+const mockRollupNotResolving = {
+  resolve() {
+    return null;
+  }
+};
+
+test('template literal with variable filename', async (t) => {
   const ast = CustomParser.parse('import(`./foo/${bar}.js`);', {
     sourceType: 'module'
   });
 
-  const glob = dynamicImportToGlob(ast.body[0].expression.arguments[0]);
+  const { glob } = await dynamicImportToGlob(
+    ast.body[0].expression.arguments[0],
+    '',
+    null,
+    mockRollup
+  );
   t.is(glob, './foo/*.js');
 });
 
-test('external', (t) => {
+test('external', async (t) => {
   const ast = CustomParser.parse('import(`https://some.cdn.com/package/${version}/index.js`);', {
     sourceType: 'module'
   });
 
-  const glob = dynamicImportToGlob(ast.body[0].expression.arguments[0]);
+  const glob = await dynamicImportToGlob(ast.body[0].expression.arguments[0], '', null, mockRollup);
   t.is(glob, null);
 });
 
-test('external - leaves bare module specifiers starting with https in tact', (t) => {
+test('external - leaves bare module specifiers starting with https in tact', async (t) => {
   const ast = CustomParser.parse('import("http_utils");', {
     sourceType: 'module'
   });
 
-  const glob = dynamicImportToGlob(ast.body[0].expression.arguments[0]);
+  const glob = await dynamicImportToGlob(ast.body[0].expression.arguments[0], '', null, mockRollup);
   t.is(glob, null);
 });
 
-test('data uri', (t) => {
+test('data uri', async (t) => {
   const ast = CustomParser.parse('import(`data:${bar}`);', {
     sourceType: 'module'
   });
 
-  const glob = dynamicImportToGlob(ast.body[0].expression.arguments[0]);
+  const glob = await dynamicImportToGlob(ast.body[0].expression.arguments[0], '', null, mockRollup);
   t.is(glob, null);
 });
 
-test('template literal with dot-prefixed suffix', (t) => {
+test('template literal with dot-prefixed suffix', async (t) => {
   const ast = CustomParser.parse('import(`./${bar}.entry.js`);', {
     sourceType: 'module'
   });
 
-  const glob = dynamicImportToGlob(ast.body[0].expression.arguments[0]);
+  const { glob } = await dynamicImportToGlob(
+    ast.body[0].expression.arguments[0],
+    '',
+    null,
+    mockRollup
+  );
   t.is(glob, './*.entry.js');
 });
 
-test('template literal with variable directory', (t) => {
+test('template literal with variable directory', async (t) => {
   const ast = CustomParser.parse('import(`./foo/${bar}/x.js`);', {
     sourceType: 'module'
   });
 
-  const glob = dynamicImportToGlob(ast.body[0].expression.arguments[0]);
+  const { glob } = await dynamicImportToGlob(
+    ast.body[0].expression.arguments[0],
+    '',
+    null,
+    mockRollup
+  );
   t.is(glob, './foo/*/x.js');
 });
 
-test('template literal with multiple variables', (t) => {
+test('template literal with multiple variables', async (t) => {
   const ast = CustomParser.parse('import(`./${foo}/${bar}.js`);', {
     sourceType: 'module'
   });
 
-  const glob = dynamicImportToGlob(ast.body[0].expression.arguments[0]);
+  const { glob } = await dynamicImportToGlob(
+    ast.body[0].expression.arguments[0],
+    '',
+    null,
+    mockRollup
+  );
   t.is(glob, './*/*.js');
 });
 
-test('dynamic expression with variable filename', (t) => {
+test('dynamic expression with variable filename', async (t) => {
   const ast = CustomParser.parse('import("./foo/".concat(bar,".js"));', {
     sourceType: 'module'
   });
 
-  const glob = dynamicImportToGlob(ast.body[0].expression.arguments[0]);
+  const { glob } = await dynamicImportToGlob(
+    ast.body[0].expression.arguments[0],
+    '',
+    null,
+    mockRollup
+  );
   t.is(glob, './foo/*.js');
 });
 
-test('dynamic expression with variable directory', (t) => {
+test('dynamic expression with variable directory', async (t) => {
   const ast = CustomParser.parse('import("./foo/".concat(bar, "/x.js"));', {
     sourceType: 'module'
   });
 
-  const glob = dynamicImportToGlob(ast.body[0].expression.arguments[0]);
+  const { glob } = await dynamicImportToGlob(
+    ast.body[0].expression.arguments[0],
+    '',
+    null,
+    mockRollup
+  );
   t.is(glob, './foo/*/x.js');
 });
 
-test('dynamic expression with multiple variables', (t) => {
+test('dynamic expression with multiple variables', async (t) => {
   const ast = CustomParser.parse('import("./".concat(foo, "/").concat(bar,".js"));', {
     sourceType: 'module'
   });
 
-  const glob = dynamicImportToGlob(ast.body[0].expression.arguments[0]);
+  const { glob } = await dynamicImportToGlob(
+    ast.body[0].expression.arguments[0],
+    '',
+    null,
+    mockRollup
+  );
   t.is(glob, './*/*.js');
 });
 
-test('string concatenation', (t) => {
+test('string concatenation', async (t) => {
   const ast = CustomParser.parse('import("./foo/" + bar + ".js");', {
     sourceType: 'module'
   });
 
-  const glob = dynamicImportToGlob(ast.body[0].expression.arguments[0]);
+  const { glob } = await dynamicImportToGlob(
+    ast.body[0].expression.arguments[0],
+    '',
+    null,
+    mockRollup
+  );
   t.is(glob, './foo/*.js');
 });
 
-test('string concatenation and template literals combined', (t) => {
+test('string concatenation and template literals combined', async (t) => {
   const ast = CustomParser.parse('import("./" + `foo/${bar}` + ".js");', {
     sourceType: 'module'
   });
 
-  const glob = dynamicImportToGlob(ast.body[0].expression.arguments[0]);
+  const { glob } = await dynamicImportToGlob(
+    ast.body[0].expression.arguments[0],
+    '',
+    null,
+    mockRollup
+  );
   t.is(glob, './foo/*.js');
 });
 
-test('string literal in a template literal expression', (t) => {
+test('string literal in a template literal expression', async (t) => {
   const ast = CustomParser.parse('import(`${"./foo/"}${bar}.js`);', {
     sourceType: 'module'
   });
 
-  const glob = dynamicImportToGlob(ast.body[0].expression.arguments[0]);
+  const { glob } = await dynamicImportToGlob(
+    ast.body[0].expression.arguments[0],
+    '',
+    null,
+    mockRollup
+  );
   t.is(glob, './foo/*.js');
 });
 
-test('multiple variables are collapsed into a single *', (t) => {
+test('multiple variables are collapsed into a single *', async (t) => {
   const ast = CustomParser.parse('import(`./foo/${bar}${baz}/${x}${y}.js`);', {
     sourceType: 'module'
   });
 
-  const glob = dynamicImportToGlob(ast.body[0].expression.arguments[0]);
+  const { glob } = await dynamicImportToGlob(
+    ast.body[0].expression.arguments[0],
+    '',
+    null,
+    mockRollup
+  );
   t.is(glob, './foo/*/*.js');
 });
 
-test('throws when dynamic import contains a *', (t) => {
+test('throws when dynamic import contains a *', async (t) => {
   const ast = CustomParser.parse('import(`./*${foo}.js`);', {
     sourceType: 'module'
   });
 
   let error;
   try {
-    dynamicImportToGlob(ast.body[0].expression.arguments[0]);
+    await dynamicImportToGlob(ast.body[0].expression.arguments[0], '', null, mockRollup);
   } catch (e) {
     error = e;
   }
@@ -149,14 +216,14 @@ test('throws when dynamic import contains a *', (t) => {
   t.true(error instanceof VariableDynamicImportError);
 });
 
-test('throws when dynamic import contains a non + operator', (t) => {
+test('throws when dynamic import contains a non + operator', async (t) => {
   const ast = CustomParser.parse('import("foo" - "bar.js");', {
     sourceType: 'module'
   });
 
   let error;
   try {
-    dynamicImportToGlob(ast.body[0].expression.arguments[0]);
+    await dynamicImportToGlob(ast.body[0].expression.arguments[0], '', null, mockRollup);
   } catch (e) {
     error = e;
   }
@@ -164,14 +231,19 @@ test('throws when dynamic import contains a non + operator', (t) => {
   t.true(error instanceof VariableDynamicImportError);
 });
 
-test('throws when dynamic import is a single variable', (t) => {
+test('throws when dynamic import is a single variable', async (t) => {
   const ast = CustomParser.parse('import(foo);', {
     sourceType: 'module'
   });
 
   let error;
   try {
-    dynamicImportToGlob(ast.body[0].expression.arguments[0], '${sourceString}');
+    await dynamicImportToGlob(
+      ast.body[0].expression.arguments[0],
+      '${sourceString}',
+      __filename,
+      mockRollup
+    );
   } catch (e) {
     error = e;
   }
@@ -182,14 +254,19 @@ test('throws when dynamic import is a single variable', (t) => {
   t.true(error instanceof VariableDynamicImportError);
 });
 
-test('throws when dynamic import starts with a variable', (t) => {
+test('throws when dynamic import starts with a variable', async (t) => {
   const ast = CustomParser.parse('import(`${folder}/foo.js`);', {
     sourceType: 'module'
   });
 
   let error;
   try {
-    dynamicImportToGlob(ast.body[0].expression.arguments[0], '${sourceString}');
+    await dynamicImportToGlob(
+      ast.body[0].expression.arguments[0],
+      '${sourceString}',
+      __filename,
+      mockRollup
+    );
   } catch (e) {
     error = e;
   }
@@ -200,14 +277,19 @@ test('throws when dynamic import starts with a variable', (t) => {
   t.true(error instanceof VariableDynamicImportError);
 });
 
-test('throws when dynamic import starts with a /', (t) => {
+test('throws when dynamic import starts with a /', async (t) => {
   const ast = CustomParser.parse('import(`/foo/${bar}.js`);', {
     sourceType: 'module'
   });
 
   let error;
   try {
-    dynamicImportToGlob(ast.body[0].expression.arguments[0], '${sourceString}');
+    await dynamicImportToGlob(
+      ast.body[0].expression.arguments[0],
+      '${sourceString}',
+      __filename,
+      mockRollup
+    );
   } catch (e) {
     error = e;
   }
@@ -218,32 +300,76 @@ test('throws when dynamic import starts with a /', (t) => {
   t.true(error instanceof VariableDynamicImportError);
 });
 
-test('throws when dynamic import does not start with ./', (t) => {
+test('does not throw when dynamic import does not start with ./', async (t) => {
+  const ast = CustomParser.parse('import(`@rollup/plugin-dynamic-import-vars/src/${bar}.js`);', {
+    sourceType: 'module'
+  });
+
+  const { glob } = await dynamicImportToGlob(
+    ast.body[0].expression.arguments[0],
+    '${sourceString}',
+    __filename,
+    mockRollup
+  );
+  t.is(glob, '../../@rollup/plugin-dynamic-import-vars/src/*.js');
+});
+
+test('throws when dynamic import does not start with ./ and not an npm package name', async (t) => {
+  const ast = CustomParser.parse('import(`$foo/${bar}.js`);', {
+    sourceType: 'module'
+  });
+
+  let error;
+  try {
+    await dynamicImportToGlob(
+      ast.body[0].expression.arguments[0],
+      '${sourceString}',
+      __filename,
+      mockRollupNotResolving
+    );
+  } catch (e) {
+    error = e;
+  }
+  t.is(
+    error.message,
+    'invalid import "${sourceString}". Non-relative variable imports that do not match an NPM package name are not supported, imports must start with either an npm package name or ./ in the static part of the import. For example: import(`./foo/${bar}.js`).'
+  );
+  t.true(error instanceof VariableDynamicImportError);
+});
+
+test('throws when dynamic import does not start with ./ and can not be resolved', async (t) => {
   const ast = CustomParser.parse('import(`foo/${bar}.js`);', {
     sourceType: 'module'
   });
 
   let error;
   try {
-    dynamicImportToGlob(ast.body[0].expression.arguments[0], '${sourceString}');
+    await dynamicImportToGlob(
+      ast.body[0].expression.arguments[0],
+      '${sourceString}',
+      __filename,
+      mockRollupNotResolving
+    );
   } catch (e) {
     error = e;
   }
-  t.is(
-    error.message,
-    'invalid import "${sourceString}". Variable bare imports are not supported, imports must start with ./ in the static part of the import. For example: import(`./foo/${bar}.js`).'
-  );
+  t.is(error.message, 'invalid import "${sourceString}". Could not resolve module "foo".');
   t.true(error instanceof VariableDynamicImportError);
 });
 
-test("throws when dynamic import imports it's own directory", (t) => {
+test("throws when dynamic import imports it's own directory", async (t) => {
   const ast = CustomParser.parse('import(`./${foo}.js`);', {
     sourceType: 'module'
   });
 
   let error;
   try {
-    dynamicImportToGlob(ast.body[0].expression.arguments[0], '${sourceString}');
+    await dynamicImportToGlob(
+      ast.body[0].expression.arguments[0],
+      '${sourceString}',
+      __filename,
+      mockRollup
+    );
   } catch (e) {
     error = e;
   }
@@ -254,14 +380,19 @@ test("throws when dynamic import imports it's own directory", (t) => {
   t.true(error instanceof VariableDynamicImportError);
 });
 
-test('throws when dynamic import imports does not contain a file extension', (t) => {
+test('throws when dynamic import imports does not contain a file extension', async (t) => {
   const ast = CustomParser.parse('import(`./foo/${bar}`);', {
     sourceType: 'module'
   });
 
   let error;
   try {
-    dynamicImportToGlob(ast.body[0].expression.arguments[0], '${sourceString}');
+    await dynamicImportToGlob(
+      ast.body[0].expression.arguments[0],
+      '${sourceString}',
+      __filename,
+      mockRollup
+    );
   } catch (e) {
     error = e;
   }


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `dynamic-import-vars`

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- (not yet) documentation 
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [ ] no
- [x] not yet

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

This Draft PR adds two things I'd like to discuss with you before iterating further on this. The code is not yet completely polished and test are missing. Happy to get your feedback on the thoughts before I iterate any further on this (adding tests, documentation, improving code, ...).

#### Introduce a way to ignore certain imports

We're currently using webpack and it's `webpackIgnore: true` comment on some imports we wish to run in the browser, i.e. `import(/* webpackIgnore: true */ someVariablePointingToAnHttpUrl);`. This is used to load modules in our proprietary microfrontend framework (think module-federation). Since we now want to bundle certain parts of our production application with rollup instead of webpack (as the webpack ESM output is sub-optimal) we need to support these runtime-dynamic-imports in our rollup builds as well.

I resorted to support the magic comment`webpackIgnore: true` on dynamic imports in order to not transform them with the dynamic-import-vars plugin. I think it could make sense to introduce a rollup or rollup/plugin-dynamic-import-vars specific magic comment in order to not break any existing builds.

#### Add support for bare module imports with variables

Currently the plugin does not support bare imports as they're a bit hard to analyze. As we're using dynamic imports to `i18n-iso-countries` to dynamically load the country names in different languages, we're in need to support dynamic variable imports with bare specifiers. (Alternative would be to copy the files to our src folder but I dislike this very much as it would not de-dupe properly when the same library is used in other parts (i.e. inside node_modules)).

To support bare import specifiers I check the generated glob (not starting with ./ nor ../) whether it starts with an npm package name (basically `@scope/name` or `name`) using a regexp. If a package name could be found, then `<name>/package.json` is `resolve()`d in order to locate the npm package. The glob is then adjusted to use the resolved location instead of the bare import specifier. In the end this has to be reversed in the switch statement generated.

##### Sub-optimal changes to dynamic-import-to-glob

The code is not very optimal yet and I had to make some changes to dynamic-import-to-glob I somewhat dislike:

- make it `async` as `resolve()` is async
- pass the rollup instance in order to access `resolve()`

I tried to work around this by moving the `resolve()` parts into the `index.js` file but this has other drawbacks:

- throwing `VariableDynamicImportError` in `index.js` instead of `dynamic-import-to-glob.js`

Happy to suggestions for this