### PR TITLE
feat(replace): add safer default delimiters

### DIFF
--- a/packages/replace/src/index.js
+++ b/packages/replace/src/index.js
@@ -69,7 +69,7 @@ function expandTypeofReplacements(replacements) {
 
 export default function replace(options = {}) {
   const filter = createFilter(options.include, options.exclude);
-  const { delimiters = ['\\b', '\\b(?!\\.)'], preventAssignment, objectGuards } = options;
+  const { delimiters = ['(?<!\\.)\\b', '\\b(?!\\.)'], preventAssignment, objectGuards } = options;
   const replacements = getReplacements(options);
   if (objectGuards) expandTypeofReplacements(replacements);
   const functionValues = mapToFunctions(replacements);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `replace`

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [x] yes (_breaking changes will not be merged unless absolutely necessary_)
- [ ] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

resolves https://github.com/rollup/plugins/issues/1524

This might be a BREAKING CHANGE for some existing users, but I'm assuming that in 99.9% of cases this is the desired behaviour, as the b delimiter is a little too greedy.

This doesn't break any existing tests, so I'm not sure if additional tests are needed. 