### PR TITLE
Change commonjs strictRequires default from "auto" to true

### DIFF
--- a/packages/commonjs/README.md
+++ b/packages/commonjs/README.md
@@ -49,7 +49,7 @@ When used together with the node-resolve plugin
 ### `strictRequires`
 
 Type: `"auto" | boolean | "debug" | string[]`<br>
-Default: `"auto"`
+Default: `true`
 
 By default, this plugin will try to hoist `require` statements as imports to the top of each file. While this works well for many code bases and allows for very efficient ESM output, it does not perfectly capture CommonJS semantics as the initialisation order of required modules will be different. The resultant side effects can include log statements being emitted in a different order, and some code that is dependent on the initialisation order of polyfills in require statements may not work. But it is especially problematic when there are circular `require` calls between CommonJS modules as those often rely on the lazy execution of nested `require` calls.
 

--- a/packages/commonjs/src/utils.js
+++ b/packages/commonjs/src/utils.js
@@ -43,12 +43,12 @@ export function capitalize(name) {
 
 export function getStrictRequiresFilter({ strictRequires }) {
   switch (strictRequires) {
+    case 'auto':
+    case 'debug':
     case true:
       return { strictRequiresFilter: () => true, detectCyclesAndConditional: false };
     // eslint-disable-next-line no-undefined
     case undefined:
-    case 'auto':
-    case 'debug':
     case null:
       return { strictRequiresFilter: () => false, detectCyclesAndConditional: true };
     case false:


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `commonjs`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

https://github.com/rollup/rollup/issues/4787

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

Having strictRequires: true is a safer default option than "auto", as auto can break in cases where **true** will not (see linked issue). Minification is omnipresent at this point, so it's not an issue to go with this option in terms of filesize.