### PR TITLE
fix(terser): replace `__filename` with `import.meta.url`

### DIFF
--- a/packages/terser/src/module.ts
+++ b/packages/terser/src/module.ts
@@ -1,3 +1,5 @@
+import { fileURLToPath } from 'url';
+
 import type { NormalizedOutputOptions, RenderedChunk } from 'rollup';
 import { hasOwnProperty, isObject, merge } from 'smob';
 
@@ -6,7 +8,7 @@ import { WorkerPool } from './worker-pool';
 
 export default function terser(options: Options = {}) {
   const workerPool = new WorkerPool({
-    filePath: __filename,
+    filePath: fileURLToPath(import.meta.url),
     maxWorkers: options.maxWorkers
   });
 

--- a/packages/terser/tsconfig.json
+++ b/packages/terser/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "include": ["src/**/*", "types/**/*"],
   "compilerOptions": {
+    "module": "ES2020",
     "noUnusedParameters": false
   }
 }


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: terser

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:
- Closes #1366
- Supersedes #1367

### Description

Because `__filename`  does not exist in the ES modules this plugin errors out when used in a Rollup config written in the same format. This PR replaces the `__filename` constant with `import.meta.url` instead, which is available in ES modules.

When building the CommonJS version `import.meta.url` is replaced with `__dirname` at compile time, making sure that it remains compatible.