### PR TITLE
fix(commonjs): dynamic require root check was broken in some cases

### DIFF
--- a/packages/commonjs/src/index.js
+++ b/packages/commonjs/src/index.js
@@ -147,7 +147,7 @@ export default function commonjs(options = {}) {
         this.error(
           {
             code: 'DYNAMIC_REQUIRE_OUTSIDE_ROOT',
-            id,
+            normalizedId,
             dynamicRequireRoot,
             message: `"${normalizedId}" contains dynamic require statements but it is not within the current dynamicRequireRoot "${normalizedRequireRoot}". You should set dynamicRequireRoot to "${dirname(
               normalizedId

--- a/packages/commonjs/src/index.js
+++ b/packages/commonjs/src/index.js
@@ -112,6 +112,7 @@ export default function commonjs(options = {}) {
   let requireResolver;
 
   function transformAndCheckExports(code, id) {
+    const normalizedId = normalizePathSlashes(id);
     const { isEsModule, hasDefaultExport, hasNamedExports, ast } = analyzeTopLevelStatements(
       this.parse,
       code,
@@ -127,7 +128,7 @@ export default function commonjs(options = {}) {
     }
 
     if (
-      !dynamicRequireModules.has(normalizePathSlashes(id)) &&
+      !dynamicRequireModules.has(normalizedId) &&
       (!(hasCjsKeywords(code, ignoreGlobal) || requireResolver.isRequiredId(id)) ||
         (isEsModule && !options.transformMixedEsModules))
     ) {
@@ -136,11 +137,9 @@ export default function commonjs(options = {}) {
     }
 
     const needsRequireWrapper =
-      !isEsModule &&
-      (dynamicRequireModules.has(normalizePathSlashes(id)) || strictRequiresFilter(id));
+      !isEsModule && (dynamicRequireModules.has(normalizedId) || strictRequiresFilter(id));
 
     const checkDynamicRequire = (position) => {
-      const normalizedId = normalizePathSlashes(id);
       const normalizedRequireRoot = normalizePathSlashes(dynamicRequireRoot);
 
       if (normalizedId.indexOf(normalizedRequireRoot) !== 0) {

--- a/packages/commonjs/src/index.js
+++ b/packages/commonjs/src/index.js
@@ -140,14 +140,17 @@ export default function commonjs(options = {}) {
       (dynamicRequireModules.has(normalizePathSlashes(id)) || strictRequiresFilter(id));
 
     const checkDynamicRequire = (position) => {
-      if (id.indexOf(dynamicRequireRoot) !== 0) {
+      const normalizedId = normalizePathSlashes(id);
+      const normalizedRequireRoot = normalizePathSlashes(dynamicRequireRoot);
+
+      if (normalizedId.indexOf(normalizedRequireRoot) !== 0) {
         this.error(
           {
             code: 'DYNAMIC_REQUIRE_OUTSIDE_ROOT',
             id,
             dynamicRequireRoot,
-            message: `"${id}" contains dynamic require statements but it is not within the current dynamicRequireRoot "${dynamicRequireRoot}". You should set dynamicRequireRoot to "${dirname(
-              id
+            message: `"${normalizedId}" contains dynamic require statements but it is not within the current dynamicRequireRoot "${normalizedRequireRoot}". You should set dynamicRequireRoot to "${dirname(
+              normalizedId
             )}" or one of its parent directories.`
           },
           position

--- a/packages/commonjs/test/helpers/util.js
+++ b/packages/commonjs/test/helpers/util.js
@@ -7,6 +7,10 @@ function commonjs(options) {
   return commonjsPlugin(options);
 }
 
+function normalizePathSlashes(path) {
+  return path.replace(/\\/g, '/');
+}
+
 function requireWithContext(code, context) {
   const module = { exports: {} };
   const contextWithExports = { ...context, module, exports: module.exports };
@@ -90,5 +94,6 @@ module.exports = {
   executeBundle,
   getCodeFromBundle,
   getCodeMapFromBundle,
+  normalizePathSlashes,
   runCodeSplitTest
 };

--- a/packages/commonjs/test/test.js
+++ b/packages/commonjs/test/test.js
@@ -738,38 +738,25 @@ test('throws when there is a dynamic require from outside dynamicRequireRoot', a
   });
 });
 
