### PR TITLE
fix(inject): rollup is optional peer dependency

### DIFF
--- a/packages/inject/package.json
+++ b/packages/inject/package.json
@@ -46,6 +46,11 @@
   "peerDependencies": {
     "rollup": "^1.20.0 || ^2.0.0"
   },
+  "peerDependenciesMeta": {
+    "rollup": {
+      "optional": true 
+    }
+  },
   "dependencies": {
     "@rollup/pluginutils": "^3.1.0",
     "estree-walker": "^2.0.1",


### PR DESCRIPTION
## Rollup Plugin Name: `inject`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

Relevant issues:

* https://github.com/climateinteractive/SDEverywhere/issues/209
* https://github.com/pnpm/pnpm/issues/4183

### Description

this plugin can be used from vite
for example in https://github.com/sodatea/vite-plugin-node-stdlib-browser

in this case, rollup is not installed

this fix should also be applied to other rollup plugins

workaround for pnpm: add this to `package.json`

```json
{
  "pnpm": {
    "peerDependencyRules": {
      "ignoreMissing": [
        "rollup"
      ]
    }
  }
}
```
