### PR TITLE
fix(alias,auto-install,buble,commonjs,data-uri,dsv,dynamic-import-vars,eslint,graphql,html,image): types should come first in exports

### DIFF
--- a/packages/alias/package.json
+++ b/packages/alias/package.json
@@ -16,8 +16,8 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "import": "./dist/es/index.js",
     "types": "./types/index.d.ts",
+    "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },
   "engines": {

--- a/packages/auto-install/package.json
+++ b/packages/auto-install/package.json
@@ -16,8 +16,8 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "import": "./dist/es/index.js",
     "types": "./types/index.d.ts",
+    "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },
   "engines": {

--- a/packages/buble/package.json
+++ b/packages/buble/package.json
@@ -16,8 +16,8 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "import": "./dist/es/index.js",
     "types": "./types/index.d.ts",
+    "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },
   "engines": {

--- a/packages/commonjs/package.json
+++ b/packages/commonjs/package.json
@@ -16,8 +16,8 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "import": "./dist/es/index.js",
     "types": "./types/index.d.ts",
+    "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },
   "engines": {

--- a/packages/data-uri/package.json
+++ b/packages/data-uri/package.json
@@ -16,8 +16,8 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "import": "./dist/es/index.js",
     "types": "./types/index.d.ts",
+    "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },
   "engines": {

--- a/packages/dsv/package.json
+++ b/packages/dsv/package.json
@@ -16,8 +16,8 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "import": "./dist/es/index.js",
     "types": "./types/index.d.ts",
+    "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },
   "scripts": {

--- a/packages/dynamic-import-vars/package.json
+++ b/packages/dynamic-import-vars/package.json
@@ -16,8 +16,8 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "import": "./dist/es/index.js",
     "types": "./types/index.d.ts",
+    "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },
   "engines": {

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -16,8 +16,8 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "import": "./dist/es/index.js",
     "types": "./types/index.d.ts",
+    "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },
   "engines": {

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -16,8 +16,8 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "import": "./dist/es/index.js",
     "types": "./types/index.d.ts",
+    "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },
   "engines": {

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -16,8 +16,8 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "import": "./dist/es/index.js",
     "types": "./types/index.d.ts",
+    "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },
   "engines": {

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -16,8 +16,8 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "import": "./dist/es/index.js",
     "types": "./types/index.d.ts",
+    "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },
   "engines": {


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `{name}`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
`types` must come first. See the TypeScript docs here: https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing