### PR TITLE
feat(alias)!: resolve entry id

### DIFF
--- a/packages/alias/src/index.ts
+++ b/packages/alias/src/index.ts
@@ -81,9 +81,6 @@ export default function alias(options: RollupAliasOptions = {}): Plugin {
       );
     },
     resolveId(importee, importer, resolveOptions) {
-      if (!importer) {
-        return null;
-      }
       // First match is supposed to be the correct one
       const matchedEntry = entries.find((entry) => matches(entry.find, importee));
       if (!matchedEntry) {

--- a/packages/alias/test/test.mjs
+++ b/packages/alias/test/test.mjs
@@ -163,14 +163,14 @@ test('Will not confuse modules with similar names', (t) =>
     ]
   ).then((result) => t.deepEqual(result, [null, null, null])));
 
-test('Leaves entry file untouched if matches alias', (t) =>
+test('Alias entry file', (t) =>
   resolveAliasWithRollup(
     {
       entries: [{ find: 'abacaxi', replacement: './abacaxi' }]
     },
     // eslint-disable-next-line no-undefined
     [{ source: 'abacaxi/entry.js' }]
-  ).then((result) => t.deepEqual(result, [null])));
+  ).then((result) => t.deepEqual(result, ['./abacaxi/entry.js'])));
 
 test('i/am/a/file', (t) =>
   resolveAliasWithRollup(


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `alias`

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [x] yes (_breaking changes will not be merged unless absolutely necessary_)
- [ ] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. - Added

List any relevant issue numbers:
fix #1190

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

When the Rollup input is passed an aliased path, the `alias` plugin doesn't resolve it because it skips if there's no `importer`. I tracked this behaviour, and found it was not done in the past due to https://github.com/rollup/rollup-plugin-alias/pull/29, but since the internals changed now, that PR's issue isn't relevant and we can continue to alias entry paths now.