### PR TITLE
feat(node-resolve): Resolve js/jsx/mjs/cjs imports from TypeScript files

### DIFF
--- a/packages/node-resolve/src/index.js
+++ b/packages/node-resolve/src/index.js
@@ -146,11 +146,18 @@ export function nodeResolve(opts = {}) {
       importSpecifierList.push(`./${importee}`);
     }
 
-    // TypeScript files may import '.js' to refer to either '.ts' or '.tsx'
-    if (importer && importee.endsWith('.js')) {
-      for (const ext of ['.ts', '.tsx']) {
-        if (importer.endsWith(ext) && extensions.includes(ext)) {
-          importSpecifierList.push(importee.replace(/.js$/, ext));
+    // TypeScript files may import '.mjs' or '.cjs' to refer to either '.mts' or '.cts'.
+    // They may also import .js to refer to either .ts or .tsx, and .jsx to refer to .tsx.
+    if (importer && /\.(ts|mts|cts|tsx)$/.test(importer)) {
+      for (const [importeeExt, resolvedExt] of [
+        ['.js', '.ts'],
+        ['.js', '.tsx'],
+        ['.jsx', '.tsx'],
+        ['.mjs', '.mts'],
+        ['.cjs', '.cts']
+      ]) {
+        if (importee.endsWith(importeeExt) && extensions.includes(resolvedExt)) {
+          importSpecifierList.push(importee.slice(0, -importeeExt.length) + resolvedExt);
         }
       }
     }

--- a/packages/node-resolve/test/fixtures/ts-import-cjs-extension/import-ts-with-cjs-extension.ts
+++ b/packages/node-resolve/test/fixtures/ts-import-cjs-extension/import-ts-with-cjs-extension.ts
@@ -1,0 +1,4 @@
+import { main } from './main.cjs';
+// This resolves as main.cts and _not_ main.cjs, despite the extension
+const mainResult = main();
+export default mainResult;

--- a/packages/node-resolve/test/fixtures/ts-import-cjs-extension/main.cts
+++ b/packages/node-resolve/test/fixtures/ts-import-cjs-extension/main.cts
@@ -1,0 +1,11 @@
+// To make this very clearly TypeScript and not just CJS with a CTS extension
+type TestType = string | string[];
+interface Main {
+  (): string;
+  propertyCall(input?: TestType): TestType;
+}
+
+const main: Main = () => 'It works!';
+main.propertyCall = () => '';
+
+export { main };

--- a/packages/node-resolve/test/fixtures/ts-import-mjs-extension/import-ts-with-mjs-extension.ts
+++ b/packages/node-resolve/test/fixtures/ts-import-mjs-extension/import-ts-with-mjs-extension.ts
@@ -1,0 +1,4 @@
+import { main } from './main.mjs';
+// This resolves as main.mts and _not_ main.mjs, despite the extension
+const mainResult = main();
+export default mainResult;

--- a/packages/node-resolve/test/fixtures/ts-import-mjs-extension/main.mts
+++ b/packages/node-resolve/test/fixtures/ts-import-mjs-extension/main.mts
@@ -1,0 +1,11 @@
+// To make this very clearly TypeScript and not just MJS with a MTS extension
+type TestType = string | string[];
+interface Main {
+  (): string;
+  propertyCall(input?: TestType): TestType;
+}
+
+const main: Main = () => 'It works!';
+main.propertyCall = () => '';
+
+export { main };

--- a/packages/node-resolve/test/fixtures/tsx-import-js-extension/MyComponent.tsx
+++ b/packages/node-resolve/test/fixtures/tsx-import-js-extension/MyComponent.tsx
@@ -1,0 +1,7 @@
+// To make this very clearly TypeScript and not just JS with a TS extension
+type TestType = string | string[];
+function MyComponent() {
+  return 'It works!';
+}
+
+export { MyComponent };

--- a/packages/node-resolve/test/fixtures/tsx-import-js-extension/import-tsx-with-js-extension.ts
+++ b/packages/node-resolve/test/fixtures/tsx-import-js-extension/import-tsx-with-js-extension.ts
@@ -1,0 +1,4 @@
+import { MyComponent } from './MyComponent.js';
+// This resolves as MyComponent.tsx and _not_ MyComponent.js, despite the extension
+const componentResult = MyComponent();
+export default componentResult;

--- a/packages/node-resolve/test/fixtures/tsx-import-jsx-extension/MyComponent.tsx
+++ b/packages/node-resolve/test/fixtures/tsx-import-jsx-extension/MyComponent.tsx
@@ -1,0 +1,7 @@
+// To make this very clearly TypeScript and not just JS with a TS extension
+type TestType = string | string[];
+function MyComponent() {
+  return 'It works!';
+}
+
+export { MyComponent };

--- a/packages/node-resolve/test/fixtures/tsx-import-jsx-extension/import-tsx-with-jsx-extension.ts
+++ b/packages/node-resolve/test/fixtures/tsx-import-jsx-extension/import-tsx-with-jsx-extension.ts
@@ -1,0 +1,4 @@
+import { MyComponent } from './MyComponent.jsx';
+// This resolves as MyComponent.tsx and _not_ MyComponent.jsx, despite the extension
+const componentResult = MyComponent();
+export default componentResult;

--- a/packages/node-resolve/test/test.mjs
+++ b/packages/node-resolve/test/test.mjs
@@ -168,6 +168,82 @@ test('supports JS extensions in TS when referring to TS imports', async (t) => {
   t.is(module.exports, 'It works!');
 });
 
+test('supports JS extensions in TS when referring to TSX imports', async (t) => {
+  const bundle = await rollup({
+    input: 'tsx-import-js-extension/import-tsx-with-js-extension.ts',
+    onwarn: failOnWarn(t),
+    plugins: [
+      nodeResolve({
+        extensions: ['.js', '.ts', '.tsx']
+      }),
+      babel({
+        babelHelpers: 'bundled',
+        plugins: ['@babel/plugin-transform-typescript'],
+        extensions: ['.js', '.ts', '.tsx']
+      })
+    ]
+  });
+  const { module } = await testBundle(t, bundle);
+  t.is(module.exports, 'It works!');
+});
+
+test('supports JSX extensions in TS when referring to TSX imports', async (t) => {
+  const bundle = await rollup({
+    input: 'tsx-import-jsx-extension/import-tsx-with-jsx-extension.ts',
+    onwarn: failOnWarn(t),
+    plugins: [
+      nodeResolve({
+        extensions: ['.js', '.ts', '.tsx']
+      }),
+      babel({
+        babelHelpers: 'bundled',
+        plugins: ['@babel/plugin-transform-typescript'],
+        extensions: ['.js', '.ts', '.tsx']
+      })
+    ]
+  });
+  const { module } = await testBundle(t, bundle);
+  t.is(module.exports, 'It works!');
+});
+
+test('supports MJS extensions in TS when referring to MTS imports', async (t) => {
+  const bundle = await rollup({
+    input: 'ts-import-mjs-extension/import-ts-with-mjs-extension.ts',
+    onwarn: failOnWarn(t),
+    plugins: [
+      nodeResolve({
+        extensions: ['.js', '.ts', '.mjs', '.mts']
+      }),
+      babel({
+        babelHelpers: 'bundled',
+        plugins: ['@babel/plugin-transform-typescript'],
+        extensions: ['.js', '.ts', '.mjs', '.mts']
+      })
+    ]
+  });
+  const { module } = await testBundle(t, bundle);
+  t.is(module.exports, 'It works!');
+});
+
+test('supports CJS extensions in TS when referring to CTS imports', async (t) => {
+  const bundle = await rollup({
+    input: 'ts-import-cjs-extension/import-ts-with-cjs-extension.ts',
+    onwarn: failOnWarn(t),
+    plugins: [
+      nodeResolve({
+        extensions: ['.js', '.ts', '.cjs', '.cts']
+      }),
+      babel({
+        babelHelpers: 'bundled',
+        plugins: ['@babel/plugin-transform-typescript'],
+        extensions: ['.js', '.ts', '.cjs', '.cts']
+      })
+    ]
+  });
+  const { module } = await testBundle(t, bundle);
+  t.is(module.exports, 'It works!');
+});
+
 test('supports JS extensions in TS actually importing JS with export map', async (t) => {
   const bundle = await rollup({
     input: 'ts-import-js-extension-for-js-file-export-map/import-js-with-js-extension.ts',


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `node-resolve`

This PR contains:

- [X] bugfix
- [X] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [X] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [X] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers: #1465

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

This patch is a combination of PRs #1475 and #1454. It updates the logic for importing from within a TypeScript file. In that case, `.js` can now resolve to `.ts` and `.tsx`, `.jsx` can resolve to `.tsx`, `.mjs` can resolve to `.mts`, and `.cjs` can resolve to `.cts`. This behavior was verified to mimic that of `tsc` itself. Importing from within plain JS files is untouched (e.g., a `.js` import from within a `.js` file will not resolve to `.ts`).
