### PR TITLE
feat(terser): Update WorkerPool to reuse Workers

### DIFF
--- a/packages/terser/src/constants.ts
+++ b/packages/terser/src/constants.ts
@@ -1,0 +1,2 @@
+export const taskInfo = Symbol('taskInfo');
+export const freeWorker = Symbol('freeWorker');

--- a/packages/terser/src/module.ts
+++ b/packages/terser/src/module.ts
@@ -9,7 +9,7 @@ import { WorkerPool } from './worker-pool';
 export default function terser(input: Options = {}) {
   const { maxWorkers, ...options } = input;
 
-  let workerPool: WorkerPool | null;
+  let workerPool: WorkerPool | undefined;
   let numOfChunks = 0;
   let numOfWorkersUsed = 0;
 
@@ -93,7 +93,7 @@ export default function terser(input: Options = {}) {
         if (numOfChunks === 0) {
           numOfWorkersUsed = workerPool.numWorkers;
           workerPool.close();
-          workerPool = null;
+          workerPool = undefined;
         }
       }
     },

--- a/packages/terser/src/module.ts
+++ b/packages/terser/src/module.ts
@@ -11,6 +11,7 @@ export default function terser(input: Options = {}) {
 
   let workerPool: WorkerPool | null;
   let numOfChunks = 0;
+  let numOfWorkersUsed = 0;
 
   return {
     name: 'terser',
@@ -90,10 +91,15 @@ export default function terser(input: Options = {}) {
       } finally {
         numOfChunks -= 1;
         if (numOfChunks === 0) {
+          numOfWorkersUsed = workerPool.numWorkers;
           workerPool.close();
           workerPool = null;
         }
       }
+    },
+
+    get numOfWorkersUsed() {
+      return numOfWorkersUsed;
     }
   };
 }

--- a/packages/terser/src/module.ts
+++ b/packages/terser/src/module.ts
@@ -9,7 +9,7 @@ import { WorkerPool } from './worker-pool';
 export default function terser(input: Options = {}) {
   const { maxWorkers, ...options } = input;
 
-  let workerPool: WorkerPool | undefined;
+  let workerPool: WorkerPool | null | undefined;
   let numOfChunks = 0;
   let numOfWorkersUsed = 0;
 
@@ -93,7 +93,7 @@ export default function terser(input: Options = {}) {
         if (numOfChunks === 0) {
           numOfWorkersUsed = workerPool.numWorkers;
           workerPool.close();
-          workerPool = undefined;
+          workerPool = null;
         }
       }
     },

