### PR TITLE
fix(commonjs): change dynamicRequireRoot to normalizedDynamicRequireRoot && tweak related tests

### DIFF
--- a/packages/commonjs/src/index.js
+++ b/packages/commonjs/src/index.js
@@ -140,15 +140,15 @@ export default function commonjs(options = {}) {
       !isEsModule && (dynamicRequireModules.has(normalizedId) || strictRequiresFilter(id));
 
     const checkDynamicRequire = (position) => {
-      const normalizedRequireRoot = normalizePathSlashes(dynamicRequireRoot);
+      const normalizedDynamicRequireRoot = normalizePathSlashes(dynamicRequireRoot);
 
-      if (normalizedId.indexOf(normalizedRequireRoot) !== 0) {
+      if (normalizedId.indexOf(normalizedDynamicRequireRoot) !== 0) {
         this.error(
           {
             code: 'DYNAMIC_REQUIRE_OUTSIDE_ROOT',
             normalizedId,
-            dynamicRequireRoot,
-            message: `"${normalizedId}" contains dynamic require statements but it is not within the current dynamicRequireRoot "${normalizedRequireRoot}". You should set dynamicRequireRoot to "${dirname(
+            normalizedDynamicRequireRoot,
+            message: `"${normalizedId}" contains dynamic require statements but it is not within the current dynamicRequireRoot "${normalizedDynamicRequireRoot}". You should set dynamicRequireRoot to "${dirname(
               normalizedId
             )}" or one of its parent directories.`
           },

--- a/packages/commonjs/test/test.js
+++ b/packages/commonjs/test/test.js
@@ -733,8 +733,8 @@ test('throws when there is a dynamic require from outside dynamicRequireRoot', a
   t.like(error, {
     message: `"${id}" contains dynamic require statements but it is not within the current dynamicRequireRoot "${dynamicRequireRoot}". You should set dynamicRequireRoot to "${minimalDynamicRequireRoot}" or one of its parent directories.`,
     pluginCode: 'DYNAMIC_REQUIRE_OUTSIDE_ROOT',
-    id,
-    dynamicRequireRoot
+    normalizedId: id,
+    normalizedDynamicRequireRoot: dynamicRequireRoot
   });
 });
 


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `commonjs`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [x] yes (_breaking changes will not be merged unless absolutely necessary_)
- [ ] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

related #1461
resolves #1507 

### Description
This PR primary fix that the test failed in windows, see this action  https://github.com/rollup/plugins/actions/runs/5104720044/jobs/9175831630?pr=1507 from #1507. By the way, I also change  `dynamicRequireRoot` to `normalizedDynamicRequireRoot` for unifying all the path value is normalized, but that also make a break change.
<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
