### PR TITLE
fix(typescript): rolve the problem of wrong output path of type file …

### DIFF
--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -12,10 +12,15 @@ import createModuleResolver from './moduleResolution';
 import { getPluginOptions } from './options/plugin';
 import { emitParsedOptionsErrors, parseTypescriptConfig } from './options/tsconfig';
 import { validatePaths, validateSourceMap } from './options/validate';
-import findTypescriptOutput, { getEmittedFile, normalizePath, emitFile } from './outputFile';
+import findTypescriptOutput, {
+  emitFile,
+  getEmittedFile,
+  normalizePath,
+  outputFileAsync
+} from './outputFile';
 import { preflight } from './preflight';
-import createWatchProgram, { WatchProgramHelper } from './watchProgram';
 import TSCache from './tscache';
+import createWatchProgram, { WatchProgramHelper } from './watchProgram';
 
 export default function typescript(options: RollupTypescriptOptions = {}): Plugin {
   const {
@@ -148,11 +153,7 @@ export default function typescript(options: RollupTypescriptOptions = {}): Plugi
           }
           if (!code || !baseDir) return;
 
-          this.emitFile({
-            type: 'asset',
-            fileName: normalizePath(path.relative(baseDir, id)),
-            source: code
-          });
+          outputFileAsync(id, code);
         });
       });
 

--- a/packages/typescript/src/outputFile.ts
+++ b/packages/typescript/src/outputFile.ts
@@ -81,6 +81,11 @@ export function normalizePath(fileName: string) {
   return fileName.split(path.win32.sep).join(path.posix.sep);
 }
 
+export async function outputFileAsync(filepath: string, fileSource: any): Promise<void> {
+  await fs.mkdir(path.dirname(filepath), { recursive: true });
+  await fs.writeFile(filepath, fileSource);
+}
+
 export async function emitFile(
   { dir }: OutputOptions,
   outputToFilesystem: boolean | undefined,
@@ -101,8 +106,7 @@ export async function emitFile(
       context.warn(`@rollup/plugin-typescript: outputToFilesystem option is defaulting to true.`);
     }
     if (outputToFilesystem !== false) {
-      await fs.mkdir(path.dirname(normalizedFilePath), { recursive: true });
-      await fs.writeFile(normalizedFilePath, fileSource);
+      await outputFileAsync(normalizedFilePath, fileSource);
     }
   } else {
     context.emitFile({


### PR DESCRIPTION
rolve the problem of wrong output path of type file during construction

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `@rollup/plugin-typescript`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
