### PR TITLE
docs(pluginutils): configure the correct options

### DIFF
--- a/packages/pluginutils/README.md
+++ b/packages/pluginutils/README.md
@@ -165,8 +165,8 @@ const esModuleSource = dataToEsm(
   {
     compact: false,
     indent: '\t',
-    preferConst: false,
-    objectShorthand: false,
+    preferConst: true,
+    objectShorthand: true,
     namedExports: true
   }
 );


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

The [`dataToEsm` API options example](https://github.com/rollup/plugins/tree/master/packages/pluginutils#usage-2) in the documentation is inconsistent with the output:

```ts
import { dataToEsm } from '@rollup/pluginutils';

const esModuleSource = dataToEsm(
  {
    custom: 'data',
    to: ['treeshake']
  },
  {
    compact: false,
    indent: '\t',
    preferConst: false,
    objectShorthand: false,
    namedExports: true
  }
);
/*
Outputs the string ES module source:
  export const custom = 'data';
  export const to = ['treeshake'];
  export default { custom, to };
*/
```

## Rollup Plugin Name: `{pluginutils}`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

### Description

The right options should be:

```ts
const esModuleSource = dataToEsm(
  {
    custom: 'data',
    to: ['treeshake']
  },
  {
    compact: false,
    indent: '\t',
    preferConst: true,
    objectShorthand: true,
    namedExports: true
  }
);
```
