### PR TITLE
chore(repo): enable `consistent-type-imports` for typescript files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,8 @@ module.exports = {
     'sort-keys': 'off',
     'typescript-sort-keys/interface': 'off',
     'import/extensions': 'off',
-    'import/no-unresolved': 'off'
+    'import/no-unresolved': 'off',
+    '@typescript-eslint/consistent-type-imports': 'error'
   },
   overrides: [
     {

--- a/packages/alias/src/index.ts
+++ b/packages/alias/src/index.ts
@@ -1,4 +1,4 @@
-import { Plugin } from 'rollup';
+import type { Plugin } from 'rollup';
 
 import type { ResolvedAlias, ResolverFunction, ResolverObject, RollupAliasOptions } from '../types';
 

--- a/packages/alias/types/index.d.ts
+++ b/packages/alias/types/index.d.ts
@@ -1,4 +1,4 @@
-import { Plugin, PluginHooks } from 'rollup';
+import type { Plugin, PluginHooks } from 'rollup';
 
 type MapToFunction<T> = T extends Function ? T : never;
 

--- a/packages/auto-install/src/index.ts
+++ b/packages/auto-install/src/index.ts
@@ -4,7 +4,7 @@ import mod from 'module';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 
-import { Plugin } from 'rollup';
+import type { Plugin } from 'rollup';
 
 import type { RollupAutoInstallOptions } from '../types';
 

--- a/packages/auto-install/types/index.d.ts
+++ b/packages/auto-install/types/index.d.ts
@@ -1,4 +1,4 @@
-import { Plugin } from 'rollup';
+import type { Plugin } from 'rollup';
 
 export interface RollupAutoInstallOptions {
   /**

--- a/packages/babel/test/types.ts
+++ b/packages/babel/test/types.ts
@@ -1,4 +1,5 @@
 /** eslint-disable @typescript-eslint/no-unused-vars */
+import type { RollupOptions } from 'rollup';
 
 import babelPlugin, {
   babel,
@@ -8,7 +9,7 @@ import babelPlugin, {
   createBabelOutputPluginFactory
 } from '../types';
 
-const rollupConfig: import('rollup').RollupOptions = {
+const rollupConfig: RollupOptions = {
   input: 'main.js',
   output: {
     file: 'bundle.js',

--- a/packages/babel/types/index.d.ts
+++ b/packages/babel/types/index.d.ts
@@ -1,6 +1,6 @@
-import { Plugin, PluginContext, TransformPluginContext } from 'rollup';
-import { FilterPattern, CreateFilter } from '@rollup/pluginutils';
-import * as babelCore from '@babel/core';
+import type { Plugin, PluginContext, TransformPluginContext } from 'rollup';
+import type { FilterPattern, CreateFilter } from '@rollup/pluginutils';
+import type * as babelCore from '@babel/core';
 
 export interface RollupBabelInputPluginOptions
   extends Omit<babelCore.TransformOptions, 'include' | 'exclude'> {

--- a/packages/beep/types/index.d.ts
+++ b/packages/beep/types/index.d.ts
@@ -1,4 +1,4 @@
-import { Plugin } from 'rollup';
+import type { Plugin } from 'rollup';
 
 /**
  * 🍣 A Rollup plugin that beeps when a build ends with errors.

--- a/packages/buble/src/index.ts
+++ b/packages/buble/src/index.ts
@@ -1,5 +1,5 @@
 import { transform } from 'buble';
-import { Plugin } from 'rollup';
+import type { Plugin } from 'rollup';
 import { createFilter } from '@rollup/pluginutils';
 
 import type { RollupBubleOptions } from '../types';

--- a/packages/buble/test/types.ts
+++ b/packages/buble/test/types.ts
@@ -1,4 +1,4 @@
-import { RollupOptions } from 'rollup';
+import type { RollupOptions } from 'rollup';
 
 import buble from '..';
 

--- a/packages/buble/types/index.d.ts
+++ b/packages/buble/types/index.d.ts
@@ -1,6 +1,6 @@
-import { FilterPattern } from '@rollup/pluginutils';
-import { TransformOptions } from 'buble';
-import { Plugin } from 'rollup';
+import type { FilterPattern } from '@rollup/pluginutils';
+import type { TransformOptions } from 'buble';
+import type { Plugin } from 'rollup';
 
 export interface RollupBubleOptions extends TransformOptions {
   /**

--- a/packages/commonjs/types/index.d.ts
+++ b/packages/commonjs/types/index.d.ts
@@ -1,5 +1,5 @@
-import { FilterPattern } from '@rollup/pluginutils';
-import { Plugin } from 'rollup';
+import type { FilterPattern } from '@rollup/pluginutils';
+import type { Plugin } from 'rollup';
 
 type RequireReturnsDefaultOption = boolean | 'auto' | 'preferred' | 'namespace';
 type DefaultIsModuleExportsOption = boolean | 'auto';

--- a/packages/data-uri/src/index.ts
+++ b/packages/data-uri/src/index.ts
@@ -1,6 +1,6 @@
 import { URL } from 'url';
 
-import { Plugin, RollupError } from 'rollup';
+import type { Plugin, RollupError } from 'rollup';
 
 import { dataToEsm } from '@rollup/pluginutils';
 

--- a/packages/data-uri/types/index.d.ts
+++ b/packages/data-uri/types/index.d.ts
@@ -1,4 +1,4 @@
-import { Plugin } from 'rollup';
+import type { Plugin } from 'rollup';
 
 /**
  * A Rollup plugin which imports modules from Data URIs.

--- a/packages/dsv/test/types.ts
+++ b/packages/dsv/test/types.ts
@@ -1,4 +1,4 @@
-import { RollupOptions } from 'rollup';
+import type { RollupOptions } from 'rollup';
 
 import dsv from '..';
 

--- a/packages/dsv/types/index.d.ts
+++ b/packages/dsv/types/index.d.ts
@@ -1,6 +1,6 @@
-import { DSVRowString } from 'd3-dsv';
-import { FilterPattern } from '@rollup/pluginutils';
-import { Plugin } from 'rollup';
+import type { DSVRowString } from 'd3-dsv';
+import type { FilterPattern } from '@rollup/pluginutils';
+import type { Plugin } from 'rollup';
 
 interface RollupDsvOptions {
   /**

--- a/packages/dynamic-import-vars/test/types.ts
+++ b/packages/dynamic-import-vars/test/types.ts
@@ -1,4 +1,4 @@
-import { RollupOptions } from 'rollup';
+import type { RollupOptions } from 'rollup';
 
 import dynamicImportVars, { dynamicImportToGlob } from '../src';
 

--- a/packages/dynamic-import-vars/types/index.d.ts
+++ b/packages/dynamic-import-vars/types/index.d.ts
@@ -1,5 +1,6 @@
 import type { FilterPattern } from '@rollup/pluginutils';
 import type { Plugin } from 'rollup';
+import type { BaseNode } from 'estree';
 
 interface RollupDynamicImportVariablesOptions {
   /**
@@ -24,10 +25,7 @@ interface RollupDynamicImportVariablesOptions {
 
 export class VariableDynamicImportError extends Error {}
 
-export function dynamicImportToGlob(
-  node: import('estree').BaseNode,
-  sourceString: string
-): null | string;
+export function dynamicImportToGlob(node: BaseNode, sourceString: string): null | string;
 
 /**
  * Support variables in dynamic imports in Rollup.

--- a/packages/dynamic-import-vars/types/index.d.ts
+++ b/packages/dynamic-import-vars/types/index.d.ts
@@ -1,5 +1,5 @@
-import { FilterPattern } from '@rollup/pluginutils';
-import { Plugin } from 'rollup';
+import type { FilterPattern } from '@rollup/pluginutils';
+import type { Plugin } from 'rollup';
 
 interface RollupDynamicImportVariablesOptions {
   /**

--- a/packages/eslint/src/index.ts
+++ b/packages/eslint/src/index.ts
@@ -1,6 +1,6 @@
 import { relative, resolve, sep } from 'path';
 
-import { Plugin } from 'rollup';
+import type { Plugin } from 'rollup';
 import { createFilter } from '@rollup/pluginutils';
 import { ESLint } from 'eslint';
 

--- a/packages/eslint/types/index.d.ts
+++ b/packages/eslint/types/index.d.ts
@@ -1,6 +1,6 @@
-import { Plugin } from 'rollup';
-import { CLIEngine, ESLint } from 'eslint';
-import { CreateFilter } from '@rollup/pluginutils';
+import type { Plugin } from 'rollup';
+import type { CLIEngine, ESLint } from 'eslint';
+import type { CreateFilter } from '@rollup/pluginutils';
 
 export interface RollupEslintOptions extends ESLint.Options {
   /**

--- a/packages/graphql/test/types.ts
+++ b/packages/graphql/test/types.ts
@@ -1,4 +1,4 @@
-import { RollupOptions } from 'rollup';
+import type { RollupOptions } from 'rollup';
 
 import graphql from '..';
 

--- a/packages/graphql/types/index.d.ts
+++ b/packages/graphql/types/index.d.ts
@@ -1,5 +1,5 @@
-import { FilterPattern } from '@rollup/pluginutils';
-import { Plugin } from 'rollup';
+import type { FilterPattern } from '@rollup/pluginutils';
+import type { Plugin } from 'rollup';
 
 export interface RollupGraphqlOptions {
   /**

--- a/packages/html/src/index.ts
+++ b/packages/html/src/index.ts
@@ -1,6 +1,6 @@
 import { extname } from 'path';
 
-import { Plugin, NormalizedOutputOptions, OutputBundle, EmittedAsset } from 'rollup';
+import type { Plugin, NormalizedOutputOptions, OutputBundle, EmittedAsset } from 'rollup';
 
 import type { RollupHtmlOptions, RollupHtmlTemplateOptions } from '../types';
 

--- a/packages/html/types/index.d.ts
+++ b/packages/html/types/index.d.ts
@@ -1,4 +1,4 @@
-import { Plugin, OutputChunk, OutputAsset, OutputBundle } from 'rollup';
+import type { Plugin, OutputChunk, OutputAsset, OutputBundle } from 'rollup';
 
 export interface RollupHtmlTemplateOptions {
   title: string;

--- a/packages/image/test/types.ts
+++ b/packages/image/test/types.ts
@@ -1,4 +1,4 @@
-import { RollupOptions } from 'rollup';
+import type { RollupOptions } from 'rollup';
 
 import image from '..';
 

--- a/packages/image/types/index.d.ts
+++ b/packages/image/types/index.d.ts
@@ -1,5 +1,5 @@
-import { FilterPattern } from '@rollup/pluginutils';
-import { Plugin } from 'rollup';
+import type { FilterPattern } from '@rollup/pluginutils';
+import type { Plugin } from 'rollup';
 
 interface RollupImageOptions {
   /**

--- a/packages/inject/test/types.ts
+++ b/packages/inject/test/types.ts
@@ -1,4 +1,4 @@
-import { RollupOptions } from 'rollup';
+import type { RollupOptions } from 'rollup';
 
 import inject from '..';
 

--- a/packages/inject/types/index.d.ts
+++ b/packages/inject/types/index.d.ts
@@ -1,4 +1,4 @@
-import { Plugin } from 'rollup';
+import type { Plugin } from 'rollup';
 
 type Injectment = string | [string, string];
 

--- a/packages/json/test/types.ts
+++ b/packages/json/test/types.ts
@@ -1,4 +1,4 @@
-import { RollupOptions } from 'rollup';
+import type { RollupOptions } from 'rollup';
 
 import json from '..';
 

--- a/packages/json/types/index.d.ts
+++ b/packages/json/types/index.d.ts
@@ -1,5 +1,5 @@
-import { FilterPattern } from '@rollup/pluginutils';
-import { Plugin } from 'rollup';
+import type { FilterPattern } from '@rollup/pluginutils';
+import type { Plugin } from 'rollup';
 
 export interface RollupJsonOptions {
   /**

--- a/packages/legacy/test/types.ts
+++ b/packages/legacy/test/types.ts
@@ -1,4 +1,4 @@
-import { RollupOptions } from 'rollup';
+import type { RollupOptions } from 'rollup';
 
 import legacy from '..';
 

--- a/packages/legacy/types/index.d.ts
+++ b/packages/legacy/types/index.d.ts
@@ -1,4 +1,4 @@
-import { Plugin } from 'rollup';
+import type { Plugin } from 'rollup';
 
 interface RollupLegacyOptions {
   [key: string]: string | { [key: string]: string };

--- a/packages/multi-entry/test/types.ts
+++ b/packages/multi-entry/test/types.ts
@@ -1,4 +1,4 @@
-import { RollupOptions } from 'rollup';
+import type { RollupOptions } from 'rollup';
 
 import multiEntry from '..';
 

--- a/packages/multi-entry/types/index.d.ts
+++ b/packages/multi-entry/types/index.d.ts
@@ -1,5 +1,5 @@
-import { FilterPattern } from '@rollup/pluginutils';
-import { Plugin } from 'rollup';
+import type { FilterPattern } from '@rollup/pluginutils';
+import type { Plugin } from 'rollup';
 
 interface RollupMultiEntryOptions {
   /**

--- a/packages/node-resolve/types/index.d.ts
+++ b/packages/node-resolve/types/index.d.ts
@@ -1,4 +1,4 @@
-import { Plugin } from 'rollup';
+import type { Plugin } from 'rollup';
 
 export const DEFAULTS: {
   customResolveOptions: {};

--- a/packages/pluginutils/src/attachScopes.ts
+++ b/packages/pluginutils/src/attachScopes.ts
@@ -1,4 +1,4 @@
-import * as estree from 'estree';
+import type * as estree from 'estree';
 
 import { walk } from 'estree-walker';
 

--- a/packages/pluginutils/src/extractAssignedNames.ts
+++ b/packages/pluginutils/src/extractAssignedNames.ts
@@ -1,3 +1,11 @@
+import type {
+  ArrayPattern,
+  AssignmentPattern,
+  Identifier,
+  ObjectPattern,
+  RestElement
+} from 'estree';
+
 import type { ExtractAssignedNames } from '../types';
 
 interface Extractors {
@@ -5,23 +13,23 @@ interface Extractors {
 }
 
 const extractors: Extractors = {
-  ArrayPattern(names: string[], param: import('estree').ArrayPattern) {
+  ArrayPattern(names: string[], param: ArrayPattern) {
     for (const element of param.elements) {
       if (element) extractors[element.type](names, element);
     }
   },
 
-  AssignmentPattern(names: string[], param: import('estree').AssignmentPattern) {
+  AssignmentPattern(names: string[], param: AssignmentPattern) {
     extractors[param.left.type](names, param.left);
   },
 
-  Identifier(names: string[], param: import('estree').Identifier) {
+  Identifier(names: string[], param: Identifier) {
     names.push(param.name);
   },
 
   MemberExpression() {},
 
-  ObjectPattern(names: string[], param: import('estree').ObjectPattern) {
+  ObjectPattern(names: string[], param: ObjectPattern) {
     for (const prop of param.properties) {
       // @ts-ignore Typescript reports that this is not a valid type
       if (prop.type === 'RestElement') {
@@ -32,7 +40,7 @@ const extractors: Extractors = {
     }
   },
 
-  RestElement(names: string[], param: import('estree').RestElement) {
+  RestElement(names: string[], param: RestElement) {
     extractors[param.argument.type](names, param.argument);
   }
 };

--- a/packages/pluginutils/test/attachScopes.ts
+++ b/packages/pluginutils/test/attachScopes.ts
@@ -1,9 +1,10 @@
-import * as estree from 'estree';
+import type * as estree from 'estree';
 
 import test from 'ava';
 import { parse } from 'acorn';
 
-import { attachScopes, AttachedScope } from '../';
+import type { AttachedScope } from '../';
+import { attachScopes } from '../';
 
 test('attaches a scope to the top level', (t) => {
   const ast = parse('var foo;', { ecmaVersion: 2020, sourceType: 'module' });

--- a/packages/pluginutils/types/index.d.ts
+++ b/packages/pluginutils/types/index.d.ts
@@ -1,4 +1,4 @@
-import { BaseNode } from 'estree';
+import type { BaseNode } from 'estree';
 
 export interface AttachedScope {
   parent?: AttachedScope;

--- a/packages/replace/test/types.ts
+++ b/packages/replace/test/types.ts
@@ -1,7 +1,7 @@
 // @ts-check
 import { dirname } from 'path';
 
-import { RollupOptions } from 'rollup';
+import type { RollupOptions } from 'rollup';
 
 import replace from '..';
 

--- a/packages/replace/types/index.d.ts
+++ b/packages/replace/types/index.d.ts
@@ -1,5 +1,5 @@
-import { FilterPattern } from '@rollup/pluginutils';
-import { Plugin } from 'rollup';
+import type { FilterPattern } from '@rollup/pluginutils';
+import type { Plugin } from 'rollup';
 
 type Replacement = string | ((id: string) => string);
 

--- a/packages/run/src/index.ts
+++ b/packages/run/src/index.ts
@@ -1,7 +1,8 @@
-import { ChildProcess, fork } from 'child_process';
+import type { ChildProcess } from 'child_process';
+import { fork } from 'child_process';
 import { resolve, join, dirname } from 'path';
 
-import { Plugin, RenderedChunk } from 'rollup';
+import type { Plugin, RenderedChunk } from 'rollup';
 
 import type { RollupRunOptions } from '../types';
 

--- a/packages/run/types/index.d.ts
+++ b/packages/run/types/index.d.ts
@@ -1,6 +1,6 @@
-import { ForkOptions } from 'child_process';
+import type { ForkOptions } from 'child_process';
 
-import { Plugin } from 'rollup';
+import type { Plugin } from 'rollup';
 
 export interface RollupRunOptions extends ForkOptions {
   args?: readonly string[];

--- a/packages/strip/test/types.ts
+++ b/packages/strip/test/types.ts
@@ -1,4 +1,4 @@
-import { RollupOptions } from 'rollup';
+import type { RollupOptions } from 'rollup';
 
 import strip from '../types/index';
 

--- a/packages/strip/types/index.d.ts
+++ b/packages/strip/types/index.d.ts
@@ -1,5 +1,5 @@
-import { FilterPattern } from '@rollup/pluginutils';
-import { Plugin } from 'rollup';
+import type { FilterPattern } from '@rollup/pluginutils';
+import type { Plugin } from 'rollup';
 
 interface RollupStripOptions {
   /**

--- a/packages/sucrase/test/types.ts
+++ b/packages/sucrase/test/types.ts
@@ -1,4 +1,4 @@
-import { RollupOptions } from 'rollup';
+import type { RollupOptions } from 'rollup';
 
 import sucrase from '..';
 

--- a/packages/sucrase/types/index.d.ts
+++ b/packages/sucrase/types/index.d.ts
@@ -1,6 +1,6 @@
-import { FilterPattern } from '@rollup/pluginutils';
-import { Plugin } from 'rollup';
-import { Options as SucraseOptions } from 'sucrase';
+import type { FilterPattern } from '@rollup/pluginutils';
+import type { Plugin } from 'rollup';
+import type { Options as SucraseOptions } from 'sucrase';
 
 interface RollupSucraseOptions
   extends Pick<

--- a/packages/typescript/src/diagnostics/emit.ts
+++ b/packages/typescript/src/diagnostics/emit.ts
@@ -1,4 +1,5 @@
 import type { PluginContext } from 'rollup';
+import type typescript from 'typescript';
 import type { Diagnostic, DiagnosticReporter } from 'typescript';
 
 import type { DiagnosticsHost } from './host';
@@ -11,7 +12,7 @@ const CANNOT_COMPILE_ESM = 1204;
  * Emit a Rollup warning or error for a Typescript type error.
  */
 export function emitDiagnostic(
-  ts: typeof import('typescript'),
+  ts: typeof typescript,
   context: PluginContext,
   host: DiagnosticsHost,
   diagnostic: Diagnostic
@@ -32,7 +33,7 @@ export function emitDiagnostic(
 }
 
 export function buildDiagnosticReporter(
-  ts: typeof import('typescript'),
+  ts: typeof typescript,
   context: PluginContext,
   host: DiagnosticsHost
 ): DiagnosticReporter {
@@ -45,7 +46,7 @@ export function buildDiagnosticReporter(
  * For each type error reported by Typescript, emit a Rollup warning or error.
  */
 export function emitDiagnostics(
-  ts: typeof import('typescript'),
+  ts: typeof typescript,
   context: PluginContext,
   host: DiagnosticsHost,
   diagnostics: readonly Diagnostic[] | undefined

--- a/packages/typescript/src/diagnostics/emit.ts
+++ b/packages/typescript/src/diagnostics/emit.ts
@@ -1,7 +1,7 @@
-import { PluginContext } from 'rollup';
+import type { PluginContext } from 'rollup';
 import type { Diagnostic, DiagnosticReporter } from 'typescript';
 
-import { DiagnosticsHost } from './host';
+import type { DiagnosticsHost } from './host';
 import diagnosticToWarning from './toWarning';
 
 // `Cannot compile modules into 'es6' when targeting 'ES5' or lower.`

--- a/packages/typescript/src/diagnostics/host.ts
+++ b/packages/typescript/src/diagnostics/host.ts
@@ -1,3 +1,4 @@
+import type typescript from 'typescript';
 import type { CompilerOptions, FormatDiagnosticsHost } from 'typescript';
 
 export interface DiagnosticsHost extends FormatDiagnosticsHost {
@@ -12,7 +13,7 @@ export interface DiagnosticsHost extends FormatDiagnosticsHost {
  * @see https://github.com/Microsoft/TypeScript/wiki/Using-the-Compiler-API
  */
 export default function createFormattingHost(
-  ts: typeof import('typescript'),
+  ts: typeof typescript,
   compilerOptions: CompilerOptions
 ): DiagnosticsHost {
   return {

--- a/packages/typescript/src/diagnostics/toWarning.ts
+++ b/packages/typescript/src/diagnostics/toWarning.ts
@@ -1,3 +1,4 @@
+import type typescript from 'typescript';
 import type { RollupWarning } from 'rollup';
 import type { Diagnostic, FormatDiagnosticsHost } from 'typescript';
 
@@ -5,7 +6,7 @@ import type { Diagnostic, FormatDiagnosticsHost } from 'typescript';
  * Converts a Typescript type error into an equivalent Rollup warning object.
  */
 export default function diagnosticToWarning(
-  ts: typeof import('typescript'),
+  ts: typeof typescript,
   host: FormatDiagnosticsHost | null,
   diagnostic: Diagnostic
 ) {

--- a/packages/typescript/src/diagnostics/toWarning.ts
+++ b/packages/typescript/src/diagnostics/toWarning.ts
@@ -1,4 +1,4 @@
-import { RollupWarning } from 'rollup';
+import type { RollupWarning } from 'rollup';
 import type { Diagnostic, FormatDiagnosticsHost } from 'typescript';
 
 /**

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 
 import { createFilter } from '@rollup/pluginutils';
 
-import { Plugin, RollupOptions, SourceDescription } from 'rollup';
+import type { Plugin, RollupOptions, SourceDescription } from 'rollup';
 import type { Watch } from 'typescript';
 
 import type { RollupTypescriptOptions } from '../types';

--- a/packages/typescript/src/moduleResolution.ts
+++ b/packages/typescript/src/moduleResolution.ts
@@ -5,7 +5,7 @@ import type {
   ModuleKind
 } from 'typescript';
 
-import { DiagnosticsHost } from './diagnostics/host';
+import type { DiagnosticsHost } from './diagnostics/host';
 
 type ModuleResolverHost = Partial<ModuleResolutionHost> & DiagnosticsHost;
 

--- a/packages/typescript/src/moduleResolution.ts
+++ b/packages/typescript/src/moduleResolution.ts
@@ -1,3 +1,4 @@
+import type typescript from 'typescript';
 import type {
   ModuleResolutionHost,
   ResolvedModuleFull,
@@ -22,7 +23,7 @@ export type Resolver = (
  * with methods for sanitizing filenames and getting compiler options.
  */
 export default function createModuleResolver(
-  ts: typeof import('typescript'),
+  ts: typeof typescript,
   host: ModuleResolverHost
 ): Resolver {
   const compilerOptions = host.getCompilationSettings();

--- a/packages/typescript/src/options/normalize.ts
+++ b/packages/typescript/src/options/normalize.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-param-reassign */
 import { resolve } from 'path';
 
-import { CompilerOptions, PartialCompilerOptions } from './interfaces';
+import type { CompilerOptions, PartialCompilerOptions } from './interfaces';
 
 export const DIRECTORY_PROPS = ['outDir', 'declarationDir'] as const;
 

--- a/packages/typescript/src/options/normalize.ts
+++ b/packages/typescript/src/options/normalize.ts
@@ -1,6 +1,8 @@
 /* eslint-disable no-param-reassign */
 import { resolve } from 'path';
 
+import type typescript from 'typescript';
+
 import type { CompilerOptions, PartialCompilerOptions } from './interfaces';
 
 export const DIRECTORY_PROPS = ['outDir', 'declarationDir'] as const;
@@ -25,10 +27,7 @@ export function makePathsAbsolute(compilerOptions: PartialCompilerOptions, relat
  * @param compilerOptions Compiler options to _mutate_.
  * @returns True if the source map compiler option was not initially set.
  */
-export function normalizeCompilerOptions(
-  ts: typeof import('typescript'),
-  compilerOptions: CompilerOptions
-) {
+export function normalizeCompilerOptions(ts: typeof typescript, compilerOptions: CompilerOptions) {
   let autoSetSourceMap = false;
   if (compilerOptions.inlineSourceMap) {
     // Force separate source map files for Rollup to work with.

--- a/packages/typescript/src/options/tsconfig.ts
+++ b/packages/typescript/src/options/tsconfig.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'fs';
 import { dirname, resolve } from 'path';
 
-import { PluginContext } from 'rollup';
+import type { PluginContext } from 'rollup';
 import typescript from 'typescript';
 import type {
   Diagnostic,
@@ -17,13 +17,11 @@ import type {
 import type { RollupTypescriptOptions } from '../../types';
 import diagnosticToWarning from '../diagnostics/toWarning';
 
+import type { CompilerOptions, EnumCompilerOptions, PartialCompilerOptions } from './interfaces';
 import {
-  CompilerOptions,
   DEFAULT_COMPILER_OPTIONS,
-  EnumCompilerOptions,
   FORCED_COMPILER_OPTIONS,
-  OVERRIDABLE_EMIT_COMPILER_OPTIONS,
-  PartialCompilerOptions
+  OVERRIDABLE_EMIT_COMPILER_OPTIONS
 } from './interfaces';
 import { normalizeCompilerOptions, makePathsAbsolute } from './normalize';
 

--- a/packages/typescript/src/options/tsconfig.ts
+++ b/packages/typescript/src/options/tsconfig.ts
@@ -49,7 +49,7 @@ function makeForcedCompilerOptions(noForceEmit: boolean) {
  * If `false` is passed, then a null path is returned.
  * @returns The absolute path, or null if the file does not exist.
  */
-function getTsConfigPath(ts: typeof import('typescript'), relativePath?: string | false) {
+function getTsConfigPath(ts: typeof typescript, relativePath?: string | false) {
   if (relativePath === false) return null;
 
   // Resolve path to file. `tsConfigOption` defaults to 'tsconfig.json'.
@@ -73,7 +73,7 @@ function getTsConfigPath(ts: typeof import('typescript'), relativePath?: string 
  * @param explicitPath If true, the path was set by the plugin user.
  * If false, the path was computed automatically.
  */
-function readTsConfigFile(ts: typeof import('typescript'), tsConfigPath: string) {
+function readTsConfigFile(ts: typeof typescript, tsConfigPath: string) {
   const { config, error } = ts.readConfigFile(tsConfigPath, (path) => readFileSync(path, 'utf8'));
   if (error) {
     throw Object.assign(Error(), diagnosticToWarning(ts, null, error));
@@ -121,7 +121,7 @@ function setModuleResolutionKind(parsedConfig: ParsedCommandLine): ParsedCommand
   };
 }
 
-const configCache = new Map() as import('typescript').Map<ExtendedConfigCacheEntry>;
+const configCache = new Map() as typescript.Map<ExtendedConfigCacheEntry>;
 
 /**
  * Parse the Typescript config to use with the plugin.
@@ -135,7 +135,7 @@ const configCache = new Map() as import('typescript').Map<ExtendedConfigCacheEnt
  * - `errors`: Any errors from parsing the config file.
  */
 export function parseTypescriptConfig(
-  ts: typeof import('typescript'),
+  ts: typeof typescript,
   tsconfig: RollupTypescriptOptions['tsconfig'],
   compilerOptions: PartialCompilerOptions,
   noForceEmit: boolean
@@ -207,7 +207,7 @@ export function parseTypescriptConfig(
  * display all of them as warnings then emit an error.
  */
 export function emitParsedOptionsErrors(
-  ts: typeof import('typescript'),
+  ts: typeof typescript,
   context: PluginContext,
   parsedOptions: ParsedCommandLine
 ) {

--- a/packages/typescript/src/options/validate.ts
+++ b/packages/typescript/src/options/validate.ts
@@ -1,8 +1,8 @@
 import { relative } from 'path';
 
-import { OutputOptions, PluginContext } from 'rollup';
+import type { OutputOptions, PluginContext } from 'rollup';
 
-import { CompilerOptions } from './interfaces';
+import type { CompilerOptions } from './interfaces';
 import { DIRECTORY_PROPS } from './normalize';
 
 /**

--- a/packages/typescript/src/outputFile.ts
+++ b/packages/typescript/src/outputFile.ts
@@ -2,6 +2,8 @@ import * as path from 'path';
 
 import { promises as fs } from 'fs';
 
+import type typescript from 'typescript';
+
 import type { OutputOptions, PluginContext, SourceDescription } from 'rollup';
 import type { ParsedCommandLine } from 'typescript';
 
@@ -55,7 +57,7 @@ export function getEmittedFile(
  * containing files emitted by the Typescript compiler.
  */
 export default function findTypescriptOutput(
-  ts: typeof import('typescript'),
+  ts: typeof typescript,
   parsedOptions: ParsedCommandLine,
   id: string,
   emittedFiles: ReadonlyMap<string, string>,

--- a/packages/typescript/src/outputFile.ts
+++ b/packages/typescript/src/outputFile.ts
@@ -2,10 +2,10 @@ import * as path from 'path';
 
 import { promises as fs } from 'fs';
 
-import { OutputOptions, PluginContext, SourceDescription } from 'rollup';
+import type { OutputOptions, PluginContext, SourceDescription } from 'rollup';
 import type { ParsedCommandLine } from 'typescript';
 
-import TSCache from './tscache';
+import type TSCache from './tscache';
 
 export interface TypescriptSourceDescription extends Partial<SourceDescription> {
   declarations: string[];

--- a/packages/typescript/src/preflight.ts
+++ b/packages/typescript/src/preflight.ts
@@ -1,7 +1,7 @@
-import { PluginContext, RollupOptions } from 'rollup';
+import type { PluginContext, RollupOptions } from 'rollup';
 import typescript from 'typescript';
 
-import { TypeScriptConfig } from './options/tsconfig';
+import type { TypeScriptConfig } from './options/tsconfig';
 // import { resolveIdAsync } from './tslib';
 
 const { ModuleKind } = typescript;

--- a/packages/typescript/src/tslib.ts
+++ b/packages/typescript/src/tslib.ts
@@ -1,6 +1,7 @@
 import { fileURLToPath } from 'url';
 
-import resolve, { SyncOpts } from 'resolve';
+import type { SyncOpts } from 'resolve';
+import resolve from 'resolve';
 
 // const resolveIdAsync = (file: string, opts: AsyncOpts) =>
 //   new Promise<string>((fulfil, reject) =>

--- a/packages/typescript/src/watchProgram.ts
+++ b/packages/typescript/src/watchProgram.ts
@@ -1,4 +1,4 @@
-import { PluginContext } from 'rollup';
+import type { PluginContext } from 'rollup';
 import typescript from 'typescript';
 import type {
   Diagnostic,
@@ -12,8 +12,8 @@ import type {
 import type { CustomTransformerFactories } from '../types';
 
 import { buildDiagnosticReporter } from './diagnostics/emit';
-import { DiagnosticsHost } from './diagnostics/host';
-import { Resolver } from './moduleResolution';
+import type { DiagnosticsHost } from './diagnostics/host';
+import type { Resolver } from './moduleResolution';
 import { mergeTransformers } from './customTransformers';
 
 const { DiagnosticCategory } = typescript;

--- a/packages/typescript/src/watchProgram.ts
+++ b/packages/typescript/src/watchProgram.ts
@@ -132,7 +132,7 @@ export class WatchProgramHelper {
  * @see https://github.com/Microsoft/TypeScript/wiki/Using-the-Compiler-API
  */
 function createWatchHost(
-  ts: typeof import('typescript'),
+  ts: typeof typescript,
   context: PluginContext,
   {
     formatHost,
@@ -195,7 +195,7 @@ function createWatchHost(
 }
 
 export default function createWatchProgram(
-  ts: typeof import('typescript'),
+  ts: typeof typescript,
   context: PluginContext,
   options: CreateProgramOptions
 ) {

--- a/packages/typescript/test/fixtures/project-references/animals/dog.ts
+++ b/packages/typescript/test/fixtures/project-references/animals/dog.ts
@@ -1,4 +1,4 @@
-import Animal from '.';
+import type Animal from '.';
 
 import { makeRandomName } from '../core/utilities';
 

--- a/packages/typescript/test/fixtures/project-references/zoo/zoo.ts
+++ b/packages/typescript/test/fixtures/project-references/zoo/zoo.ts
@@ -1,5 +1,6 @@
 // import Animal from '../animals/index';
-import { Dog, createDog } from '../animals/index';
+import type { Dog} from '../animals/index';
+import { createDog } from '../animals/index';
 
 export default function createZoo(): Array<Dog> {
   return [createDog()];

--- a/packages/typescript/test/tslib.ts
+++ b/packages/typescript/test/tslib.ts
@@ -1,7 +1,8 @@
 import { platform } from 'os';
 
 import test from 'ava';
-import { rollup, RollupError } from 'rollup';
+import type { RollupError } from 'rollup';
+import { rollup } from 'rollup';
 
 import typescript from '..';
 

--- a/packages/typescript/types/index.d.ts
+++ b/packages/typescript/types/index.d.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-use-before-define */
-import { FilterPattern } from '@rollup/pluginutils';
-import { Plugin } from 'rollup';
-import {
+import type { FilterPattern } from '@rollup/pluginutils';
+import type { Plugin } from 'rollup';
+import type {
   CompilerOptions,
   CompilerOptionsValue,
   CustomTransformers,

--- a/packages/typescript/types/index.d.ts
+++ b/packages/typescript/types/index.d.ts
@@ -1,4 +1,6 @@
 /* eslint-disable no-use-before-define */
+import type _typescript from 'typescript';
+
 import type { FilterPattern } from '@rollup/pluginutils';
 import type { Plugin } from 'rollup';
 import type {
@@ -65,7 +67,7 @@ export interface RollupTypescriptPluginOptions {
   /**
    * Overrides TypeScript used for transpilation
    */
-  typescript?: typeof import('typescript');
+  typescript?: typeof _typescript;
   /**
    * Overrides the injected TypeScript helpers with a custom version.
    */

--- a/packages/url/test/types.ts
+++ b/packages/url/test/types.ts
@@ -1,4 +1,4 @@
-import { RollupOptions } from 'rollup';
+import type { RollupOptions } from 'rollup';
 
 import url from '..';
 

--- a/packages/url/types/index.d.ts
+++ b/packages/url/types/index.d.ts
@@ -1,5 +1,5 @@
-import { FilterPattern } from '@rollup/pluginutils';
-import { Plugin } from 'rollup';
+import type { FilterPattern } from '@rollup/pluginutils';
+import type { Plugin } from 'rollup';
 
 interface RollupUrlOptions {
   // Note: the @default tag below uses the zero-width character joiner "‍" to escape the "*/"

--- a/packages/virtual/src/index.ts
+++ b/packages/virtual/src/index.ts
@@ -1,8 +1,8 @@
 import * as path from 'path';
 
-import { Plugin } from 'rollup';
+import type { Plugin } from 'rollup';
 
-import { RollupVirtualOptions } from '../';
+import type { RollupVirtualOptions } from '../';
 
 const PREFIX = `\0virtual:`;
 

--- a/packages/virtual/types/index.d.ts
+++ b/packages/virtual/types/index.d.ts
@@ -1,4 +1,4 @@
-import { Plugin } from 'rollup';
+import type { Plugin } from 'rollup';
 
 export interface RollupVirtualOptions {
   [id: string]: string;

--- a/packages/wasm/src/index.ts
+++ b/packages/wasm/src/index.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { createHash } from 'crypto';
 
-import { Plugin } from 'rollup';
+import type { Plugin } from 'rollup';
 
 import type { RollupWasmOptions } from '../types';
 

--- a/packages/wasm/types/index.d.ts
+++ b/packages/wasm/types/index.d.ts
@@ -1,4 +1,4 @@
-import { Plugin } from 'rollup';
+import type { Plugin } from 'rollup';
 
 /**
  * - `"auto"` will determine the environment at runtime and invoke the correct methods accordingly

--- a/packages/yaml/test/types.ts
+++ b/packages/yaml/test/types.ts
@@ -1,4 +1,4 @@
-import { RollupOptions } from 'rollup';
+import type { RollupOptions } from 'rollup';
 
 import yaml from '..';
 

--- a/packages/yaml/types/index.d.ts
+++ b/packages/yaml/types/index.d.ts
@@ -1,5 +1,5 @@
-import { FilterPattern } from '@rollup/pluginutils';
-import { Plugin } from 'rollup';
+import type { FilterPattern } from '@rollup/pluginutils';
+import type { Plugin } from 'rollup';
 
 type ValidYamlType =
   | number

--- a/util/test.d.ts
+++ b/util/test.d.ts
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import { RollupBuild, OutputOptions, OutputChunk, OutputAsset } from 'rollup';
-import { Assertions } from 'ava';
+import type { RollupBuild, OutputOptions, OutputChunk, OutputAsset } from 'rollup';
+import type { Assertions } from 'ava';
 
 interface GetCode {
   (bundle: RollupBuild, outputOptions?: OutputOptions | null, allFiles?: false): Promise<string>;


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `{name}`

This PR contains:

- [ ] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

we added eslint rule `'@typescript-eslint/consistent-type-imports': 'error'` 
It can make some optimizations.
For example, if you `import typescript`, the whole typescript library will be imported, but the `import type typescript` this library will not be imported, saving a lot of volume. 

`typescript` documentation is described as follows
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export
