### PR TITLE
fix(node-resolve): handle star in the middle in exports map

### DIFF
--- a/packages/node-resolve/test/fixtures/exports-star-inbetween.js
+++ b/packages/node-resolve/test/fixtures/exports-star-inbetween.js
@@ -1,0 +1,5 @@
+import a from 'exports-star-inbetween/foo/a.js';
+import b from 'exports-star-inbetween/foo/b.js';
+import c from 'exports-star-inbetween/foo/bar/c.js';
+
+export default { a, b, c };

--- a/packages/node-resolve/test/fixtures/node_modules/exports-star-inbetween/foo/a.js
+++ b/packages/node-resolve/test/fixtures/node_modules/exports-star-inbetween/foo/a.js
@@ -1,0 +1,1 @@
+export default 'A';

--- a/packages/node-resolve/test/fixtures/node_modules/exports-star-inbetween/foo/b.js
+++ b/packages/node-resolve/test/fixtures/node_modules/exports-star-inbetween/foo/b.js
@@ -1,0 +1,1 @@
+export default 'B';

--- a/packages/node-resolve/test/fixtures/node_modules/exports-star-inbetween/foo/bar/c.js
+++ b/packages/node-resolve/test/fixtures/node_modules/exports-star-inbetween/foo/bar/c.js
@@ -1,0 +1,1 @@
+export default 'C';

--- a/packages/node-resolve/test/fixtures/node_modules/exports-star-inbetween/package.json
+++ b/packages/node-resolve/test/fixtures/node_modules/exports-star-inbetween/package.json
@@ -1,0 +1,7 @@
+{
+	"name": "exports-star-inbetween",
+	"main": "index.js",
+	"exports": {
+		"./foo/*.js": "./foo/*.js"
+	}
+}

--- a/packages/node-resolve/test/package-entry-points.js
+++ b/packages/node-resolve/test/package-entry-points.js
@@ -206,6 +206,19 @@ test('can use star pattern in exports field', async (t) => {
   t.deepEqual(module.exports, { a: 'A', b: 'B', c: 'C' });
 });
 
+test('can use star pattern appearing inbetween in exports field', async (t) => {
+  const bundle = await rollup({
+    input: 'exports-star-inbetween.js',
+    onwarn: () => {
+      t.fail('No warnings were expected');
+    },
+    plugins: [nodeResolve()]
+  });
+  const { module } = await testBundle(t, bundle);
+
+  t.deepEqual(module.exports, { a: 'A', b: 'B', c: 'C' });
+});
+
 test('the most specific star pattern matches', async (t) => {
   const bundle = await rollup({
     input: 'exports-star-specificity.js',


### PR DESCRIPTION
## Rollup Plugin Name: `node-resolve`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

`@rollup/plugin-node-resolve` can't deal with stars in the middle of a key of an exports map. It's allowed though (see [subpath patterns](https://nodejs.org/docs/latest-v18.x/api/packages.html#package-entry-points).

```json
{
	"exports": {
		"./foo/*.js": "./foo/*.js"
	}
}
```

To fix it I suggest to replace most of the current implementation around import and export maps with [resolve.exports](https://www.npmjs.com/package/resolve.exports), a widely-used npm package which aims to consolidate resolving export maps across tooling. It would potentially mean to get rid of some of the validation errors this plugin throws when encountering invalid export maps. I'm not sure if you want that, or to what extend, which is why I marked this as draft for now and only added a failing test.