### PR TITLE
fix(json)!: log more robustly when JSON parsing fails

### DIFF
--- a/packages/json/src/index.js
+++ b/packages/json/src/index.js
@@ -24,8 +24,7 @@ export default function json(options = {}) {
         };
       } catch (err) {
         const message = 'Could not parse JSON file';
-        const position = parseInt(/[\d]/.exec(err.message)[0], 10);
-        this.warn({ message, id, position });
+        this.warn({ message, id, cause: err });
         return null;
       }
     }

--- a/packages/json/src/index.js
+++ b/packages/json/src/index.js
@@ -24,7 +24,7 @@ export default function json(options = {}) {
         };
       } catch (err) {
         const message = 'Could not parse JSON file';
-        this.warn({ message, id, cause: err });
+        this.error({ message, id, cause: err });
         return null;
       }
     }

--- a/packages/json/test/test.js
+++ b/packages/json/test/test.js
@@ -81,11 +81,11 @@ test('handles garbage', async (t) => {
     onwarn: (warning) => warns.push(warning)
   }).catch(() => {});
 
-  const [{ message, id, position, plugin }] = warns;
+  const [{ message, id, cause, plugin }] = warns;
 
   t.is(warns.length, 1);
   t.is(plugin, 'json');
-  t.is(position, 1);
+  t.true(cause instanceof SyntaxError);
   t.is(message, 'Could not parse JSON file');
   t.regex(id, /(.*)bad.json$/);
 });

--- a/packages/json/test/test.js
+++ b/packages/json/test/test.js
@@ -73,21 +73,18 @@ test('handles JSON objects with no valid keys (#19)', async (t) => {
 });
 
 test('handles garbage', async (t) => {
-  const warns = [];
-
-  await rollup({
-    input: 'fixtures/garbage/main.js',
-    plugins: [json()],
-    onwarn: (warning) => warns.push(warning)
-  }).catch(() => {});
-
-  const [{ message, id, cause, plugin }] = warns;
-
-  t.is(warns.length, 1);
-  t.is(plugin, 'json');
-  t.true(cause instanceof SyntaxError);
-  t.is(message, 'Could not parse JSON file');
-  t.regex(id, /(.*)bad.json$/);
+  const err = await t.throwsAsync(
+    rollup({
+      input: 'fixtures/garbage/main.js',
+      plugins: [json()]
+    })
+  );
+  t.is(err.code, 'PLUGIN_ERROR');
+  t.is(err.plugin, 'json');
+  t.is(err.message, 'Could not parse JSON file');
+  t.is(err.name, 'RollupError');
+  t.is(err.cause.name, 'SyntaxError');
+  t.regex(err.id, /(.*)bad.json$/);
 });
 
 test('does not generate an AST', async (t) => {


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `parse-json`

This PR contains:

- [X] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [X] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [X] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

Previously, when JSON failed to parse (say it was transformed by another plugin), you would get a message like below. The json plugin fails to parse, and, because the error message doesn't match the `/[\d]/` regex, you get an uninformative warning message. Even if the regex *did* match, it would only match the first digit, not the whole line number.

```
bundles test/bench/versions/benchmarks.ts, src/source/worker.ts → rollup/build/benchmarks/versions...
[!] (plugin json) TypeError: Cannot read properties of null (reading '0')
src/style-spec/reference/v8.json
TypeError: Cannot read properties of null (reading '0')
    at Object.transform (C:\Users\dan\Source\maplibre-gl-js\node_modules\@rollup\plugin-json\dist\cjs\index.js:33:57)
    at C:\Users\dan\Source\maplibre-gl-js\node_modules\rollup\dist\shared\rollup.js:22879:40
```
