### PR TITLE
chore(repo): Add StackBlitz reproduction template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG.md
+++ b/.github/ISSUE_TEMPLATE/BUG.md
@@ -29,11 +29,11 @@ about: Something went awry and you'd like to tell us about it.
   🚨 Issues WITHOUT a valid reproduction WILL BE CLOSED!
 
   Please provide one by:
-  1. Using the REPL.it plugin reproduction template at https://repl.it/@rollup/rollup-plugin-repro
-  2. Provide a minimal repository link (Read https://gist.github.com/Rich-Harris/88c5fc2ac6dc941b22e7996af05d70ff for instructions).
+  1. Using the StackBlitz reproduction template at https://stackblitz.com/fork/rollup-repro
+  2. Using the REPL.it plugin reproduction template at https://repl.it/@rollup/rollup-plugin-repro
+  3. Provide a minimal repository link (Read https://gist.github.com/Rich-Harris/88c5fc2ac6dc941b22e7996af05d70ff for instructions).
      Please use NPM for installing dependencies!
      These may take more time to triage than the other options.
-  3. Using the Rollup REPL at https://rollupjs.org/repl/
 
   ⚠️ ZIP Files are unsafe and maintainers will NOT download them.
 -->


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `repo`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [ ] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description
The current repl.it template no longer works with Rollup 3 because it runs on Node 14. For Rollup core, I created a minimal StackBlitz template that we could also use for plugins if we want to. Or we fork it to have a dedicated one for plugins.
I also removed the Rollup REPL as reproduction option because, well, the REPL does not support plugins, so it is probably not helpful here.