--- a/packages/terser/src/module.ts
+++ b/packages/terser/src/module.ts
@@ -9,15 +9,22 @@ import { WorkerPool } from './worker-pool';
 export default function terser(input: Options = {}) {
   const { maxWorkers, ...options } = input;
 
-  const workerPool = new WorkerPool({
-    filePath: fileURLToPath(import.meta.url),
-    maxWorkers
-  });
+  let workerPool: WorkerPool | null;
+  let numOfChunks = 0;
 
   return {
     name: 'terser',
 
     async renderChunk(code: string, chunk: RenderedChunk, outputOptions: NormalizedOutputOptions) {
+      if (!workerPool) {
+        workerPool = new WorkerPool({
+          filePath: fileURLToPath(import.meta.url),
+          maxWorkers
+        });
+      }
+
+      numOfChunks += 1;
+
       const defaultOptions: Options = {
         sourceMap: outputOptions.sourcemap === true || typeof outputOptions.sourcemap === 'string'
       };
@@ -80,6 +87,12 @@ export default function terser(input: Options = {}) {
         return result;
       } catch (e) {
         return Promise.reject(e);
+      } finally {
+        numOfChunks -= 1;
+        if (numOfChunks === 0) {
+          workerPool.close();
+          workerPool = null;
+        }
       }
     }
   };

--- a/packages/terser/src/type.ts
+++ b/packages/terser/src/type.ts
@@ -1,4 +1,9 @@
+import type { AsyncResource } from 'async_hooks';
+import type { Worker } from 'worker_threads';
+
 import type { MinifyOptions } from 'terser';
+
+import type { taskInfo } from './constants';
 
 export interface Options extends MinifyOptions {
   nameCache?: Record<string, any>;
@@ -11,6 +16,12 @@ export interface WorkerContext {
 }
 
 export type WorkerCallback = (err: Error | null, output?: WorkerOutput) => void;
+
+interface WorkerPoolTaskInfo extends AsyncResource {
+  done(err: Error | null, result: any): void;
+}
+
+export type WorkerWithTaskInfo = Worker & { [taskInfo]?: WorkerPoolTaskInfo | null };
 
 export interface WorkerContextSerialized {
   code: string;

--- a/packages/terser/src/worker-pool.ts
+++ b/packages/terser/src/worker-pool.ts
@@ -5,18 +5,16 @@ import { EventEmitter } from 'events';
 
 import serializeJavascript from 'serialize-javascript';
 
+import { freeWorker, taskInfo } from './constants';
+
 import type {
   WorkerCallback,
   WorkerContext,
   WorkerOutput,
   WorkerPoolOptions,
-  WorkerPoolTask
+  WorkerPoolTask,
+  WorkerWithTaskInfo
 } from './type';
-
-const taskInfo = Symbol('taskInfo');
-const freeWorker = Symbol('freeWorker');
-
-type WorkerWithTaskInfo = Worker & { [taskInfo]?: WorkerPoolTaskInfo | null };
 
 class WorkerPoolTaskInfo extends AsyncResource {
   constructor(private callback: WorkerCallback) {

--- a/packages/terser/src/worker-pool.ts
+++ b/packages/terser/src/worker-pool.ts
@@ -16,7 +16,7 @@ import type {
 const taskInfo = Symbol('taskInfo');
 const freeWorker = Symbol('freeWorker');
 
-type WorkerWithTaskInfo = Worker & { [taskInfo]?: undefined | WorkerPoolTaskInfo };
+type WorkerWithTaskInfo = Worker & { [taskInfo]?: WorkerPoolTaskInfo | null };
 
 class WorkerPoolTaskInfo extends AsyncResource {
   constructor(private callback: WorkerCallback) {
@@ -86,7 +86,7 @@ export class WorkerPool extends EventEmitter {
 
     worker.on('message', (result) => {
       worker[taskInfo]?.done(null, result);
-      worker[taskInfo] = undefined;
+      worker[taskInfo] = null;
       this.freeWorkers.push(worker);
       this.emit(freeWorker);
     });

--- a/packages/terser/src/worker-pool.ts
+++ b/packages/terser/src/worker-pool.ts
@@ -53,6 +53,10 @@ export class WorkerPool extends EventEmitter {
     });
   }
 
+  get numWorkers(): number {
+    return this.workers.length;
+  }
+
   addAsync(context: WorkerContext): Promise<WorkerOutput> {
     return new Promise((resolve, reject) => {
       this.runTask(context, (err, output) => {
@@ -105,7 +109,7 @@ export class WorkerPool extends EventEmitter {
   private runTask(context: WorkerContext, cb: WorkerCallback) {
     if (this.freeWorkers.length === 0) {
       this.tasks.push({ context, cb });
-      if (this.workers.length < this.maxInstances) {
+      if (this.numWorkers < this.maxInstances) {
         this.addNewWorker();
       }
       return;

--- a/packages/terser/src/worker-pool.ts
+++ b/packages/terser/src/worker-pool.ts
@@ -1,3 +1,4 @@
+import { AsyncResource } from 'async_hooks';
 import { Worker } from 'worker_threads';
 import { cpus } from 'os';
 import { EventEmitter } from 'events';
@@ -12,7 +13,21 @@ import type {
   WorkerPoolTask
 } from './type';
 
-const symbol = Symbol.for('FreeWoker');
+const taskInfo = Symbol('taskInfo');
+const freeWorker = Symbol('freeWorker');
+
+type WorkerWithTaskInfo = Worker & { [taskInfo]?: null | WorkerPoolTaskInfo };
+
+class WorkerPoolTaskInfo extends AsyncResource {
+  constructor(private callback: WorkerCallback) {
+    super('WorkerPoolTaskInfo');
+  }
+
+  done(err: Error | null, result: any) {
+    this.runInAsyncScope(this.callback, null, err, result);
+    this.emitDestroy();
+  }
+}
 
 export class WorkerPool extends EventEmitter {
   protected maxInstances: number;
@@ -21,7 +36,8 @@ export class WorkerPool extends EventEmitter {
 
   protected tasks: WorkerPoolTask[] = [];
 
-  protected workers = 0;
+  protected workers: WorkerWithTaskInfo[] = [];
+  protected freeWorkers: WorkerWithTaskInfo[] = [];
 
   constructor(options: WorkerPoolOptions) {
     super();
@@ -29,29 +45,17 @@ export class WorkerPool extends EventEmitter {
     this.maxInstances = options.maxWorkers || cpus().length;
     this.filePath = options.filePath;
 
-    this.on(symbol, () => {
+    this.on(freeWorker, () => {
       if (this.tasks.length > 0) {
-        this.run();
+        const { context, cb } = this.tasks.shift()!;
+        this.runTask(context, cb);
       }
     });
   }
 
-  add(context: WorkerContext, cb: WorkerCallback) {
-    this.tasks.push({
-      context,
-      cb
-    });
-
-    if (this.workers >= this.maxInstances) {
-      return;
-    }
-
-    this.run();
-  }
-
-  async addAsync(context: WorkerContext): Promise<WorkerOutput> {
+  addAsync(context: WorkerContext): Promise<WorkerOutput> {
     return new Promise((resolve, reject) => {
-      this.add(context, (err, output) => {
+      this.runTask(context, (err, output) => {
         if (err) {
           reject(err);
           return;
@@ -67,51 +71,51 @@ export class WorkerPool extends EventEmitter {
     });
   }
 
-  private run() {
-    if (this.tasks.length === 0) {
-      return;
+  close() {
+    for (const worker of this.workers) {
+      worker.terminate();
     }
+  }
 
-    const task = this.tasks.shift();
+  private addNewWorker() {
+    const worker: WorkerWithTaskInfo = new Worker(this.filePath);
 
-    if (typeof task === 'undefined') {
-      return;
-    }
-
-    this.workers += 1;
-
-    let called = false;
-    const callCallback = (err: Error | null, output?: WorkerOutput) => {
-      if (called) {
-        return;
-      }
-      called = true;
-
-      this.workers -= 1;
-
-      task.cb(err, output);
-      this.emit(symbol);
-    };
-
-    const worker = new Worker(this.filePath, {
-      workerData: {
-        code: task.context.code,
-        options: serializeJavascript(task.context.options)
-      }
-    });
-
-    worker.on('message', (data) => {
-      callCallback(null, data);
+    worker.on('message', (result) => {
+      worker[taskInfo]!.done(null, result);
+      worker[taskInfo] = null;
+      this.freeWorkers.push(worker);
+      this.emit(freeWorker);
     });
 
     worker.on('error', (err) => {
-      callCallback(err);
+      if (worker[taskInfo]) {
+        worker[taskInfo].done(err, null);
+      } else {
+        this.emit('error', err);
+      }
+      this.workers.splice(this.workers.indexOf(worker), 1);
+      this.addNewWorker();
     });
 
-    worker.on('exit', (code) => {
-      if (code !== 0) {
-        callCallback(new Error(`Minify worker stopped with exit code ${code}`));
+    this.workers.push(worker);
+    this.freeWorkers.push(worker);
+    this.emit(freeWorker);
+  }
+
+  private runTask(context: WorkerContext, cb: WorkerCallback) {
+    if (this.freeWorkers.length === 0) {
+      this.tasks.push({ context, cb });
+      if (this.workers.length < this.maxInstances) {
+        this.addNewWorker();
       }
+      return;
+    }
+
+    const worker = this.freeWorkers.pop()!;
+    worker[taskInfo] = new WorkerPoolTaskInfo(cb);
+    worker.postMessage({
+      code: context.code,
+      options: serializeJavascript(context.options)
     });
   }
 }

--- a/packages/terser/src/worker-pool.ts
+++ b/packages/terser/src/worker-pool.ts
@@ -76,7 +76,8 @@ export class WorkerPool extends EventEmitter {
   }
 
   close() {
-    for (const worker of this.workers) {
+    for (let i = 0; i < this.workers.length; i++) {
+      const worker = this.workers[i];
       worker.terminate();
     }
   }

--- a/packages/terser/src/worker.ts
+++ b/packages/terser/src/worker.ts
@@ -1,5 +1,4 @@
-import process from 'process';
-import { isMainThread, parentPort, workerData } from 'worker_threads';
+import { isMainThread, parentPort } from 'worker_threads';
 
 import { hasOwnProperty, isObject } from 'smob';
 
@@ -22,21 +21,25 @@ function isWorkerContextSerialized(input: unknown): input is WorkerContextSerial
   );
 }
 
-export async function runWorker() {
-  if (isMainThread || !parentPort || !isWorkerContextSerialized(workerData)) {
+export function runWorker() {
+  if (isMainThread || !parentPort) {
     return;
   }
 
-  try {
-    // eslint-disable-next-line no-eval
-    const eval2 = eval;
+  // eslint-disable-next-line no-eval
+  const eval2 = eval;
 
-    const options = eval2(`(${workerData.options})`);
+  parentPort.on('message', async (data: WorkerContextSerialized) => {
+    if (!isWorkerContextSerialized(data)) {
+      return;
+    }
 
-    const result = await minify(workerData.code, options);
+    const options = eval2(`(${data.options})`);
+
+    const result = await minify(data.code, options);
 
     const output: WorkerOutput = {
-      code: result.code || workerData.code,
+      code: result.code || data.code,
       nameCache: options.nameCache
     };
 
@@ -48,8 +51,6 @@ export async function runWorker() {
       output.sourceMap = result.map;
     }
 
-    parentPort.postMessage(output);
-  } catch (e) {
-    process.exit(1);
-  }
+    parentPort!.postMessage(output);
+  });
 }

--- a/packages/terser/src/worker.ts
+++ b/packages/terser/src/worker.ts
@@ -51,6 +51,6 @@ export function runWorker() {
       output.sourceMap = result.map;
     }
 
-    parentPort!.postMessage(output);
+    parentPort?.postMessage(output);
   });
 }

--- a/packages/terser/test/test.js
+++ b/packages/terser/test/test.js
@@ -122,7 +122,7 @@ test.serial('throw error on terser fail', async (t) => {
     await bundle.generate({ format: 'esm' });
     t.falsy(true);
   } catch (error) {
-    t.is(error.toString(), 'Error: Minify worker stopped with exit code 1');
+    t.is(error.toString(), 'SyntaxError: Name expected');
   }
 });
 
@@ -142,7 +142,7 @@ test.serial('throw error on terser fail with multiple outputs', async (t) => {
     await Promise.all([bundle.generate({ format: 'cjs' }), bundle.generate({ format: 'esm' })]);
     t.falsy(true);
   } catch (error) {
-    t.is(error.toString(), 'Error: Minify worker stopped with exit code 1');
+    t.is(error.toString(), 'SyntaxError: Name expected');
   }
 });
 

--- a/packages/terser/test/test.js
+++ b/packages/terser/test/test.js
@@ -46,9 +46,11 @@ test.serial('minify via terser options', async (t) => {
 });
 
 test.serial('minify multiple outputs', async (t) => {
+  let plugin;
+
   const bundle = await rollup({
     input: 'test/fixtures/unminified.js',
-    plugins: [terser()]
+    plugins: [(plugin = terser({ maxWorkers: 2 }))]
   });
 
   const [bundle1, bundle2] = await Promise.all([
@@ -60,6 +62,20 @@ test.serial('minify multiple outputs', async (t) => {
 
   t.is(output1.code, '"use strict";window.a=5,window.a<3&&console.log(4);\n');
   t.is(output2.code, 'window.a=5,window.a<3&&console.log(4);\n');
+  t.is(plugin.numOfWorkersUsed, 2, 'used 2 workers');
+});
+
+test.serial('minify multiple outputs with only 1 worker', async (t) => {
+  let plugin;
+
+  const bundle = await rollup({
+    input: 'test/fixtures/unminified.js',
+    plugins: [(plugin = terser({ maxWorkers: 1 }))]
+  });
+
+  await Promise.all([bundle.generate({ format: 'cjs' }), bundle.generate({ format: 'es' })]);
+
+  t.is(plugin.numOfWorkersUsed, 1, 'used 1 worker');
 });
 
 test.serial('minify esm module', async (t) => {


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `terser`

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers: https://github.com/rollup/plugins/pull/1341#pullrequestreview-1176576290

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

The existing WorkerPool creates a new Worker instance for every chunk. This PR reuses them instead. There is still a max number of workers, and the pool size still increases based on demand up to this max.

In my testing, on a 10 CPU machine, this reduced the build time from about 4.5 minutes to 2.5 minutes. This is for a large project with about 8,000 chunks.

I refactored the WorkerPool based on [this](https://nodejs.org/dist/latest-v18.x/docs/api/async_context.html#using-asyncresource-for-a-worker-thread-pool) Node doc example. I changed it to not create all the workers immediately though since this isn't needed in simple cases.

The changes to `module.ts` are based on the logic in https://github.com/TrySound/rollup-plugin-terser/blob/master/rollup-plugin-terser.js This is needed since the Workers now need to be explicitly terminated.

Similar to PR #1394, this PR also improves the error messages.