### PR TITLE
fix(pluginutils): Move `@types/estree` to dependencies (fixes #1315)

### DIFF
--- a/packages/pluginutils/package.json
+++ b/packages/pluginutils/package.json
@@ -61,6 +61,7 @@
     }
   },
   "dependencies": {
+    "@types/estree": "^1.0.0",
     "estree-walker": "^2.0.2",
     "picomatch": "^2.3.1"
   },
@@ -68,7 +69,6 @@
     "@rollup/plugin-commonjs": "^22.0.2",
     "@rollup/plugin-node-resolve": "^14.1.0",
     "@rollup/plugin-typescript": "^8.5.0",
-    "@types/estree": "1.0.0",
     "@types/node": "^14.18.30",
     "@types/picomatch": "^2.3.0",
     "acorn": "^8.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -412,7 +412,7 @@ importers:
       '@rollup/plugin-commonjs': ^22.0.2
       '@rollup/plugin-node-resolve': ^14.1.0
       '@rollup/plugin-typescript': ^8.5.0
-      '@types/estree': 1.0.0
+      '@types/estree': ^1.0.0
       '@types/node': ^14.18.30
       '@types/picomatch': ^2.3.0
       acorn: ^8.8.0
@@ -421,13 +421,13 @@ importers:
       rollup: ^3.0.0-7
       typescript: ^4.8.3
     dependencies:
+      '@types/estree': 1.0.0
       estree-walker: 2.0.2
       picomatch: 2.3.1
     devDependencies:
       '@rollup/plugin-commonjs': 22.0.2_rollup@3.0.0-7
       '@rollup/plugin-node-resolve': 14.1.0_rollup@3.0.0-7
       '@rollup/plugin-typescript': 8.5.0_wkkufgeabp7wfx7iyk42bruffi
-      '@types/estree': 1.0.0
       '@types/node': 14.18.31
       '@types/picomatch': 2.3.0
       acorn: 8.8.0


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `@rollup/pluginutils`

This PR contains:

- [X] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [X] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [X] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers: #1315

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

estree types are required for downstream packages, since pluginutils/types/index.d.ts makes use of them.
They were previously already part of `dependencies` (vs. `devDependencies`, where they currently are) but were accidentally moved in #616. This breaks TypeScript projects on the newest versions of `@rollup/plugin-typescript`, for example. See #1315 for more info and a reproduction.