### PR TITLE
fix(typescript)!: don't resolve filtered files (#1267)

### DIFF
--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -125,6 +125,7 @@ export default function typescript(options: RollupTypescriptOptions = {}): Plugi
 
       if (resolved) {
         if (/\.d\.[cm]?ts/.test(resolved.extension)) return null;
+        if (!filter(resolved.resolvedFileName)) return null;
         return path.normalize(resolved.resolvedFileName);
       }
 

--- a/packages/typescript/test/test.js
+++ b/packages/typescript/test/test.js
@@ -999,8 +999,8 @@ test.serial('does it fail for filtering with incorrect rootDir in nested project
       plugins: [typescript({ tsconfig: 'tsconfig.json' })]
     })
   );
-  // Will throw parse error because it includes a typescript file outside CWD
-  t.is(error.code, 'PARSE_ERROR');
+  // It imports a typescript file outside CWD, hence will not get resolved
+  t.is(error.code, 'UNRESOLVED_IMPORT');
 });
 
 test.serial('does manually setting filterRoot resolve nested projects', async (t) => {


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `typescript`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [x] yes (_breaking changes will not be merged unless absolutely necessary_)
- [ ] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:
#1267 

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

BREAKING CHANGES: The signature of the error being thrown has changed.

This should fix the issue #1267, which is caused by the use of `order: "post"` as part of https://github.com/rollup/plugins/pull/1245. It will prevent the typescript plugin from resolving files which are not included by its provided configuration/options. Instead the `node-resolve` plugin will again handle these cases, which is able to correctly handle the `browser` config parameter. The same fix has been done for the `rollup-plugin-typescrip2` here: https://github.com/ezolenko/rollup-plugin-typescript2/commit/f6db59613a66f58c48310aa8fa785951970b5d6d