### PR TITLE
fix(terser): always make at least 1 worker thread

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@ava/babel": "2.0.0",
     "@rollup/plugin-typescript": "^9.0.1",
     "@types/conventional-commits-parser": "^3.0.2",
-    "@types/node": "14.18.30",
+    "@types/node": "20.8.4",
     "@types/semver": "^7.3.7",
     "@types/source-map-support": "^0.5.4",
     "@types/yargs-parser": "^20.2.1",

--- a/packages/terser/src/worker-pool.ts
+++ b/packages/terser/src/worker-pool.ts
@@ -40,7 +40,8 @@ export class WorkerPool extends EventEmitter {
   constructor(options: WorkerPoolOptions) {
     super();
 
-    this.maxInstances = options.maxWorkers || cpus().length;
+    // cpus() can return [] on some platforms, and we always need at least 1 worker
+    this.maxInstances = options.maxWorkers || cpus().length || 1;
     this.filePath = options.filePath;
 
     this.on(freeWorker, () => {

--- a/packages/terser/src/worker-pool.ts
+++ b/packages/terser/src/worker-pool.ts
@@ -1,6 +1,6 @@
 import { AsyncResource } from 'async_hooks';
 import { Worker } from 'worker_threads';
-import { cpus } from 'os';
+import os from 'os';
 import { EventEmitter } from 'events';
 
 import serializeJavascript from 'serialize-javascript';
@@ -40,8 +40,14 @@ export class WorkerPool extends EventEmitter {
   constructor(options: WorkerPoolOptions) {
     super();
 
-    // cpus() can return [] on some platforms, and we always need at least 1 worker
-    this.maxInstances = options.maxWorkers || cpus().length || 1;
+    if (options.maxWorkers) {
+      this.maxInstances = options.maxWorkers;
+    } else if (typeof os.availableParallelism === 'function') {
+      this.maxInstances = os.availableParallelism();
+    } else {
+      // cpus() can return [] on some platforms, and we always need at least 1 worker
+      this.maxInstances = os.cpus().length || 1;
+    }
     this.filePath = options.filePath;
 
     this.on(freeWorker, () => {

--- a/packages/terser/test/test.js
+++ b/packages/terser/test/test.js
@@ -360,7 +360,8 @@ test.serial('terser preserve vars in nameCache when provided', async (t) => {
 });
 
 test.serial('minify when os.cpus().length === 0', async (t) => {
-  const original = os.cpus;
+  const originalAvailableParallelism = os.availableParallelism;
+  const originalCpus = os.cpus;
   os.cpus = () => [];
   try {
     const bundle = await rollup({
@@ -373,6 +374,7 @@ test.serial('minify when os.cpus().length === 0', async (t) => {
     t.is(output.code, '"use strict";window.a=5,window.a<3&&console.log(4);\n');
     t.falsy(output.map);
   } finally {
-    os.cpus = original;
+    os.availableParallelism = originalAvailableParallelism;
+    os.cpus = originalCpus;
   }
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^3.0.2
         version: 3.0.2
       '@types/node':
-        specifier: 14.18.30
-        version: 14.18.30
+        specifier: 20.8.4
+        version: 20.8.4
       '@types/semver':
         specifier: ^7.3.7
         version: 7.3.12
@@ -85,7 +85,7 @@ importers:
         version: 0.5.21
       ts-node:
         specifier: 10.9.1
-        version: 10.9.1(@types/node@14.18.30)(typescript@4.8.4)
+        version: 10.9.1(@types/node@20.8.4)(typescript@4.8.4)
       tsconfig-paths:
         specifier: ^3.9.0
         version: 3.14.1
@@ -2731,6 +2731,12 @@ packages:
 
   /@types/node@14.18.31:
     resolution: {integrity: sha512-vQAnaReSQkEDa8uwAyQby8bYGKu84R/deEc6mg5T8fX6gzCn8QW6rziSgsti1fNvsrswKUKPnVTi7uoB+u62Mw==}
+    dev: true
+
+  /@types/node@20.8.4:
+    resolution: {integrity: sha512-ZVPnqU58giiCjSxjVUESDtdPk4QR5WQhhINbc9UBrKLU68MX5BF6kbQzTrkwbolyr0X8ChBpXfavr5mZFKZQ5A==}
+    dependencies:
+      undici-types: 5.25.3
     dev: true
 
   /@types/normalize-package-data@2.4.1:
@@ -6413,7 +6419,7 @@ packages:
     dependencies:
       lilconfig: 2.0.6
       postcss: 8.4.17
-      ts-node: 10.9.1(@types/node@14.18.30)(typescript@4.8.4)
+      ts-node: 10.9.1(@types/node@20.8.4)(typescript@4.8.4)
       yaml: 1.10.2
     dev: true
 
@@ -7605,7 +7611,7 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: false
 
-  /ts-node@10.9.1(@types/node@14.18.30)(typescript@4.8.4):
+  /ts-node@10.9.1(@types/node@20.8.4)(typescript@4.8.4):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -7624,7 +7630,7 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
-      '@types/node': 14.18.30
+      '@types/node': 20.8.4
       acorn: 8.8.0
       acorn-walk: 8.2.0
       arg: 4.1.3
@@ -7744,6 +7750,10 @@ packages:
       has-bigints: 1.0.2
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
+    dev: true
+
+  /undici-types@5.25.3:
+    resolution: {integrity: sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA==}
     dev: true
 
   /unicode-canonical-property-names-ecmascript@1.0.4:


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `terser`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:
Resolves #1594 
<!--
If this PR resolves any issues, list them as

  resolves #1234 

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
On some platforms (I noticed it on Android), `os.cpus()` can return `[]`, resulting in no workers being spawned, so the jobs never run. This patch makes sure the maximum number of workers is never 0. 