### PR TITLE
fix(eslint): fix async support for `formatter` option and TypeScript types

### DIFF
--- a/packages/eslint/README.md
+++ b/packages/eslint/README.md
@@ -67,6 +67,8 @@ Default: `stylish`
 
 Custom error formatter, the name of a built-in formatter, or the path to a custom formatter.
 
+When the type is a function, the function should return `String` or `Promise<String>`.
+
 ### include
 
 Type: `String | String[]`<br>

--- a/packages/eslint/README.md
+++ b/packages/eslint/README.md
@@ -62,12 +62,10 @@ If true, will auto fix source code.
 
 ### formatter
 
-Type: `Function | String`<br>
+Type: `Function<String> | Function<Promise<String>> | String`<br>
 Default: `stylish`
 
 Custom error formatter, the name of a built-in formatter, or the path to a custom formatter.
-
-When the type is a function, the function should return `String` or `Promise<String>`.
 
 ### include
 

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -35,7 +35,7 @@
     "pretest": "pnpm build",
     "release": "pnpm --workspace-root plugin:release --pkg $npm_package_name",
     "test": "ava",
-    "test:ts": "tsc --noEmit"
+    "test:ts": "tsc types/index.d.ts test/types.ts --noEmit"
   },
   "files": [
     "dist",

--- a/packages/eslint/src/index.ts
+++ b/packages/eslint/src/index.ts
@@ -55,7 +55,7 @@ export default function eslint(options = {} as RollupEslintOptions): Plugin {
         typeof formatter === 'string'
           ? await eslintInstance.loadFormatter(formatter)
           : { format: formatter };
-      const output = eslintFormatter.format(results);
+      const output = await eslintFormatter.format(results);
 
       if (output) {
         // eslint-disable-next-line no-console

--- a/packages/eslint/test/test.mjs
+++ b/packages/eslint/test/test.mjs
@@ -166,6 +166,19 @@ test('should not fail with found formatter', async (t) => {
   t.pass();
 });
 
+test('should not fail with asynchronous formatter function', async (t) => {
+  await rollup({
+    input: './test/fixtures/use-strict.js',
+    plugins: [
+      eslint({
+        formatter: async () => 'json'
+      })
+    ]
+  });
+
+  t.pass();
+});
+
 test('should fix source code', async (t) => {
   fs.writeFileSync(
     './test/fixtures/fixable-clone.js',

--- a/packages/eslint/test/types.ts
+++ b/packages/eslint/test/types.ts
@@ -1,0 +1,32 @@
+import type { RollupOptions } from 'rollup';
+
+import eslintPlugin from '../types';
+
+const rollupConfig: RollupOptions = {
+  input: 'main.js',
+  output: {
+    file: 'bundle.js',
+    format: 'iife'
+  },
+  plugins: [
+    eslintPlugin(),
+    eslintPlugin({}),
+    eslintPlugin({
+      formatter: () => 'json'
+    }),
+    eslintPlugin({
+      formatter: async () => 'json'
+    }),
+    eslintPlugin({
+      fix: false,
+      throwOnWarning: true,
+      throwOnError: true,
+      include: 'node_modules/**',
+      exclude: ['node_modules/foo/**', 'node_modules/bar/**', /node_modules/],
+      extensions: ['.js', '.coffee'],
+      formatter: 'json'
+    })
+  ]
+};
+
+export default rollupConfig;

--- a/packages/eslint/types/index.d.ts
+++ b/packages/eslint/types/index.d.ts
@@ -1,5 +1,5 @@
 import type { Plugin } from 'rollup';
-import type { CLIEngine, ESLint } from 'eslint';
+import type { ESLint } from 'eslint';
 import type { CreateFilter } from '@rollup/pluginutils';
 
 export interface RollupEslintOptions extends ESLint.Options {
@@ -37,7 +37,7 @@ export interface RollupEslintOptions extends ESLint.Options {
    * Custom error formatter or the name of a built-in formatter.
    * @default stylish
    */
-  formatter?: CLIEngine.Formatter | string;
+  formatter?: Awaited<ReturnType<ESLint['loadFormatter']>>['format'] | string;
 }
 
 /**


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `eslint`

This PR contains:

- [x] bugfix

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)

Breaking Changes?

- [x] no

List any relevant issue numbers:

### Description

1. ESLint's [`CLIEngine` class has been deprecated](https://eslint.org/docs/latest/user-guide/migrating-to-7.0.0#-the-cliengine-class-has-been-deprecated), so the latest `@types/eslint` 8.x no longer exports the `CLIEngine` type, so the latest version of `@rollup/plugin-eslint` formatter is inferred to have the wrong argument type.

2. The latest type of `ESLint.Formatter` allows to return async values, while the current `@rollup/plugin-eslint` only supports sync function.
    - [Change Request: Support async formatter](https://github.com/eslint/eslint/issues/15242)
    - [feat: support async formatters](https://github.com/eslint/eslint/commit/f1b7499a5162d3be918328ce496eb80692353a5a)
