### PR TITLE
feat(typescript): write declaration files in configured directory for `output.file`

### DIFF
--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -300,54 +300,6 @@ export default {
 
 Previous versions of this plugin used Typescript's `transpileModule` API, which is faster but does not perform typechecking and does not support cross-file features like `const enum`s and emit-less types. If you want this behaviour, you can use [@rollup/plugin-sucrase](https://github.com/rollup/plugins/tree/master/packages/sucrase) instead.
 
-### Declaration Output With `output.file`
-
-When instructing Rollup to output a specific file name via the `output.file` Rollup configuration, and TypeScript to output declaration files, users may encounter a situation where the declarations are nested improperly. And additionally when attempting to fix the improper nesting via use of `outDir` or `declarationDir` result in further TypeScript errors.
-
-Consider the following `rollup.config.js` file:
-
-```js
-import typescript from '@rollup/plugin-typescript';
-
-export default {
-  input: 'src/index.ts',
-  output: {
-    file: 'dist/index.mjs'
-  },
-  plugins: [typescript()]
-};
-```
-
-And accompanying `tsconfig.json` file:
-
-```json
-{
-  "include": ["*"],
-  "compilerOptions": {
-    "outDir": "dist",
-    "declaration": true
-  }
-}
-```
-
-This setup will produce `dist/index.mjs` and `dist/src/index.d.ts`. To correctly place the declaration file, add an `exclude` setting in `tsconfig` and modify the `declarationDir` setting in `compilerOptions` to resemble:
-
-```json
-{
-  "include": ["*"],
-  "exclude": ["dist"],
-  "compilerOptions": {
-    "outDir": "dist",
-    "declaration": true,
-    "declarationDir": "."
-  }
-}
-```
-
-This will result in the correct output of `dist/index.mjs` and `dist/index.d.ts`.
-
-_For reference, please see the workaround this section is based on [here](https://github.com/microsoft/bistring/commit/7e57116c812ae2c01f383c234f3b447f733b5d0c)_
-
 ## Meta
 
 [CONTRIBUTING](/.github/CONTRIBUTING.md)

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -71,6 +71,7 @@
     "@rollup/plugin-buble": "^1.0.0",
     "@rollup/plugin-commonjs": "^23.0.0",
     "@types/node": "^14.18.30",
+    "@types/resolve": "^1.20.2",
     "buble": "^0.20.0",
     "rollup": "^3.2.3",
     "typescript": "^4.8.3"

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -159,13 +159,16 @@ export default function typescript(options: RollupTypescriptOptions = {}): Plugi
             (parsedOptions.options.declaration
               ? parsedOptions.options.declarationDir || parsedOptions.options.outDir
               : null);
-          const cwd = normalizePath(process.cwd());
+          const outputDir = normalizePath(
+            outputOptions.dir ||
+              (outputOptions.file ? path.dirname(outputOptions.file) : process.cwd())
+          );
           if (
             parsedOptions.options.declaration &&
             parsedOptions.options.declarationDir &&
-            baseDir?.startsWith(cwd)
+            baseDir?.startsWith(outputDir)
           ) {
-            const declarationDir = baseDir.slice(cwd.length + 1);
+            const declarationDir = baseDir.slice(outputDir.length + 1);
             baseDir = baseDir.slice(0, -1 * declarationDir.length);
           }
           if (!baseDir && tsconfig) {

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -154,27 +154,30 @@ export default function typescript(options: RollupTypescriptOptions = {}): Plugi
         const output = findTypescriptOutput(ts, parsedOptions, fileName, emittedFiles, tsCache);
         output.declarations.forEach((id) => {
           const code = getEmittedFile(id, emittedFiles, tsCache);
-          let baseDir =
-            outputOptions.dir ||
-            (parsedOptions.options.declaration
-              ? parsedOptions.options.declarationDir || parsedOptions.options.outDir
-              : null);
-          const outputDir = normalizePath(
-            outputOptions.dir ||
-              (outputOptions.file ? path.dirname(outputOptions.file) : process.cwd())
-          );
-          if (
-            parsedOptions.options.declaration &&
-            parsedOptions.options.declarationDir &&
-            baseDir?.startsWith(outputDir)
-          ) {
-            const declarationDir = baseDir.slice(outputDir.length + 1);
-            baseDir = baseDir.slice(0, -1 * declarationDir.length);
+          if (!code || !parsedOptions.options.declaration) {
+            return;
           }
-          if (!baseDir && tsconfig) {
-            baseDir = tsconfig.substring(0, tsconfig.lastIndexOf('/'));
+
+          let baseDir: string | undefined;
+          if (outputOptions.dir) {
+            baseDir = outputOptions.dir;
+          } else if (outputOptions.file) {
+            // find common path of output.file and configured declation output
+            const outputDir = path.dirname(outputOptions.file);
+            const configured = path.resolve(
+              parsedOptions.options.declarationDir ||
+                parsedOptions.options.outDir ||
+                tsconfig ||
+                process.cwd()
+            );
+            const backwards = path
+              .relative(outputDir, configured)
+              .split(path.sep)
+              .filter((v) => v === '..')
+              .join(path.sep);
+            baseDir = path.normalize(`${outputDir}/${backwards}`);
           }
-          if (!code || !baseDir) return;
+          if (!baseDir) return;
 
           this.emitFile({
             type: 'asset',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -525,6 +525,7 @@ importers:
       '@rollup/plugin-commonjs': ^23.0.0
       '@rollup/pluginutils': ^5.0.1
       '@types/node': ^14.18.30
+      '@types/resolve': ^1.20.2
       buble: ^0.20.0
       resolve: ^1.22.1
       rollup: ^3.2.3
@@ -536,6 +537,7 @@ importers:
       '@rollup/plugin-buble': 1.0.0_rollup@3.2.3
       '@rollup/plugin-commonjs': 23.0.0_rollup@3.2.3
       '@types/node': 14.18.31
+      '@types/resolve': 1.20.2
       buble: 0.20.0
       rollup: 3.2.3
       typescript: 4.8.4

--- a/util/test.d.ts
+++ b/util/test.d.ts
@@ -15,6 +15,16 @@ interface GetCode {
 
 export const getCode: GetCode;
 
+export function getFiles(
+  bundle: RollupBuild,
+  outputOptions?: OutputOptions
+): Promise<
+  {
+    fileName: string;
+    content: any;
+  }[]
+>;
+
 export function evaluateBundle(bundle: RollupBuild): Promise<Pick<NodeModule, 'exports'>>;
 
 export function getImports(bundle: RollupBuild): Promise<string[]>;


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `typescript`

This PR contains:

- [x] bugfix
- [x] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:
* #1049 (even if closed the issue was not resolved until now)
* #1253 (if `output.file` is used, if `output.dir` is used everything should, as it does, be placed inside that directory)

### Description
If you configure rollup with `output.file = 'dist/main.js'` and typscript with `'declarationDir: "dist"`
Instead of writing the declarations into `dist/` they  are written into `dist/dist`, and the workaround from the README does not work anymore, if you set 'declarationDir: "."` no declarations are written at all.

So this is fixes by only enforcing declarations inside `output.dir` but not inside `dirname(output.file)` (see added test case).

Additionally:
* I had to add the types package for `resolve` to get the package build.
* I added a new test helper that returns the output file names as rollup would write the files (emulating `handleGenerateWrite` and `writeOutputFile`)