### PR TITLE
fix(dsv): update type of processRow option

### DIFF
--- a/packages/dsv/types/index.d.ts
+++ b/packages/dsv/types/index.d.ts
@@ -1,4 +1,4 @@
-import type { DSVRowString } from 'd3-dsv';
+import type { DSVRowAny, DSVRowString } from 'd3-dsv';
 import type { FilterPattern } from '@rollup/pluginutils';
 import type { Plugin } from 'rollup';
 
@@ -20,7 +20,7 @@ interface RollupDsvOptions {
    * The function can either manipulate the passed row, or return an entirely new row object.
    * @default undefined
    */
-  processRow?: null | ((row: DSVRowString, id: string) => DSVRowString | undefined);
+  processRow?: null | ((row: DSVRowString, id: string) => DSVRowAny | undefined | void);
 }
 
 /**


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `dsv`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers: #1492 

### Description

This updates the type definition for the `processRow` option to the DVS plugin, so that:

* a function that doesn't return anything can be used
* a function that returns a row object that includes non-string values (such as number or dates) can be used