-test('does not mistakely says that a dynamic require is outside of dynamicRequireRoot when `path` uses backslashes', async (t) => {
-  const plugin = commonjs({
-    dynamicRequireRoot: 'fixtures/samples/dynamic-require-outside-root/nested',
-    dynamicRequireTargets: ['fixtures/samples/dynamic-require-outside-root/nested/target.js']
-  });
-
+test('does not throw when a dynamic require uses different slashes than dynamicRequireRoot', async (t) => {
   let error = null;
-  const cwd = process.cwd();
-  const id = normalizePathSlashes(
-    path.join(cwd, 'fixtures/samples/dynamic-require-outside-root/main.js')
-  );
-  const dynamicRequireRoot = normalizePathSlashes(
-    path.join(cwd, 'fixtures/samples/dynamic-require-outside-root/nested')
-  );
-  const minimalDynamicRequireRoot = normalizePathSlashes(
-    path.join(cwd, 'fixtures/samples/dynamic-require-outside-root')
-  );
-
-  const code = (await import('fixtures/samples/dynamic-require-outside-root/main.js')).default;
-
   try {
-    plugin.transform(code, id.replace('/', '\\'));
-  } catch (e) {
-    error = e;
+    await rollup({
+      input: 'fixtures/samples/dynamic-require-outside-root/main.js',
+      plugins: [
+        commonjs({
+          dynamicRequireRoot: 'fixtures\\samples\\dynamic-require-outside-root',
+          dynamicRequireTargets: [
+            'fixtures\\samples\\dynamic-require-outside-root\\nested\\target.js'
+          ]
+        })
+      ]
+    });
+  } catch (err) {
+    error = err;
   }
 
-  t.like(error, {
-    message: `"${id}" contains dynamic require statements but it is not within the current dynamicRequireRoot "${dynamicRequireRoot}". You should set dynamicRequireRoot to "${minimalDynamicRequireRoot}" or one of its parent directories.`,
-    pluginCode: 'DYNAMIC_REQUIRE_OUTSIDE_ROOT',
-    id,
-    dynamicRequireRoot
-  });
+  t.is(error, null);
 });
 
 test('does not transform typeof exports for mixed modules', async (t) => {

--- a/packages/commonjs/test/test.js
+++ b/packages/commonjs/test/test.js
@@ -738,6 +738,40 @@ test('throws when there is a dynamic require from outside dynamicRequireRoot', a
   });
 });
 
+test('does not mistakely says that a dynamic require is outside of dynamicRequireRoot when `path` uses backslashes', async (t) => {
+  const plugin = commonjs({
+    dynamicRequireRoot: 'fixtures/samples/dynamic-require-outside-root/nested',
+    dynamicRequireTargets: ['fixtures/samples/dynamic-require-outside-root/nested/target.js']
+  });
+
+  let error = null;
+  const cwd = process.cwd();
+  const id = normalizePathSlashes(
+    path.join(cwd, 'fixtures/samples/dynamic-require-outside-root/main.js')
+  );
+  const dynamicRequireRoot = normalizePathSlashes(
+    path.join(cwd, 'fixtures/samples/dynamic-require-outside-root/nested')
+  );
+  const minimalDynamicRequireRoot = normalizePathSlashes(
+    path.join(cwd, 'fixtures/samples/dynamic-require-outside-root')
+  );
+
+  const code = (await import('fixtures/samples/dynamic-require-outside-root/main.js')).default;
+
+  try {
+    plugin.transform(code, id.replace('/', '\\'));
+  } catch (e) {
+    error = e;
+  }
+
+  t.like(error, {
+    message: `"${id}" contains dynamic require statements but it is not within the current dynamicRequireRoot "${dynamicRequireRoot}". You should set dynamicRequireRoot to "${minimalDynamicRequireRoot}" or one of its parent directories.`,
+    pluginCode: 'DYNAMIC_REQUIRE_OUTSIDE_ROOT',
+    id,
+    dynamicRequireRoot
+  });
+});
+
 test('does not transform typeof exports for mixed modules', async (t) => {
   const bundle = await rollup({
     input: 'fixtures/samples/mixed-module-typeof-exports/main.js',

--- a/packages/commonjs/test/test.js
+++ b/packages/commonjs/test/test.js
@@ -720,7 +720,9 @@ test('throws when there is a dynamic require from outside dynamicRequireRoot', a
   }
 
   const cwd = process.cwd();
-  const id = path.join(cwd, 'fixtures/samples/dynamic-require-outside-root/main.js');
+  const id = normalizePathSlashes(
+    path.join(cwd, 'fixtures/samples/dynamic-require-outside-root/main.js')
+  );
   const dynamicRequireRoot = normalizePathSlashes(
     path.join(cwd, 'fixtures/samples/dynamic-require-outside-root/nested')
   );

--- a/packages/commonjs/test/test.js
+++ b/packages/commonjs/test/test.js
@@ -13,7 +13,12 @@ const { testBundle } = require('../../../util/test');
 
 const { peerDependencies } = require('../package.json');
 
-const { commonjs, executeBundle, getCodeFromBundle } = require('./helpers/util.js');
+const {
+  commonjs,
+  executeBundle,
+  getCodeFromBundle,
+  normalizePathSlashes
+} = require('./helpers/util.js');
 
 install();
 test.beforeEach(() => process.chdir(__dirname));
@@ -716,8 +721,13 @@ test('throws when there is a dynamic require from outside dynamicRequireRoot', a
 
   const cwd = process.cwd();
   const id = path.join(cwd, 'fixtures/samples/dynamic-require-outside-root/main.js');
-  const dynamicRequireRoot = path.join(cwd, 'fixtures/samples/dynamic-require-outside-root/nested');
-  const minimalDynamicRequireRoot = path.join(cwd, 'fixtures/samples/dynamic-require-outside-root');
+  const dynamicRequireRoot = normalizePathSlashes(
+    path.join(cwd, 'fixtures/samples/dynamic-require-outside-root/nested')
+  );
+  const minimalDynamicRequireRoot = normalizePathSlashes(
+    path.join(cwd, 'fixtures/samples/dynamic-require-outside-root')
+  );
+
   t.like(error, {
     message: `"${id}" contains dynamic require statements but it is not within the current dynamicRequireRoot "${dynamicRequireRoot}". You should set dynamicRequireRoot to "${minimalDynamicRequireRoot}" or one of its parent directories.`,
     pluginCode: 'DYNAMIC_REQUIRE_OUTSIDE_ROOT',

--- a/packages/commonjs/test/test.js
+++ b/packages/commonjs/test/test.js
@@ -759,6 +759,31 @@ test('does not throw when a dynamic require uses different slashes than dynamicR
   t.is(error, null);
 });
 
+// On Windows, avoid a false error about a module not being in the dynamic require root due to
+// incoherent slashes/backslashes in the paths.
+if (os.platform() === 'win32') {
+  test('correctly asserts dynamicRequireRoot on Windows', async (t) => {
+    let error = null;
+    try {
+      await rollup({
+        input: 'fixtures/samples/dynamic-require-outside-root/main.js',
+        plugins: [
+          commonjs({
+            dynamicRequireRoot: 'fixtures/samples/dynamic-require-outside-root',
+            dynamicRequireTargets: [
+              'fixtures/samples/dynamic-require-outside-root/nested/target.js'
+            ]
+          })
+        ]
+      });
+    } catch (err) {
+      error = err;
+    }
+
+    t.is(error, null);
+  });
+}
+
 test('does not transform typeof exports for mixed modules', async (t) => {
   const bundle = await rollup({
     input: 'fixtures/samples/mixed-module-typeof-exports/main.js',


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `commonjs`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (updated existing tests for the feature)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

### Description

When using the `dynamicRequireTargets` option, the files detected by the option are matched against the dynamic require root path used by the plugin — either the project root or the `dynamicRequireRoot` option to ensure that the root contains all dynamically required paths.

The test is done in `packages/commonjs/index.js:142` through a simple string comparison using `id.indexOf(dynamicRequireRoot)`.

In some cases, it happens that `dynamicRequireRoot` is using the OS path syntax (e.g. backslashes on Windows) but `id` is using unix paths (regular slashes). This leads to an issue where even if the root is correct, a simple string comparison fails to recognise that.

I reused the `normalizePathSlashes()` function provided in the plugin’s src to ensure that both `id` and `dynamicRequireRoot` have similar slash logic so that the check doesn’t fail.

Please advise on how to automate a test for that fix, as I have 0 experience on writing tests for Rollup plugins and that behaviour is located deep within the source, in a lambda returned by a function returned by another function with lots of params. Would exporting that lambda in a public function do the trick?