### PR TITLE
fix(terser): print message when terser worker throws an error

### DIFF
--- a/packages/terser/src/worker.ts
+++ b/packages/terser/src/worker.ts
@@ -42,6 +42,7 @@ export async function runWorker() {
 
     parentPort.postMessage(output);
   } catch (e) {
+    console.error(e);
     process.exit(1);
   }
 }


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `terser`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

(Extremely minor change, just adding a `console.error()` call)

Currently, if an error occurs inside a worker, it exits without printing a useful error message.  
e.g. `Error: Minify worker stopped with exit code 1`, in https://github.com/rollup/plugins/issues/1366#issuecomment-1347708877, when the actual error was `DefaultsError: 'maxWorkers' is not a supported option`

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
