### PR TITLE
fix(dsv): fix type of processRow option

### DIFF
--- a/packages/dsv/test/types.ts
+++ b/packages/dsv/test/types.ts
@@ -13,7 +13,17 @@ const config: RollupOptions = {
       include: 'node_modules/**',
       exclude: ['node_modules/foo/**', 'node_modules/bar/**'],
       processRow(row) {
-        return row;
+        return {
+          foo: +row.foo,
+          bar: new Date(row.bar),
+          baz: row.baz === 'true',
+          ...row
+        };
+      }
+    }),
+    dsv({
+      processRow() {
+        // void
       }
     })
   ]

--- a/packages/dsv/types/index.d.ts
+++ b/packages/dsv/types/index.d.ts
@@ -20,7 +20,7 @@ interface RollupDsvOptions {
    * The function can either manipulate the passed row, or return an entirely new row object.
    * @default undefined
    */
-  processRow?: null | ((row: DSVRowString, id: string) => DSVRowString | undefined);
+  processRow?: null | ((row: DSVRowString, id: string) => object | void);
 }
 
 /**

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -17,7 +17,7 @@ import findTypescriptOutput, {
   normalizePath,
   emitFile,
   isDeclarationOutputFile,
-  isMapOutputFile
+  isTypeScriptMapOutputFile
 } from './outputFile';
 import { preflight } from './preflight';
 import createWatchProgram, { WatchProgramHelper } from './watchProgram';
@@ -156,11 +156,11 @@ export default function typescript(options: RollupTypescriptOptions = {}): Plugi
     },
 
     async generateBundle(outputOptions) {
-      const declarationAndMapFiles = [...emittedFiles.keys()].filter(
-        (fileName) => isDeclarationOutputFile(fileName) || isMapOutputFile(fileName)
+      const declarationAndTypeScriptMapFiles = [...emittedFiles.keys()].filter(
+        (fileName) => isDeclarationOutputFile(fileName) || isTypeScriptMapOutputFile(fileName)
       );
 
-      declarationAndMapFiles.forEach((id) => {
+      declarationAndTypeScriptMapFiles.forEach((id) => {
         const code = getEmittedFile(id, emittedFiles, tsCache);
         if (!code || !parsedOptions.options.declaration) {
           return;

--- a/packages/typescript/src/outputFile.ts
+++ b/packages/typescript/src/outputFile.ts
@@ -24,6 +24,13 @@ export function isCodeOutputFile(name: string): boolean {
  * Checks if the given OutputFile represents some source map
  */
 export function isMapOutputFile(name: string): boolean {
+  return name.endsWith('.map');
+}
+
+/**
+ * Checks if the given OutputFile represents some TypeScript source map
+ */
+export function isTypeScriptMapOutputFile(name: string): boolean {
   return name.endsWith('ts.map');
 }
 

--- a/packages/typescript/test/test.js
+++ b/packages/typescript/test/test.js
@@ -612,6 +612,24 @@ test.serial('should not emit null sourceContent', async (t) => {
   t.false(sourcemap.sourcesContent.includes(undefined));
 });
 
+test.serial('should not emit sourceContent that references a non-existent file', async (t) => {
+  const bundle = await rollup({
+    input: 'fixtures/basic/main.ts',
+    output: {
+      sourcemap: true
+    },
+    plugins: [
+      typescript({
+        tsconfig: 'fixtures/basic/tsconfig.json'
+      })
+    ],
+    onwarn
+  });
+  const output = await getCode(bundle, { format: 'es', sourcemap: true }, true);
+  const sourcemap = output[0].map;
+  t.false(sourcemap.sourcesContent.includes('//# sourceMappingURL=main.js.map'));
+});
+
 test.serial('should not fail if source maps are off', async (t) => {
   await t.notThrowsAsync(
     rollup({


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `dsv`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers: #1492

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

(successor to #1493)

This fixes the type definition for the processRow option to the DSV plugin, so that:

- a function that doesn't return anything can be used
- a function that returns a row object that includes non-string values (such as `number` or `Date`) can be used

This PR also removes `undefined` from the return value type, since there is no case where `undefined` is explicitly returned.
