### PR TITLE
fix(terser): don't assume code is running in worker created by the worker pool

### DIFF
--- a/packages/terser/src/constants.ts
+++ b/packages/terser/src/constants.ts
@@ -1,2 +1,3 @@
 export const taskInfo = Symbol('taskInfo');
 export const freeWorker = Symbol('freeWorker');
+export const workerPoolWorkerFlag = 'WorkerPoolWorker';

--- a/packages/terser/src/worker-pool.ts
+++ b/packages/terser/src/worker-pool.ts
@@ -5,7 +5,7 @@ import { EventEmitter } from 'events';
 
 import serializeJavascript from 'serialize-javascript';
 
-import { freeWorker, workerPoolWorkerFlag, taskInfo } from './constants';
+import { freeWorker, taskInfo, workerPoolWorkerFlag } from './constants';
 
 import type {
   WorkerCallback,

--- a/packages/terser/src/worker-pool.ts
+++ b/packages/terser/src/worker-pool.ts
@@ -5,7 +5,7 @@ import { EventEmitter } from 'events';
 
 import serializeJavascript from 'serialize-javascript';
 
-import { freeWorker, taskInfo } from './constants';
+import { freeWorker, workerPoolWorkerFlag, taskInfo } from './constants';
 
 import type {
   WorkerCallback,
@@ -81,7 +81,9 @@ export class WorkerPool extends EventEmitter {
   }
 
   private addNewWorker() {
-    const worker: WorkerWithTaskInfo = new Worker(this.filePath);
+    const worker: WorkerWithTaskInfo = new Worker(this.filePath, {
+      workerData: workerPoolWorkerFlag
+    });
 
     worker.on('message', (result) => {
       worker[taskInfo]?.done(null, result);

--- a/packages/terser/src/worker.ts
+++ b/packages/terser/src/worker.ts
@@ -1,8 +1,10 @@
-import { isMainThread, parentPort } from 'worker_threads';
+import { isMainThread, parentPort, workerData } from 'worker_threads';
 
 import { hasOwnProperty, isObject } from 'smob';
 
 import { minify } from 'terser';
+
+import { workerPoolWorkerFlag } from './constants';
 
 import type { WorkerContextSerialized, WorkerOutput } from './type';
 
@@ -22,7 +24,7 @@ function isWorkerContextSerialized(input: unknown): input is WorkerContextSerial
 }
 
 export function runWorker() {
-  if (isMainThread || !parentPort) {
+  if (isMainThread || !parentPort || workerData !== workerPoolWorkerFlag) {
     return;
   }
 


### PR DESCRIPTION
Fixes issue shown at https://github.com/dumbmatter/rollup-terser-worker-threads by making sure the worker code is only executed when the worker was created by the worker pool.

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `terser`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no (I don't see a good way to test for this change, but the current tests are testing for regressions.)

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers: #1482

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
Currently the worker only checks if it's not running on the main thread and then assumes that if it it isn't, it was created by the worker pool. This isn't true when Rollup itself is being run in a worker.