### PR TITLE
fix(node-resolve): Resolve all combinations of .ts/.tsx imported as .js

### DIFF
--- a/packages/node-resolve/src/index.js
+++ b/packages/node-resolve/src/index.js
@@ -147,9 +147,13 @@ export function nodeResolve(opts = {}) {
     }
 
     // TypeScript files may import '.js' to refer to either '.ts' or '.tsx'
-    if (importer && importee.endsWith('.js')) {
+    if (
+      importer &&
+      (importer.endsWith('.ts') || importer.endsWith('.tsx')) &&
+      importee.endsWith('.js')
+    ) {
       for (const ext of ['.ts', '.tsx']) {
-        if (importer.endsWith(ext) && extensions.includes(ext)) {
+        if (extensions.includes(ext)) {
           importSpecifierList.push(importee.replace(/.js$/, ext));
         }
       }

--- a/packages/node-resolve/test/fixtures/ts-import-js-extension/MyComponent.tsx
+++ b/packages/node-resolve/test/fixtures/ts-import-js-extension/MyComponent.tsx
@@ -1,0 +1,7 @@
+// To make this very clearly TypeScript and not just JS with a TS extension
+type TestType = string | string[];
+function MyComponent () {
+  return 'MyComponent works!'
+}
+
+export { MyComponent };

--- a/packages/node-resolve/test/fixtures/ts-import-js-extension/import-tsx-with-js-extension.ts
+++ b/packages/node-resolve/test/fixtures/ts-import-js-extension/import-tsx-with-js-extension.ts
@@ -1,0 +1,4 @@
+import { MyComponent } from './MyComponent.js';
+// This resolves as MyComponent.tsx and _not_ MyComponent.js, despite the extension
+const componentResult = MyComponent();
+export default componentResult;

--- a/packages/node-resolve/test/test.mjs
+++ b/packages/node-resolve/test/test.mjs
@@ -168,6 +168,25 @@ test('supports JS extensions in TS when referring to TS imports', async (t) => {
   t.is(module.exports, 'It works!');
 });
 
+test('supports JS extensions in TS when referring to TSX imports', async (t) => {
+  const bundle = await rollup({
+    input: 'ts-import-js-extension/import-tsx-with-js-extension.ts',
+    onwarn: failOnWarn(t),
+    plugins: [
+      nodeResolve({
+        extensions: ['.js', '.ts', '.tsx']
+      }),
+      babel({
+        babelHelpers: 'bundled',
+        plugins: ['@babel/plugin-transform-typescript'],
+        extensions: ['.js', '.ts', '.tsx']
+      })
+    ]
+  });
+  const { module } = await testBundle(t, bundle);
+  t.is(module.exports, 'MyComponent works!');
+});
+
 test('supports JS extensions in TS actually importing JS with export map', async (t) => {
   const bundle = await rollup({
     input: 'ts-import-js-extension-for-js-file-export-map/import-js-with-js-extension.ts',


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `node-resolve`

This PR contains:

- [X] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [X] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [X] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers: #1465

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

When importing a file ending in `.js` from a TypeScript file (extension `.ts` or `.tsx`), this should resolve to both `.ts`
 or `.tsx`. Before this patch, `.tsx` would only be resolved when the importing file was itself a `.tsx`, and the same for `.ts`. This behavior was contrary to the existing comment above the check.