### PR TITLE
fix(pluginutils): add current working dirctory when pattern starts with one *

### DIFF
--- a/packages/pluginutils/src/createFilter.ts
+++ b/packages/pluginutils/src/createFilter.ts
@@ -8,7 +8,7 @@ import ensureArray from './utils/ensureArray';
 import normalizePath from './normalizePath';
 
 function getMatcherString(id: string, resolutionBase: string | false | null | undefined) {
-  if (resolutionBase === false || isAbsolute(id) || id.startsWith('*')) {
+  if (resolutionBase === false || isAbsolute(id) || id.startsWith('**')) {
     return normalizePath(id);
   }
 

--- a/packages/pluginutils/test/createFilter.ts
+++ b/packages/pluginutils/test/createFilter.ts
@@ -134,6 +134,20 @@ test('does not add current working directory when pattern is an absolute path', 
   t.falsy(filter(resolve('..', 'c')));
 });
 
+test('does not add current working directory when pattern starts with character **', (t) => {
+  const filter = createFilter(['**/*']);
+
+  t.truthy(filter(resolve('a')));
+  t.truthy(filter(resolve('..', '..', 'a')));
+});
+
+test('add current working directory when pattern starts with one *', (t) => {
+  const filter = createFilter([`*`]);
+
+  t.truthy(filter(resolve('a')));
+  t.falsy(filter(resolve('..', '..', 'a')));
+});
+
 test('normalizes path when pattern is an absolute path', (t) => {
   const filterPosix = createFilter([`${resolve('.')}/*`]);
   const filterWin = createFilter([`${resolve('.')}\\*`]);
@@ -160,10 +174,4 @@ test('normalizes path when pattern has resolution base', (t) => {
 
   t.truthy(filterPosix(resolve('test/a')));
   t.truthy(filterWin(resolve('test/a')));
-});
-
-test('does not add current working directory when pattern starts with a glob', (t) => {
-  const filter = createFilter(['**/*']);
-  t.truthy(filter(resolve('a')));
-  t.truthy(filter(resolve('..', '..', 'a')));
 });


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `pluginutils`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:
relevant: #1538
### Description
Currently, if we use a format like `*.js` in the `include` option of `@rollup/plugins`, the plugin cannot filter files correctly, I created a minimal reprodution https://stackblitz.com/edit/rollup-repro-dnz5kc?file=rollup.config.js. This PR addresses this problem with the solution described in issue [#1538](https://github.com/rollup/plugins/issues/1538#issue-1809790595).

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
