### PR TITLE
fix(pluginutils): prepare for Rollup 3

### DIFF
--- a/packages/pluginutils/README.md
+++ b/packages/pluginutils/README.md
@@ -13,7 +13,7 @@ A set of utility functions commonly used by 🍣 Rollup plugins.
 
 ## Requirements
 
-This plugin requires an [LTS](https://github.com/nodejs/Release) Node version (v8.0.0+) and Rollup v1.20.0+.
+The plugin utils require an [LTS](https://github.com/nodejs/Release) Node version (v14.0.0+) and Rollup v1.20.0+.
 
 ## Install
 

--- a/packages/pluginutils/package.json
+++ b/packages/pluginutils/package.json
@@ -19,11 +19,12 @@
   "module": "./dist/es/index.js",
   "type": "commonjs",
   "exports": {
-    "require": "./dist/cjs/index.js",
-    "import": "./dist/es/index.js"
+    "types": "./types/index.d.ts",
+    "import": "./dist/es/index.js",
+    "default": "./dist/cjs/index.js"
   },
   "engines": {
-    "node": ">= 8.0.0"
+    "node": ">=14.0.0"
   },
   "scripts": {
     "build": "rollup -c",
@@ -41,6 +42,7 @@
   },
   "files": [
     "dist",
+    "!dist/**/*.map",
     "types",
     "README.md",
     "LICENSE"
@@ -50,22 +52,30 @@
     "plugin",
     "utils"
   ],
+  "peerDependencies": {
+    "rollup": "^1.20.0||^2.0.0||^3.0.0"
+  },
+  "peerDependenciesMeta": {
+    "rollup": {
+      "optional": true
+    }
+  },
   "dependencies": {
-    "estree-walker": "^2.0.1",
-    "picomatch": "^2.2.2"
+    "estree-walker": "^2.0.2",
+    "picomatch": "^2.3.1"
   },
   "devDependencies": {
-    "@rollup/plugin-commonjs": "^14.0.0",
-    "@rollup/plugin-node-resolve": "^8.4.0",
-    "@rollup/plugin-typescript": "^5.0.2",
-    "@types/estree": "0.0.45",
-    "@types/node": "^14.0.26",
-    "@types/picomatch": "^2.2.1",
-    "acorn": "^8.0.4",
-    "rollup": "^2.67.3",
-    "typescript": "^4.1.2"
+    "@rollup/plugin-commonjs": "^22.0.2",
+    "@rollup/plugin-node-resolve": "^14.1.0",
+    "@rollup/plugin-typescript": "^8.5.0",
+    "@types/estree": "1.0.0",
+    "@types/node": "^14.18.30",
+    "@types/picomatch": "^2.3.0",
+    "acorn": "^8.8.0",
+    "rollup": "^3.0.0-7",
+    "typescript": "^4.8.3"
   },
-  "types": "types/index.d.ts",
+  "types": "./types/index.d.ts",
   "ava": {
     "extensions": [
       "ts"

--- a/packages/pluginutils/rollup.config.mjs
+++ b/packages/pluginutils/rollup.config.mjs
@@ -1,23 +1,19 @@
-import { builtinModules } from 'module';
+import { readFileSync } from 'fs';
 
 import commonjs from '@rollup/plugin-commonjs';
 import resolve from '@rollup/plugin-node-resolve';
 import typescript from '@rollup/plugin-typescript';
 
-import { emitModulePackageFile } from '../../shared/rollup.config';
-
-import pkg from './package.json';
+import { createConfig } from '../../shared/rollup.config.mjs';
 
 export default {
+  ...createConfig({
+    pkg: JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8'))
+  }),
   input: 'src/index.ts',
   plugins: [
     resolve(),
     commonjs({ include: '../../node_modules/.pnpm/registry.npmjs.org/**' }),
     typescript({ include: '**/*.{ts,js}', module: 'esnext' })
-  ],
-  external: [...builtinModules, 'picomatch'],
-  output: [
-    { file: pkg.main, format: 'cjs', exports: 'named' },
-    { file: pkg.module, format: 'es', plugins: [emitModulePackageFile()] }
   ]
 };

--- a/packages/pluginutils/src/addExtension.ts
+++ b/packages/pluginutils/src/addExtension.ts
@@ -1,6 +1,6 @@
 import { extname } from 'path';
 
-import { AddExtension } from '../types';
+import type { AddExtension } from '../types';
 
 const addExtension: AddExtension = function addExtension(filename, ext = '.js') {
   let result = `${filename}`;

--- a/packages/pluginutils/src/attachScopes.ts
+++ b/packages/pluginutils/src/attachScopes.ts
@@ -1,9 +1,8 @@
-// eslint-disable-next-line import/no-unresolved
 import * as estree from 'estree';
 
 import { walk } from 'estree-walker';
 
-import { AttachedScope, AttachScopes } from '../types';
+import type { AttachedScope, AttachScopes } from '../types';
 
 import extractAssignedNames from './extractAssignedNames';
 

--- a/packages/pluginutils/src/createFilter.ts
+++ b/packages/pluginutils/src/createFilter.ts
@@ -2,7 +2,7 @@ import { resolve, posix, isAbsolute } from 'path';
 
 import pm from 'picomatch';
 
-import { CreateFilter } from '../types';
+import type { CreateFilter } from '../types';
 
 import ensureArray from './utils/ensureArray';
 import normalizePath from './normalizePath';

--- a/packages/pluginutils/src/dataToEsm.ts
+++ b/packages/pluginutils/src/dataToEsm.ts
@@ -1,4 +1,4 @@
-import { DataToEsm } from '../types';
+import type { DataToEsm } from '../types';
 
 import makeLegalIdentifier from './makeLegalIdentifier';
 

--- a/packages/pluginutils/src/extractAssignedNames.ts
+++ b/packages/pluginutils/src/extractAssignedNames.ts
@@ -1,4 +1,4 @@
-import { ExtractAssignedNames } from '../types';
+import type { ExtractAssignedNames } from '../types';
 
 interface Extractors {
   [key: string]: (names: string[], param: any) => void;

--- a/packages/pluginutils/src/makeLegalIdentifier.ts
+++ b/packages/pluginutils/src/makeLegalIdentifier.ts
@@ -1,4 +1,4 @@
-import { MakeLegalIdentifier } from '../types';
+import type { MakeLegalIdentifier } from '../types';
 
 const reservedWords =
   'break case class catch const continue debugger default delete do else export extends finally for function if import in instanceof let new return super switch this throw try typeof var void while with yield enum await implements package protected static interface private public';

--- a/packages/pluginutils/src/normalizePath.ts
+++ b/packages/pluginutils/src/normalizePath.ts
@@ -1,6 +1,6 @@
 import { win32, posix } from 'path';
 
-import { NormalizePath } from '../types';
+import type { NormalizePath } from '../types';
 
 const normalizePath: NormalizePath = function normalizePath(filename: string) {
   return filename.split(win32.sep).join(posix.sep);

--- a/packages/pluginutils/test/attachScopes.ts
+++ b/packages/pluginutils/test/attachScopes.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-unresolved
 import * as estree from 'estree';
 
 import test from 'ava';

--- a/packages/pluginutils/types/index.d.ts
+++ b/packages/pluginutils/types/index.d.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-unresolved
 import { BaseNode } from 'estree';
 
 export interface AttachedScope {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -409,29 +409,29 @@ importers:
 
   packages/pluginutils:
     specifiers:
-      '@rollup/plugin-commonjs': ^14.0.0
-      '@rollup/plugin-node-resolve': ^8.4.0
-      '@rollup/plugin-typescript': ^5.0.2
-      '@types/estree': 0.0.45
-      '@types/node': ^14.0.26
-      '@types/picomatch': ^2.2.1
-      acorn: ^8.0.4
-      estree-walker: ^2.0.1
-      picomatch: ^2.2.2
-      rollup: ^2.67.3
-      typescript: ^4.1.2
+      '@rollup/plugin-commonjs': ^22.0.2
+      '@rollup/plugin-node-resolve': ^14.1.0
+      '@rollup/plugin-typescript': ^8.5.0
+      '@types/estree': 1.0.0
+      '@types/node': ^14.18.30
+      '@types/picomatch': ^2.3.0
+      acorn: ^8.8.0
+      estree-walker: ^2.0.2
+      picomatch: ^2.3.1
+      rollup: ^3.0.0-7
+      typescript: ^4.8.3
     dependencies:
       estree-walker: 2.0.2
       picomatch: 2.3.1
     devDependencies:
-      '@rollup/plugin-commonjs': 14.0.0_rollup@2.79.1
-      '@rollup/plugin-node-resolve': 8.4.0_rollup@2.79.1
-      '@rollup/plugin-typescript': 5.0.2_5q64ijqsuisqe52alrh6v6njki
-      '@types/estree': 0.0.45
+      '@rollup/plugin-commonjs': 22.0.2_rollup@3.0.0-7
+      '@rollup/plugin-node-resolve': 14.1.0_rollup@3.0.0-7
+      '@rollup/plugin-typescript': 8.5.0_vmpcm5aav5u37diqfc6pdubvhq
+      '@types/estree': 1.0.0
       '@types/node': 14.18.30
       '@types/picomatch': 2.3.0
       acorn: 8.8.0
-      rollup: 2.79.1
+      rollup: 3.0.0-7
       typescript: 4.8.3
 
   packages/replace:
@@ -2031,22 +2031,6 @@ packages:
       rollup: 2.79.1
     dev: true
 
-  /@rollup/plugin-commonjs/14.0.0_rollup@2.79.1:
-    resolution: {integrity: sha512-+PSmD9ePwTAeU106i9FRdc+Zb3XUWyW26mo5Atr2mk82hor8+nPwkztEjFo8/B1fJKfaQDg9aM2bzQkjhi7zOw==}
-    engines: {node: '>= 8.0.0'}
-    peerDependencies:
-      rollup: ^2.3.4
-    dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.79.1
-      commondir: 1.0.1
-      estree-walker: 1.0.1
-      glob: 7.2.3
-      is-reference: 1.2.1
-      magic-string: 0.25.9
-      resolve: 1.22.1
-      rollup: 2.79.1
-    dev: true
-
   /@rollup/plugin-commonjs/22.0.2_rollup@3.0.0-7:
     resolution: {integrity: sha512-//NdP6iIwPbMTcazYsiBMbJW7gfmpHom33u1beiIoHDEM0Q9clvtQB1T0efvMqHeKsGohiHo97BCPCkBXdscwg==}
     engines: {node: '>= 12.0.0'}
@@ -2341,10 +2325,6 @@ packages:
 
   /@types/estree/0.0.39:
     resolution: {integrity: sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==}
-
-  /@types/estree/0.0.45:
-    resolution: {integrity: sha512-jnqIUKDUqJbDIUxm0Uj7bnlMnRm1T/eZ9N+AVMqhPgzrba2GhGG5o/jCTwmdPK709nEZsGoMzXEDUjcXHa3W0g==}
-    dev: true
 
   /@types/estree/1.0.0:
     resolution: {integrity: sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==}


### PR DESCRIPTION
BREAKING CHANGES: Requires Node 14

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `pluginutils`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [x] yes (_breaking changes will not be merged unless absolutely necessary_) Requires Node 14
- [ ] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers:

### Description
This PR updates the plugin for Rollup 3 compatibility. This will not change compatibility with older Rollup versions.
* It should be merged after #1277

It contains the following:
* Update minimal required Node version to 14 (also reflected in README, breaking change)
* Extend Rollup peerDependency version with `||^3.0.0`
* Make Rollup an optional peerDependency as technically, plugins do not require Rollup but only depend on its API. Apparently solves issues with pnpm, see #1272
* Use a shared Rollup config for all plugins
    * This allows to share bundling improvements and unifies the build
    * All plugins now use `strictDeprecations` to fail early if they use deprecated Rollup features as well as an `onward` handler that fails the build
    * The CJS output now uses

      ```
      exports: 'named',
      footer: 'module.exports = Object.assign(exports.default, exports);'
      ```

      which will allow the default export to be directly required while still supporting named exports
* The `"exports"` `package.json` field is now properly configured for `require` and `import`.
* CJS and ESM output are now in different sub-folders with a  `package.json` file with `"type": "module"` next to the CJS output (via the shared Rollup config)
* Internally, the latest Rollup 3 pre-release build is used to ensure compatibility
* Rollup configs now follow Node semantics, i.e. `.mjs` for ESM configs, no direct import of `package.json`
* TypeScript output has been changed to target ES2019