### PR TITLE
chore(repo): correct READMEs, minimatch to picomatch

### DIFF
--- a/packages/babel/README.md
+++ b/packages/babel/README.md
@@ -84,13 +84,13 @@ All options are as per the [Babel documentation](https://babeljs.io/docs/en/opti
 
 Type: `String | RegExp | Array[...String|RegExp]`<br>
 
-A [minimatch pattern](https://github.com/isaacs/minimatch), or array of patterns, which specifies the files in the build the plugin should _ignore_. When relying on Babel configuration files you can only exclude additional files with this option, you cannot override what you have configured for Babel itself.
+A [picomatch pattern](https://github.com/micromatch/picomatch), or array of patterns, which specifies the files in the build the plugin should _ignore_. When relying on Babel configuration files you can only exclude additional files with this option, you cannot override what you have configured for Babel itself.
 
 ### `include`
 
 Type: `String | RegExp | Array[...String|RegExp]`<br>
 
-A [minimatch pattern](https://github.com/isaacs/minimatch), or array of patterns, which specifies the files in the build the plugin should operate on. When relying on Babel configuration files you cannot include files already excluded there.
+A [picomatch pattern](https://github.com/micromatch/picomatch), or array of patterns, which specifies the files in the build the plugin should operate on. When relying on Babel configuration files you cannot include files already excluded there.
 
 ### `filter`
 

--- a/packages/babel/types/index.d.ts
+++ b/packages/babel/types/index.d.ts
@@ -5,12 +5,12 @@ import * as babelCore from '@babel/core';
 export interface RollupBabelInputPluginOptions
   extends Omit<babelCore.TransformOptions, 'include' | 'exclude'> {
   /**
-   * A minimatch pattern, or array of patterns, which specifies the files in the build the plugin should operate on. When relying on Babel configuration files you cannot include files already excluded there.
+   * A picomatch pattern, or array of patterns, which specifies the files in the build the plugin should operate on. When relying on Babel configuration files you cannot include files already excluded there.
    * @default undefined;
    */
   include?: FilterPattern;
   /**
-   * A minimatch pattern, or array of patterns, which specifies the files in the build the plugin should ignore. When relaying on Babel configuration files you can only exclude additional files with this option, you cannot override what you have configured for Babel itself.
+   * A picomatch pattern, or array of patterns, which specifies the files in the build the plugin should ignore. When relaying on Babel configuration files you can only exclude additional files with this option, you cannot override what you have configured for Babel itself.
    * @default undefined;
    */
   exclude?: FilterPattern;

--- a/packages/buble/README.md
+++ b/packages/buble/README.md
@@ -56,14 +56,14 @@ Specifies additional [transform options](https://buble.surge.sh/guide/) for the 
 Type: `String` | `Array[...String]`<br>
 Default: `null`
 
-A [minimatch pattern](https://github.com/isaacs/minimatch), or array of patterns, which specifies the files in the build the plugin should _ignore_. By default no files are ignored.
+A [picomatch pattern](https://github.com/micromatch/picomatch), or array of patterns, which specifies the files in the build the plugin should _ignore_. By default no files are ignored.
 
 ### `include`
 
 Type: `String` | `Array[...String]`<br>
 Default: `null`
 
-A [minimatch pattern](https://github.com/isaacs/minimatch), or array of patterns, which specifies the files in the build the plugin should operate on. By default all files are targeted.
+A [picomatch pattern](https://github.com/micromatch/picomatch), or array of patterns, which specifies the files in the build the plugin should operate on. By default all files are targeted.
 
 ## Meta
 

--- a/packages/buble/types/index.d.ts
+++ b/packages/buble/types/index.d.ts
@@ -4,7 +4,7 @@ import { Plugin } from 'rollup';
 
 export interface RollupBubleOptions extends TransformOptions {
   /**
-   * A minimatch pattern, or array of patterns, of files that should be
+   * A picomatch pattern, or array of patterns, of files that should be
    * processed by this plugin (if omitted, all files are included by default)
    */
   include?: FilterPattern;

--- a/packages/commonjs/README.md
+++ b/packages/commonjs/README.md
@@ -59,9 +59,9 @@ The default value of `"auto"` will only wrap CommonJS files when they are part o
 
 `false` will entirely prevent wrapping and hoist all files. This may still work depending on the nature of cyclic dependencies but will often cause problems.
 
-You can also provide a [minimatch pattern](https://github.com/isaacs/minimatch), or array of patterns, to only specify a subset of files which should be wrapped in functions for proper `require` semantics.
+You can also provide a [picomatch pattern](https://github.com/micromatch/picomatch), or array of patterns, to only specify a subset of files which should be wrapped in functions for proper `require` semantics.
 
-`"debug"` works like `"auto"` but after bundling, it will display a warning containing a list of ids that have been wrapped which can be used as minimatch pattern for fine-tuning or to avoid the potential race conditions mentioned for `"auto"`.
+`"debug"` works like `"auto"` but after bundling, it will display a warning containing a list of ids that have been wrapped which can be used as picomatch pattern for fine-tuning or to avoid the potential race conditions mentioned for `"auto"`.
 
 ### `dynamicRequireTargets`
 
@@ -104,14 +104,14 @@ To avoid long paths when using the `dynamicRequireTargets` option, you can use t
 Type: `string | string[]`<br>
 Default: `null`
 
-A [minimatch pattern](https://github.com/isaacs/minimatch), or array of patterns, which specifies the files in the build the plugin should _ignore_. By default, all files with extensions other than those in `extensions` or `".cjs"` are ignored, but you can exclude additional files. See also the `include` option.
+A [picomatch pattern](https://github.com/micromatch/picomatch), or array of patterns, which specifies the files in the build the plugin should _ignore_. By default, all files with extensions other than those in `extensions` or `".cjs"` are ignored, but you can exclude additional files. See also the `include` option.
 
 ### `include`
 
 Type: `string | string[]`<br>
 Default: `null`
 
-A [minimatch pattern](https://github.com/isaacs/minimatch), or array of patterns, which specifies the files in the build the plugin should operate on. By default, all files with extension `".cjs"` or those in `extensions` are included, but you can narrow this list by only including specific files. These files will be analyzed and transpiled if either the analysis does not find ES module specific statements or `transformMixedEsModules` is `true`.
+A [picomatch pattern](https://github.com/micromatch/picomatch), or array of patterns, which specifies the files in the build the plugin should operate on. By default, all files with extension `".cjs"` or those in `extensions` are included, but you can narrow this list by only including specific files. These files will be analyzed and transpiled if either the analysis does not find ES module specific statements or `transformMixedEsModules` is `true`.
 
 ### `extensions`
 

--- a/packages/commonjs/types/index.d.ts
+++ b/packages/commonjs/types/index.d.ts
@@ -6,7 +6,7 @@ type DefaultIsModuleExportsOption = boolean | 'auto';
 
 interface RollupCommonJSOptions {
   /**
-   * A minimatch pattern, or array of patterns, which specifies the files in
+   * A picomatch pattern, or array of patterns, which specifies the files in
    * the build the plugin should operate on. By default, all files with
    * extension `".cjs"` or those in `extensions` are included, but you can
    * narrow this list by only including specific files. These files will be
@@ -16,7 +16,7 @@ interface RollupCommonJSOptions {
    */
   include?: FilterPattern;
   /**
-   * A minimatch pattern, or array of patterns, which specifies the files in
+   * A picomatch pattern, or array of patterns, which specifies the files in
    * the build the plugin should _ignore_. By default, all files with
    * extensions other than those in `extensions` or `".cjs"` are ignored, but you
    * can exclude additional files. See also the `include` option.
@@ -88,13 +88,13 @@ interface RollupCommonJSOptions {
    * work depending on the nature of cyclic dependencies but will often cause
    * problems.
    *
-   * You can also provide a minimatch pattern, or array of patterns, to only
+   * You can also provide a picomatch pattern, or array of patterns, to only
    * specify a subset of files which should be wrapped in functions for proper
    * `require` semantics.
    *
    * `"debug"` works like `"auto"` but after bundling, it will display a warning
    * containing a list of ids that have been wrapped which can be used as
-   * minimatch pattern for fine-tuning.
+   * picomatch pattern for fine-tuning.
    * @default "auto"
    */
   strictRequires?: boolean | FilterPattern;

--- a/packages/dsv/types/index.d.ts
+++ b/packages/dsv/types/index.d.ts
@@ -4,13 +4,13 @@ import { Plugin } from 'rollup';
 
 interface RollupDsvOptions {
   /**
-   * A minimatch pattern, or array of patterns, which specifies the files in the build the plugin
+   * A picomatch pattern, or array of patterns, which specifies the files in the build the plugin
    * should operate on.
    * By default all files are targeted.
    */
   include?: FilterPattern;
   /**
-   * A minimatch pattern, or array of patterns, which specifies the files in the build the plugin
+   * A picomatch pattern, or array of patterns, which specifies the files in the build the plugin
    * should _ignore_.
    * By default no files are ignored.
    */

--- a/packages/dynamic-import-vars/types/index.d.ts
+++ b/packages/dynamic-import-vars/types/index.d.ts
@@ -3,13 +3,13 @@ import { Plugin } from 'rollup';
 
 interface RollupDynamicImportVariablesOptions {
   /**
-   * A minimatch pattern, or array of patterns, which specifies the files in the build the plugin
+   * A picomatch pattern, or array of patterns, which specifies the files in the build the plugin
    * should operate on.
    * By default all files are targeted.
    */
   include?: FilterPattern;
   /**
-   * A minimatch pattern, or array of patterns, which specifies the files in the build the plugin
+   * A picomatch pattern, or array of patterns, which specifies the files in the build the plugin
    * should _ignore_.
    * By default no files are ignored.
    */

--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -86,14 +86,14 @@ query AllHeroes {
 Type: `String` | `Array[...String]`<br>
 Default: `null`
 
-A [minimatch pattern](https://github.com/isaacs/minimatch), or array of patterns, which specifies the files in the build the plugin should _ignore_. By default no files are ignored.
+A [picomatch pattern](https://github.com/micromatch/picomatch), or array of patterns, which specifies the files in the build the plugin should _ignore_. By default no files are ignored.
 
 ### `include`
 
 Type: `String` | `Array[...String]`<br>
 Default: `null`
 
-A [minimatch pattern](https://github.com/isaacs/minimatch), or array of patterns, which specifies the files in the build the plugin should operate on. By default all files are targeted.
+A [picomatch pattern](https://github.com/micromatch/picomatch), or array of patterns, which specifies the files in the build the plugin should operate on. By default all files are targeted.
 
 ## Meta
 

--- a/packages/image/README.md
+++ b/packages/image/README.md
@@ -75,14 +75,14 @@ document.body.appendChild(logo);
 Type: `String` | `Array[...String]`<br>
 Default: `null`
 
-A [minimatch pattern](https://github.com/isaacs/minimatch), or array of patterns, which specifies the files in the build the plugin should _ignore_. By default no files are ignored.
+A [picomatch pattern](https://github.com/micromatch/picomatch), or array of patterns, which specifies the files in the build the plugin should _ignore_. By default no files are ignored.
 
 ### `include`
 
 Type: `String` | `Array[...String]`<br>
 Default: `null`
 
-A [minimatch pattern](https://github.com/isaacs/minimatch), or array of patterns, which specifies the files in the build the plugin should operate on. By default all files are targeted.
+A [picomatch pattern](https://github.com/micromatch/picomatch), or array of patterns, which specifies the files in the build the plugin should operate on. By default all files are targeted.
 
 ## Meta
 

--- a/packages/image/types/index.d.ts
+++ b/packages/image/types/index.d.ts
@@ -3,13 +3,13 @@ import { Plugin } from 'rollup';
 
 interface RollupImageOptions {
   /**
-   * A minimatch pattern, or array of patterns, which specifies the files in the build the plugin
+   * A picomatch pattern, or array of patterns, which specifies the files in the build the plugin
    * should operate on.
    * By default all files are targeted.
    */
   include?: FilterPattern;
   /**
-   * A minimatch pattern, or array of patterns, which specifies the files in the build the plugin
+   * A picomatch pattern, or array of patterns, which specifies the files in the build the plugin
    * should _ignore_.
    * By default no files are ignored.
    */

--- a/packages/inject/README.md
+++ b/packages/inject/README.md
@@ -80,14 +80,14 @@ In addition to the properties and values specified for injecting, users may also
 Type: `String` | `Array[...String]`<br>
 Default: `null`
 
-A [minimatch pattern](https://github.com/isaacs/minimatch), or array of patterns, which specifies the files in the build the plugin should _ignore_. By default no files are ignored.
+A [picomatch pattern](https://github.com/micromatch/picomatch), or array of patterns, which specifies the files in the build the plugin should _ignore_. By default no files are ignored.
 
 ### `include`
 
 Type: `String` | `Array[...String]`<br>
 Default: `null`
 
-A [minimatch pattern](https://github.com/isaacs/minimatch), or array of patterns, which specifies the files in the build the plugin should operate on. By default all files are targeted.
+A [picomatch pattern](https://github.com/micromatch/picomatch), or array of patterns, which specifies the files in the build the plugin should operate on. By default all files are targeted.
 
 ## Meta
 

--- a/packages/inject/index.d.ts
+++ b/packages/inject/index.d.ts
@@ -14,7 +14,7 @@ export interface RollupInjectOptions {
     | RollupInjectOptions['modules'];
 
   /**
-   * A minimatch pattern, or array of patterns, of files that should be
+   * A picomatch pattern, or array of patterns, of files that should be
    * processed by this plugin (if omitted, all files are included by default)
    */
   include?: string | RegExp | ReadonlyArray<string | RegExp> | null;

--- a/packages/replace/README.md
+++ b/packages/replace/README.md
@@ -145,14 +145,14 @@ if (false == true) {
 Type: `String` | `Array[...String]`<br>
 Default: `null`
 
-A [minimatch pattern](https://github.com/isaacs/minimatch), or array of patterns, which specifies the files in the build the plugin should _ignore_. By default no files are ignored.
+A [picomatch pattern](https://github.com/micromatch/picomatch), or array of patterns, which specifies the files in the build the plugin should _ignore_. By default no files are ignored.
 
 ### `include`
 
 Type: `String` | `Array[...String]`<br>
 Default: `null`
 
-A [minimatch pattern](https://github.com/isaacs/minimatch), or array of patterns, which specifies the files in the build the plugin should operate on. By default all files are targeted.
+A [picomatch pattern](https://github.com/micromatch/picomatch), or array of patterns, which specifies the files in the build the plugin should operate on. By default all files are targeted.
 
 ### `values`
 

--- a/packages/replace/types/index.d.ts
+++ b/packages/replace/types/index.d.ts
@@ -15,7 +15,7 @@ export interface RollupReplaceOptions {
     | RollupReplaceOptions['preventAssignment'];
 
   /**
-   * A minimatch pattern, or array of patterns, of files that should be
+   * A picomatch pattern, or array of patterns, of files that should be
    * processed by this plugin (if omitted, all files are included by default)
    */
   include?: FilterPattern;

--- a/packages/strip/types/index.d.ts
+++ b/packages/strip/types/index.d.ts
@@ -3,13 +3,13 @@ import { Plugin } from 'rollup';
 
 interface RollupStripOptions {
   /**
-   * A minimatch pattern, or array of patterns, which specifies the files in the build the plugin
+   * A picomatch pattern, or array of patterns, which specifies the files in the build the plugin
    * should operate on.
    * By default all files are targeted.
    */
   include?: FilterPattern;
   /**
-   * A minimatch pattern, or array of patterns, which specifies the files in the build the plugin
+   * A picomatch pattern, or array of patterns, which specifies the files in the build the plugin
    * should _ignore_.
    * By default no files are ignored.
    */

--- a/packages/sucrase/README.md
+++ b/packages/sucrase/README.md
@@ -67,14 +67,14 @@ The following [Sucrase options](https://github.com/alangpierce/sucrase#transform
 Type: `String` | `Array[...String]`
 Default: `null`
 
-A [minimatch pattern](https://github.com/isaacs/minimatch), or array of patterns, which specifies the files in the build the plugin should _ignore_. By default no files are ignored.
+A [picomatch pattern](https://github.com/micromatch/picomatch), or array of patterns, which specifies the files in the build the plugin should _ignore_. By default no files are ignored.
 
 ### `include`
 
 Type: `String` | `Array[...String]`
 Default: `null`
 
-A [minimatch pattern](https://github.com/isaacs/minimatch), or array of patterns, which specifies the files in the build the plugin should operate on. By default all files are targeted.
+A [picomatch pattern](https://github.com/micromatch/picomatch), or array of patterns, which specifies the files in the build the plugin should operate on. By default all files are targeted.
 
 ## Meta
 

--- a/packages/sucrase/types/index.d.ts
+++ b/packages/sucrase/types/index.d.ts
@@ -14,13 +14,13 @@ interface RollupSucraseOptions
     | 'disableESTransforms'
   > {
   /**
-   * A minimatch pattern, or array of patterns, which specifies the files in the build the plugin
+   * A picomatch pattern, or array of patterns, which specifies the files in the build the plugin
    * should operate on.
    * By default all files are targeted.
    */
   include?: FilterPattern;
   /**
-   * A minimatch pattern, or array of patterns, which specifies the files in the build the plugin
+   * A picomatch pattern, or array of patterns, which specifies the files in the build the plugin
    * should _ignore_.
    * By default no files are ignored.
    */

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -70,14 +70,14 @@ The following options are unique to `rollup-plugin-typescript`:
 Type: `String` | `Array[...String]`<br>
 Default: `null`
 
-A [minimatch pattern](https://github.com/isaacs/minimatch), or array of patterns, which specifies the files in the build the plugin should _ignore_. By default no files are ignored.
+A [picomatch pattern](https://github.com/micromatch/picomatch), or array of patterns, which specifies the files in the build the plugin should _ignore_. By default no files are ignored.
 
 ### `include`
 
 Type: `String` | `Array[...String]`<br>
 Default: `null`
 
-A [minimatch pattern](https://github.com/isaacs/minimatch), or array of patterns, which specifies the files in the build the plugin should operate on. By default all `.ts` and `.tsx` files are targeted.
+A [picomatch pattern](https://github.com/micromatch/picomatch), or array of patterns, which specifies the files in the build the plugin should operate on. By default all `.ts` and `.tsx` files are targeted.
 
 ### `filterRoot`
 

--- a/packages/url/README.md
+++ b/packages/url/README.md
@@ -57,14 +57,14 @@ console.log(`svg contents: ${svg}`);
 Type: `String` | `Array[...String]`<br>
 Default: `null`
 
-A [minimatch pattern](https://github.com/isaacs/minimatch), or array of patterns, which specifies the files in the build the plugin should _ignore_. By default no files are ignored.
+A [picomatch pattern](https://github.com/micromatch/picomatch), or array of patterns, which specifies the files in the build the plugin should _ignore_. By default no files are ignored.
 
 ### `include`
 
 Type: `String` | `Array[...String]`<br>
 Default: `['**/*.svg', '**/*.png', '**/*.jp(e)?g', '**/*.gif', '**/*.webp']`
 
-A [minimatch pattern](https://github.com/isaacs/minimatch), or array of patterns, which specifies the files in the build the plugin should operate on. By default .svg, .png, .jpg, .jpeg, .gif and .webp files are targeted.
+A [picomatch pattern](https://github.com/micromatch/picomatch), or array of patterns, which specifies the files in the build the plugin should operate on. By default .svg, .png, .jpg, .jpeg, .gif and .webp files are targeted.
 
 ### `limit`
 

--- a/packages/url/types/index.d.ts
+++ b/packages/url/types/index.d.ts
@@ -5,14 +5,14 @@ interface RollupUrlOptions {
   // Note: the @default tag below uses the zero-width character joiner "‍" to escape the "*/"
   // https://en.wikipedia.org/wiki/Zero-width_joiner
   /**
-   * A minimatch pattern, or array of patterns, which specifies the files in the build the plugin
+   * A picomatch pattern, or array of patterns, which specifies the files in the build the plugin
    * should operate on.
    * By default all files are targeted.
    * @default ['**‍/*.svg', '**‍/*.png', '**‍/*.jp(e)?g', '**‍/*.gif', '**‍/*.webp']
    */
   include?: FilterPattern;
   /**
-   * A minimatch pattern, or array of patterns, which specifies the files in the build the plugin
+   * A picomatch pattern, or array of patterns, which specifies the files in the build the plugin
    * should _ignore_.
    * By default no files are ignored.
    */

--- a/packages/yaml/README.md
+++ b/packages/yaml/README.md
@@ -65,14 +65,14 @@ If `single`, specifies that the target YAML documents contain only one document 
 Type: `String` | `Array[...String]`<br>
 Default: `null`
 
-A [minimatch pattern](https://github.com/isaacs/minimatch), or array of patterns, which specifies the files in the build the plugin should _ignore_. By default no files are ignored.
+A [picomatch pattern](https://github.com/micromatch/picomatch), or array of patterns, which specifies the files in the build the plugin should _ignore_. By default no files are ignored.
 
 ### `include`
 
 Type: `String` | `Array[...String]`<br>
 Default: `null`
 
-A [minimatch pattern](https://github.com/isaacs/minimatch), or array of patterns, which specifies the files in the build the plugin should operate on. By default all files are targeted.
+A [picomatch pattern](https://github.com/micromatch/picomatch), or array of patterns, which specifies the files in the build the plugin should operate on. By default all files are targeted.
 
 ### `safe`
 

--- a/packages/yaml/types/index.d.ts
+++ b/packages/yaml/types/index.d.ts
@@ -11,13 +11,13 @@ type ValidYamlType =
 
 interface RollupYamlOptions {
   /**
-   * A minimatch pattern, or array of patterns, which specifies the files in the build the plugin
+   * A picomatch pattern, or array of patterns, which specifies the files in the build the plugin
    * should operate on.
    * By default all files are targeted.
    */
   include?: FilterPattern;
   /**
-   * A minimatch pattern, or array of patterns, which specifies the files in the build the plugin
+   * A picomatch pattern, or array of patterns, which specifies the files in the build the plugin
    * should _ignore_.
    * By default no files are ignored.
    */


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `babel`, `buble`, `commonjs`, `dsv`, `dynamic-import-vars`, `graphql`, `image`, `inject`, `replace`, `strip`, `sucrase`, `typescript`, `url`, `yaml`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

`createFilter` func from `@rollup/pluginutils` <=v3.0.10 uses picomatch and >v3.0.10 uses `minimatch` (https://github.com/rollup/plugins/pull/306). 

[`picomatch` supports slightly different features from `minimatch`](https://github.com/micromatch/picomatch#library-comparisons). https://github.com/rollup/plugins/tree/master/packages/pluginutils#include-and-exclude

So I updated documents/dts from "minimatch pattern" to "picomatch pattern".

This is the list that shows which plugin uses which version of `@rollup/pluginutils`:
- `@rollup/plugin-babel`: ^3.1.0
- `@rollup/plugin-buble`: ^3.1.0
- `@rollup/plugin-commonjs`: ^3.1.0
- `@rollup/plugin-dsv`: ^3.1.0
- `@rollup/plugin-dynamic-import-vars`: ^4.1.2
- `@rollup/plugin-graphql`: ^4.0.0
- `@rollup/plugin-image`: ^3.1.0
- `@rollup/plugin-inject`: ^3.1.0
- `@rollup/plugin-replace`: ^3.1.0
- `@rollup/plugin-strip`: ^3.1.0
- `@rollup/plugin-sucrase`: ^4.1.1
- `@rollup/plugin-typescript`: ^3.1.0
- `@rollup/plugin-url`: ^4.2.1
- `@rollup/plugin-yaml`: ^3.1.0

I didn't change:
- `@rollup/plugin-json`: because it uses `@rollup/pluginutils` ^3.0.8, so either `minimatch` or `picomatch` might be used
- `@rollup/plugin-multi-entry`: because it uses [`matched`](https://github.com/jonschlinkert/matched)
