### PR TITLE
fix(yaml): Add extensions?: string[] to RollupYamlOptions

### DIFF
--- a/packages/yaml/test/types.ts
+++ b/packages/yaml/test/types.ts
@@ -19,7 +19,8 @@ const config: RollupOptions = {
         }
 
         return data;
-      }
+      },
+      extensions: ['.yaml', '.yml', '.cff']
     })
   ]
 };

--- a/packages/yaml/types/index.d.ts
+++ b/packages/yaml/types/index.d.ts
@@ -37,6 +37,13 @@ interface RollupYamlOptions {
    * @default 'single'
    */
   documentMode?: 'single' | 'multi';
+
+  /**
+   * File extensions to process. Useful if you have files that contain YAML but do not have a
+   * `.yaml` or `.yml` extension.
+   * @default ['.yaml', '.yml']
+   */
+  extensions?: string[];
 }
 
 /**


### PR DESCRIPTION
Follow up to #1445.

## Rollup Plugin Name: `yaml`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

Follow up to #1445.

Fixes:

![Screenshot 2023-05-24 at 11 45 25](https://github.com/rollup/plugins/assets/30958850/392f1d32-6038-4d58-80cd-3c9d2eb97873)
