### PR TITLE
fix(commonjs,dynamic-import-vars,inject,replace,strip): update magic-string

### DIFF
--- a/packages/commonjs/package.json
+++ b/packages/commonjs/package.json
@@ -67,7 +67,7 @@
     "estree-walker": "^2.0.2",
     "glob": "^8.0.3",
     "is-reference": "1.2.1",
-    "magic-string": "^0.26.4"
+    "magic-string": "^0.27.0"
   },
   "devDependencies": {
     "@rollup/plugin-json": "^5.0.0",

--- a/packages/dynamic-import-vars/package.json
+++ b/packages/dynamic-import-vars/package.json
@@ -65,7 +65,7 @@
     "@rollup/pluginutils": "^5.0.1",
     "estree-walker": "^2.0.2",
     "fast-glob": "^3.2.12",
-    "magic-string": "^0.26.4"
+    "magic-string": "^0.27.0"
   },
   "devDependencies": {
     "acorn": "^8.8.0",

--- a/packages/inject/package.json
+++ b/packages/inject/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@rollup/pluginutils": "^5.0.1",
     "estree-walker": "^2.0.2",
-    "magic-string": "^0.26.4"
+    "magic-string": "^0.27.0"
   },
   "devDependencies": {
     "@rollup/plugin-buble": "^1.0.0",

--- a/packages/replace/package.json
+++ b/packages/replace/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@rollup/pluginutils": "^5.0.1",
-    "magic-string": "^0.26.4"
+    "magic-string": "^0.27.0"
   },
   "devDependencies": {
     "@rollup/plugin-buble": "^1.0.0",

--- a/packages/strip/package.json
+++ b/packages/strip/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@rollup/pluginutils": "^5.0.1",
     "estree-walker": "^2.0.2",
-    "magic-string": "^0.26.4"
+    "magic-string": "^0.27.0"
   },
   "devDependencies": {
     "acorn": "^8.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,7 +171,7 @@ importers:
       glob: ^8.0.3
       is-reference: 1.2.1
       locate-character: ^2.0.5
-      magic-string: ^0.26.4
+      magic-string: ^0.27.0
       require-relative: ^0.8.7
       rollup: 3.0.0-7
       shx: ^0.3.4
@@ -184,7 +184,7 @@ importers:
       estree-walker: 2.0.2
       glob: 8.0.3
       is-reference: 1.2.1
-      magic-string: 0.26.7
+      magic-string: 0.27.0
     devDependencies:
       '@rollup/plugin-json': 5.0.0_rollup@3.0.0-7
       '@rollup/plugin-node-resolve': 15.0.0_rollup@3.0.0-7
@@ -232,14 +232,14 @@ importers:
       acorn: ^8.8.0
       estree-walker: ^2.0.2
       fast-glob: ^3.2.12
-      magic-string: ^0.26.4
+      magic-string: ^0.27.0
       prettier: ^2.7.1
       rollup: ^3.2.3
     dependencies:
       '@rollup/pluginutils': 5.0.1_rollup@3.2.3
       estree-walker: 2.0.2
       fast-glob: 3.2.12
-      magic-string: 0.26.7
+      magic-string: 0.27.0
     devDependencies:
       acorn: 8.8.0
       prettier: 2.7.1
@@ -313,14 +313,14 @@ importers:
       del-cli: ^5.0.0
       estree-walker: ^2.0.2
       locate-character: ^2.0.5
-      magic-string: ^0.26.4
+      magic-string: ^0.27.0
       rollup: ^3.2.3
       source-map: ^0.7.4
       typescript: ^4.8.3
     dependencies:
       '@rollup/pluginutils': 5.0.1_rollup@3.2.3
       estree-walker: 2.0.2
-      magic-string: 0.26.7
+      magic-string: 0.27.0
     devDependencies:
       '@rollup/plugin-buble': 1.0.0_rollup@3.2.3
       del-cli: 5.0.0
@@ -436,13 +436,13 @@ importers:
       '@rollup/pluginutils': ^5.0.1
       del-cli: ^5.0.0
       locate-character: ^2.0.5
-      magic-string: ^0.26.4
+      magic-string: ^0.27.0
       rollup: ^3.2.3
       source-map: ^0.7.4
       typescript: ^4.8.3
     dependencies:
       '@rollup/pluginutils': 5.0.1_rollup@3.2.3
-      magic-string: 0.26.7
+      magic-string: 0.27.0
     devDependencies:
       '@rollup/plugin-buble': 1.0.0_rollup@3.2.3
       del-cli: 5.0.0
@@ -473,12 +473,12 @@ importers:
       '@rollup/pluginutils': ^5.0.1
       acorn: ^8.8.0
       estree-walker: ^2.0.2
-      magic-string: ^0.26.4
+      magic-string: ^0.27.0
       rollup: ^3.2.3
     dependencies:
       '@rollup/pluginutils': 5.0.1_rollup@3.2.3
       estree-walker: 2.0.2
-      magic-string: 0.26.7
+      magic-string: 0.27.0
     devDependencies:
       acorn: 8.8.0
       rollup: 3.2.3
@@ -5289,6 +5289,14 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       sourcemap-codec: 1.4.8
+    dev: true
+
+  /magic-string/0.27.0:
+    resolution: {integrity: sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.14
+    dev: false
 
   /make-dir/2.1.0:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `commonjs`,`dynamic-import-vars`,`inject`,`replace`,`strip`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers: fixes #1365

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

`sourcemap-codec@1.4.8` was deprecated and installing these plugins shows the following warning.

> npm WARN deprecated sourcemap-codec@1.4.8: Please use @jridgewell/sourcemap-codec instead

This PR updates `magic-string` to `^0.27.0` to remove that warning.

`magic-string@0.27.0` does not include any breaking changes.
https://github.com/Rich-Harris/magic-string/blob/master/CHANGELOG.md
