### PR TITLE
fix(typescript)!: incorrect declarations directory

### DIFF
--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -157,6 +157,15 @@ export default function typescript(options: RollupTypescriptOptions = {}): Plugi
             (parsedOptions.options.declaration
               ? parsedOptions.options.declarationDir || parsedOptions.options.outDir
               : null);
+          const cwd = normalizePath(process.cwd());
+          if (
+            parsedOptions.options.declaration &&
+            parsedOptions.options.declarationDir &&
+            baseDir?.startsWith(cwd)
+          ) {
+            const declarationDir = baseDir.slice(cwd.length + 1);
+            baseDir = baseDir.slice(0, -1 * declarationDir.length);
+          }
           if (!baseDir && tsconfig) {
             baseDir = tsconfig.substring(0, tsconfig.lastIndexOf('/'));
           }

--- a/packages/typescript/test/test.js
+++ b/packages/typescript/test/test.js
@@ -153,7 +153,7 @@ test.serial('supports emitting types also for single file output', async (t) => 
 
   t.deepEqual(
     output.map((out) => out.fileName),
-    ['main.js', 'main.d.ts']
+    ['main.js', 'dist/main.d.ts']
   );
   t.is(warnings.length, 0);
 });


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `plugin-typescript`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:
- #1230

### Description
The commit 5f78173 changed the behaviour of the typescript plugin. This introduced the issue #1230: The `declarationDir` was now ignored for single file setups. I made some analysis and found the problem:
* In the construction of the plugin the typescript configuration is parsed
* while parsing all paths are made absolute, prepended with `process.cwd()` ([packages/typescript/src/options/tsconfig.ts#L147](https://github.com/rollup/plugins/blob/master/packages/typescript/src/options/tsconfig.ts#L147))
* in order to output declaration files the `baseDir` is determied from the parsed config
* the `id` (filename generated by typescript) of the declaration file is also an absolute path, generated with the config
* as the "prefixes" match the result file misses the `declarationDir`

Example:
```javascript
let tsConfig = {
  // [...]
  "declaration": true,
  "declarationDir": "types"
  // [...]
};
// After initial config processing
tsConfig = {
  // [...]
  "declaration": true,
  "declarationDir": "/home/user/app/types"
  // [...]
};
// declaration file generation
const id = '/home/user/app/types/index.d.ts';
const baseDir = parsedOptions.options.declarationDir; // -> '/home/user/app/types'
path.relative(baseDir, id) // gives `index.d.ts` instead of `types/index.d.ts`
```

There is another description of this error in https://github.com/rollup/plugins/issues/1230#issuecomment-1233630234

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
