### PR TITLE
fix(node-resolve): handle circular commonjs

### DIFF
--- a/packages/node-resolve/src/index.js
+++ b/packages/node-resolve/src/index.js
@@ -285,7 +285,7 @@ export function nodeResolve(opts = {}) {
           // `moduleSideEffects` information.
           const resolvedResolved = await this.resolve(resolved.id, importer, {
             ...resolveOptions,
-            custom: { ...custom, 'node-resolve': { resolved } }
+            custom: { ...custom, 'node-resolve': { ...custom['node-resolve'], resolved } }
           });
           if (resolvedResolved) {
             // Handle plugins that manually make the result external

--- a/packages/node-resolve/test/fixtures/cyclic-commonjs/main.js
+++ b/packages/node-resolve/test/fixtures/cyclic-commonjs/main.js
@@ -1,0 +1,4 @@
+exports.main = 'main';
+const other = require('./other.js');
+
+t.is(other.main, 'main');

--- a/packages/node-resolve/test/fixtures/cyclic-commonjs/other.js
+++ b/packages/node-resolve/test/fixtures/cyclic-commonjs/other.js
@@ -1,0 +1,3 @@
+const { main } = require('./main.js');
+
+exports.main = main;

--- a/packages/node-resolve/test/test.js
+++ b/packages/node-resolve/test/test.js
@@ -44,6 +44,21 @@ test('finds and converts a basic CommonJS module', async (t) => {
   t.is(module.exports, 'It works!');
 });
 
+test('handles cyclic CommonJS modules', async (t) => {
+  const bundle = await rollup({
+    input: 'cyclic-commonjs/main.js',
+    onwarn(warning) {
+      if (warning.code !== 'CIRCULAR_DEPENDENCY') {
+        t.fail(`Unexpected warning:\n${warning.code}\n${warning.message}`);
+      }
+    },
+    plugins: [nodeResolve(), commonjs()]
+  });
+  const { module } = await testBundle(t, bundle);
+
+  t.is(module.exports.main, 'main');
+});
+
 test('handles a trailing slash', async (t) => {
   const bundle = await rollup({
     input: 'trailing-slash.js',


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `node-resolve`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:
- resolves #1258 

### Description
It turns out in the change that lead to node-resolve 14, I forgot to forward node-resolves own "isRequire" flag in its call to "this.resolve", sending the commonjs plugin into a deadlock. Would like to merge this tomorrow if there are no concerns as it is an important hot fix.