### PR TITLE
chore(repo): add missing `prepare` script for several packages

### DIFF
--- a/packages/babel/package.json
+++ b/packages/babel/package.json
@@ -30,6 +30,7 @@
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose",
     "prebuild": "del-cli dist",
+    "prepare": "if [ ! -d 'dist' ]; then pnpm build; fi",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",
     "release": "pnpm --workspace-root plugin:release --pkg $npm_package_name",

--- a/packages/data-uri/package.json
+++ b/packages/data-uri/package.json
@@ -30,6 +30,7 @@
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose",
     "prebuild": "del-cli dist",
+    "prepare": "if [ ! -d 'dist' ]; then pnpm build; fi",
     "prerelease": "pnpm build",
     "pretest": "pnpm build --sourcemap",
     "release": "pnpm --workspace-root plugin:release --pkg $npm_package_name",

--- a/packages/dynamic-import-vars/package.json
+++ b/packages/dynamic-import-vars/package.json
@@ -30,6 +30,7 @@
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose",
     "prebuild": "del-cli dist",
+    "prepare": "if [ ! -d 'dist' ]; then pnpm build; fi",
     "prerelease": "pnpm build",
     "pretest": "pnpm build --sourcemap",
     "release": "pnpm --workspace-root plugin:release --pkg $npm_package_name",

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -30,6 +30,7 @@
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose",
     "prebuild": "del-cli dist",
+    "prepare": "if [ ! -d 'dist' ]; then pnpm build; fi",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",
     "release": "pnpm --workspace-root plugin:release --pkg $npm_package_name",

--- a/packages/strip/package.json
+++ b/packages/strip/package.json
@@ -29,6 +29,7 @@
     "ci:lint": "pnpm lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose",
+    "prepare": "if [ ! -d 'dist' ]; then pnpm build; fi",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",
     "release": "pnpm --workspace-root plugin:release --pkg $npm_package_name",


### PR DESCRIPTION
## Rollup Plugin Name: `babel`, `data-uri`, `dynamic-import-vars`, `html`, `strip`

This PR contains:

- [ ] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers: None

### Description

This PR adds the missing `prepare` script to several packages, so that they will be built upon running `pnpm install`. This aligns with the behavior of other packages.

Alternatively, this could be solved by having a single `prepare` script in the root package, which can then run this command for all projects in the workspace. This approach would prevent accidental inconsistencies from being introduced, such as those mitigated in this PR. It would also remove duplicated code between package scripts.

Please do let me know what the preferred solution for this would be, and I will adjust the PR accordingly if required.
