### PR TITLE
fix(run): commonjs chunks not found

### DIFF
--- a/packages/run/src/index.ts
+++ b/packages/run/src/index.ts
@@ -52,7 +52,7 @@ export default function run(opts: RollupRunOptions = {}): Plugin {
       const dir = outputOptions.dir || dirname(outputOptions.file!);
       const entryFileName = Object.keys(bundle).find((fileName) => {
         const chunk = bundle[fileName] as RenderedChunk;
-        return chunk.isEntry && chunk.facadeModuleId === input;
+        return chunk.isEntry && chunk.facadeModuleId.replace(/\?.*$/, '') === input;
       });
 
       if (entryFileName) {


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `{name}`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

When using this plugin in combination with `@rollup/plugin-typescript` and having `module: "commonjs"`  in `tsconfig.json`, rollup will add a `?commonjs-entry` query param at the end of the `facadeModuleId`, which causes the condition `chunk.facadeModuleId === input` to fail and the chunk not to be found.

Currently, as a workaround, I override the `writeBundle` method with a proxy where I remove the `?commonjs-entry` bit in the `facadeModuleId`:

```js
const run = require('@rollup/plugin-run');

const runPlugin = run();

// workaround
const originalWriteBundle = runPlugin.writeBundle;
runPlugin.writeBundle = (outputOptions, bundle) => {
  Object.keys(bundle).forEach(fileName => {
    const chunk = bundle[fileName];
    if (chunk.isEntry && chunk.facadeModuleId.endsWith('?commonjs-entry')) {
      chunk.facadeModuleId = chunk.facadeModuleId.replace('?commonjs-entry', '');
    }
  });
  originalWriteBundle(outputOptions, bundle);
};

module.exports = {
  input: 'apps/assets-api/src/index.ts',
  output: {
    file: 'dist/assets-api/index.js',
    format: 'cjs',
    sourcemap: true,
  },
  plugins: [
    typescript({
      compilerOptions: { module: 'commonjs' },
    }),
    commonjs({ extensions: ['.js', '.ts'] }),
    json(),
    runPlugin,
  ],
};
```

but I thought a proper fix in the lib would be best.