### PR TITLE
fix(commonjs,dynamic-import-vars,inject,replace,strip,esm-shim): update magic-string

### DIFF
--- a/packages/commonjs/package.json
+++ b/packages/commonjs/package.json
@@ -67,7 +67,7 @@
     "estree-walker": "^2.0.2",
     "glob": "^8.0.3",
     "is-reference": "1.2.1",
-    "magic-string": "^0.30.4"
+    "magic-string": "^0.30.5"
   },
   "devDependencies": {
     "@rollup/plugin-json": "^5.0.0",

--- a/packages/commonjs/package.json
+++ b/packages/commonjs/package.json
@@ -67,7 +67,7 @@
     "estree-walker": "^2.0.2",
     "glob": "^8.0.3",
     "is-reference": "1.2.1",
-    "magic-string": "^0.27.0"
+    "magic-string": "^0.30.4"
   },
   "devDependencies": {
     "@rollup/plugin-json": "^5.0.0",

--- a/packages/dynamic-import-vars/package.json
+++ b/packages/dynamic-import-vars/package.json
@@ -67,7 +67,7 @@
     "astring": "^1.8.5",
     "estree-walker": "^2.0.2",
     "fast-glob": "^3.2.12",
-    "magic-string": "^0.27.0"
+    "magic-string": "^0.30.4"
   },
   "devDependencies": {
     "acorn": "^8.8.0",

--- a/packages/dynamic-import-vars/package.json
+++ b/packages/dynamic-import-vars/package.json
@@ -67,7 +67,7 @@
     "astring": "^1.8.5",
     "estree-walker": "^2.0.2",
     "fast-glob": "^3.2.12",
-    "magic-string": "^0.30.4"
+    "magic-string": "^0.30.5"
   },
   "devDependencies": {
     "acorn": "^8.8.0",

--- a/packages/esm-shim/package.json
+++ b/packages/esm-shim/package.json
@@ -60,7 +60,7 @@
     }
   },
   "dependencies": {
-    "magic-string": "^0.30.0"
+    "magic-string": "^0.30.4"
   },
   "devDependencies": {
     "rollup": "^4.0.0-24",

--- a/packages/esm-shim/package.json
+++ b/packages/esm-shim/package.json
@@ -60,7 +60,7 @@
     }
   },
   "dependencies": {
-    "magic-string": "^0.30.4"
+    "magic-string": "^0.30.5"
   },
   "devDependencies": {
     "rollup": "^4.0.0-24",

--- a/packages/inject/package.json
+++ b/packages/inject/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@rollup/pluginutils": "^5.0.1",
     "estree-walker": "^2.0.2",
-    "magic-string": "^0.27.0"
+    "magic-string": "^0.30.4"
   },
   "devDependencies": {
     "@rollup/plugin-buble": "^1.0.0",

--- a/packages/inject/package.json
+++ b/packages/inject/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@rollup/pluginutils": "^5.0.1",
     "estree-walker": "^2.0.2",
-    "magic-string": "^0.30.4"
+    "magic-string": "^0.30.5"
   },
   "devDependencies": {
     "@rollup/plugin-buble": "^1.0.0",

--- a/packages/replace/package.json
+++ b/packages/replace/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@rollup/pluginutils": "^5.0.1",
-    "magic-string": "^0.27.0"
+    "magic-string": "^0.30.4"
   },
   "devDependencies": {
     "@rollup/plugin-buble": "^1.0.0",

--- a/packages/replace/package.json
+++ b/packages/replace/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@rollup/pluginutils": "^5.0.1",
-    "magic-string": "^0.30.4"
+    "magic-string": "^0.30.5"
   },
   "devDependencies": {
     "@rollup/plugin-buble": "^1.0.0",

--- a/packages/strip/package.json
+++ b/packages/strip/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@rollup/pluginutils": "^5.0.1",
     "estree-walker": "^2.0.2",
-    "magic-string": "^0.30.4"
+    "magic-string": "^0.30.5"
   },
   "devDependencies": {
     "acorn": "^8.8.0",

--- a/packages/strip/package.json
+++ b/packages/strip/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@rollup/pluginutils": "^5.0.1",
     "estree-walker": "^2.0.2",
-    "magic-string": "^0.27.0"
+    "magic-string": "^0.30.4"
   },
   "devDependencies": {
     "acorn": "^8.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 2.0.0
       '@rollup/plugin-typescript':
         specifier: ^9.0.1
-        version: 9.0.1(rollup@4.0.0-24)(typescript@4.8.4)
+        version: 9.0.1(typescript@4.8.4)
       '@types/conventional-commits-parser':
         specifier: ^3.0.2
         version: 3.0.2
@@ -31,10 +31,10 @@ importers:
         version: 20.2.2
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.38.0
-        version: 5.39.0(@typescript-eslint/parser@5.39.0)(eslint@8.28.0)(typescript@4.8.4)
+        version: 5.39.0(@typescript-eslint/parser@5.39.0)(typescript@4.8.4)
       '@typescript-eslint/parser':
         specifier: ^5.38.0
-        version: 5.39.0(eslint@8.28.0)(typescript@4.8.4)
+        version: 5.39.0(typescript@4.8.4)
       ava:
         specifier: ^4.3.3
         version: 4.3.3
@@ -76,7 +76,7 @@ importers:
         version: 8.7.5
       prettier-plugin-package:
         specifier: ^1.3.0
-        version: 1.3.0(prettier@2.8.0)
+        version: 1.3.0
       semver:
         specifier: ^7.3.2
         version: 7.3.8
@@ -144,6 +144,12 @@ importers:
       typescript:
         specifier: ^4.8.3
         version: 4.8.4
+
+  packages/auto-install/test/fixtures/pnpm-bare:
+    dependencies:
+      node-noop:
+        specifier: ^1.0.0
+        version: 1.0.0
 
   packages/babel:
     dependencies:
@@ -243,8 +249,8 @@ importers:
         specifier: 1.2.1
         version: 1.2.1
       magic-string:
-        specifier: ^0.27.0
-        version: 0.27.0
+        specifier: ^0.30.4
+        version: 0.30.4
     devDependencies:
       '@rollup/plugin-json':
         specifier: ^5.0.0
@@ -327,8 +333,8 @@ importers:
         specifier: ^3.2.12
         version: 3.2.12
       magic-string:
-        specifier: ^0.27.0
-        version: 0.27.0
+        specifier: ^0.30.4
+        version: 0.30.4
     devDependencies:
       acorn:
         specifier: ^8.8.0
@@ -368,8 +374,8 @@ importers:
   packages/esm-shim:
     dependencies:
       magic-string:
-        specifier: ^0.30.0
-        version: 0.30.0
+        specifier: ^0.30.4
+        version: 0.30.4
     devDependencies:
       rollup:
         specifier: ^4.0.0-24
@@ -410,7 +416,7 @@ importers:
         version: 4.0.0-24
       rollup-plugin-postcss:
         specifier: ^4.0.2
-        version: 4.0.2(postcss@8.4.17)(ts-node@10.9.1)
+        version: 4.0.2(postcss@8.4.17)
       typescript:
         specifier: ^4.8.3
         version: 4.8.4
@@ -440,8 +446,8 @@ importers:
         specifier: ^2.0.2
         version: 2.0.2
       magic-string:
-        specifier: ^0.27.0
-        version: 0.27.0
+        specifier: ^0.30.4
+        version: 0.30.4
     devDependencies:
       '@rollup/plugin-buble':
         specifier: ^1.0.0
@@ -602,8 +608,8 @@ importers:
         specifier: ^5.0.1
         version: 5.0.1(rollup@4.0.0-24)
       magic-string:
-        specifier: ^0.27.0
-        version: 0.27.0
+        specifier: ^0.30.4
+        version: 0.30.4
     devDependencies:
       '@rollup/plugin-buble':
         specifier: ^1.0.0
@@ -655,8 +661,8 @@ importers:
         specifier: ^2.0.2
         version: 2.0.2
       magic-string:
-        specifier: ^0.27.0
-        version: 0.27.0
+        specifier: ^0.30.4
+        version: 0.30.4
     devDependencies:
       acorn:
         specifier: ^8.8.0
@@ -730,9 +736,6 @@ importers:
       resolve:
         specifier: ^1.22.1
         version: 1.22.1
-      tslib:
-        specifier: '*'
-        version: 2.4.0
     devDependencies:
       '@rollup/plugin-buble':
         specifier: ^1.0.0
@@ -2170,7 +2173,7 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       '@jridgewell/set-array': 1.1.2
-      '@jridgewell/sourcemap-codec': 1.4.14
+      '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
   /@jridgewell/gen-mapping@0.3.2:
@@ -2178,7 +2181,7 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       '@jridgewell/set-array': 1.1.2
-      '@jridgewell/sourcemap-codec': 1.4.14
+      '@jridgewell/sourcemap-codec': 1.4.15
       '@jridgewell/trace-mapping': 0.3.16
 
   /@jridgewell/resolve-uri@3.1.0:
@@ -2199,6 +2202,9 @@ packages:
   /@jridgewell/sourcemap-codec@1.4.14:
     resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
 
+  /@jridgewell/sourcemap-codec@1.4.15:
+    resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
+
   /@jridgewell/trace-mapping@0.3.16:
     resolution: {integrity: sha512-LCQ+NeThyJ4k1W2d+vIKdxuSt9R3pQSZ4P92m7EakaYuXcVWbHuT5bjNcqLd4Rdgi6xYWYDvBJZJLZSLanjDcA==}
     dependencies:
@@ -2209,7 +2215,7 @@ packages:
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
     dependencies:
       '@jridgewell/resolve-uri': 3.1.0
-      '@jridgewell/sourcemap-codec': 1.4.14
+      '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
   /@nodelib/fs.scandir@2.1.5:
@@ -2342,6 +2348,24 @@ packages:
       '@rollup/pluginutils': 4.2.1
       resolve: 1.22.1
       rollup: 4.0.0-24
+      typescript: 4.8.4
+    dev: true
+
+  /@rollup/plugin-typescript@9.0.1(typescript@4.8.4):
+    resolution: {integrity: sha512-fj+CTk8+HvFCEwwDQdNgWd0lIJVXtMQ0Z3vH/ZgzFSbK2s1zs5wjZrjzrhViTTN+UF49+P69/tybgKRdGHpj/Q==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.14.0||^3.0.0
+      tslib: '*'
+      typescript: '>=3.7.0'
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+      tslib:
+        optional: true
+    dependencies:
+      '@rollup/pluginutils': 4.2.1
+      resolve: 1.22.1
       typescript: 4.8.4
     dev: true
 
@@ -2772,7 +2796,7 @@ packages:
     resolution: {integrity: sha512-sUWMriymrSqTvxCmCkf+7k392TNDcMJBHI1/rysWJxKnWAan/Zk4gZ/GEieSRo4EqIEPpbGU3Sd/0KTRoIA3pA==}
     dev: true
 
-  /@typescript-eslint/eslint-plugin@5.39.0(@typescript-eslint/parser@5.39.0)(eslint@8.28.0)(typescript@4.8.4):
+  /@typescript-eslint/eslint-plugin@5.39.0(@typescript-eslint/parser@5.39.0)(typescript@4.8.4):
     resolution: {integrity: sha512-xVfKOkBm5iWMNGKQ2fwX5GVgBuHmZBO1tCRwXmY5oAIsPscfwm2UADDuNB8ZVYCtpQvJK4xpjrK7jEhcJ0zY9A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2783,12 +2807,11 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.39.0(eslint@8.28.0)(typescript@4.8.4)
+      '@typescript-eslint/parser': 5.39.0(typescript@4.8.4)
       '@typescript-eslint/scope-manager': 5.39.0
-      '@typescript-eslint/type-utils': 5.39.0(eslint@8.28.0)(typescript@4.8.4)
-      '@typescript-eslint/utils': 5.39.0(eslint@8.28.0)(typescript@4.8.4)
+      '@typescript-eslint/type-utils': 5.39.0(typescript@4.8.4)
+      '@typescript-eslint/utils': 5.39.0(typescript@4.8.4)
       debug: 4.3.4
-      eslint: 8.28.0
       ignore: 5.2.0
       regexpp: 3.2.0
       semver: 7.3.8
@@ -2838,7 +2861,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/parser@5.39.0(eslint@8.28.0)(typescript@4.8.4):
+  /@typescript-eslint/parser@5.39.0(typescript@4.8.4):
     resolution: {integrity: sha512-PhxLjrZnHShe431sBAGHaNe6BDdxAASDySgsBCGxcBecVCi8NQWxQZMcizNA4g0pN51bBAn/FUfkWG3SDVcGlA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2852,7 +2875,6 @@ packages:
       '@typescript-eslint/types': 5.39.0
       '@typescript-eslint/typescript-estree': 5.39.0(typescript@4.8.4)
       debug: 4.3.4
-      eslint: 8.28.0
       typescript: 4.8.4
     transitivePeerDependencies:
       - supports-color
@@ -2894,7 +2916,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.44.0
     dev: true
 
-  /@typescript-eslint/type-utils@5.39.0(eslint@8.28.0)(typescript@4.8.4):
+  /@typescript-eslint/type-utils@5.39.0(typescript@4.8.4):
     resolution: {integrity: sha512-KJHJkOothljQWzR3t/GunL0TPKY+fGJtnpl+pX+sJ0YiKTz3q2Zr87SGTmFqsCMFrLt5E0+o+S6eQY0FAXj9uA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2905,9 +2927,8 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/typescript-estree': 5.39.0(typescript@4.8.4)
-      '@typescript-eslint/utils': 5.39.0(eslint@8.28.0)(typescript@4.8.4)
+      '@typescript-eslint/utils': 5.39.0(typescript@4.8.4)
       debug: 4.3.4
-      eslint: 8.28.0
       tsutils: 3.21.0(typescript@4.8.4)
       typescript: 4.8.4
     transitivePeerDependencies:
@@ -2999,6 +3020,23 @@ packages:
       eslint: 8.28.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0(eslint@8.28.0)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
+  /@typescript-eslint/utils@5.39.0(typescript@4.8.4):
+    resolution: {integrity: sha512-+DnY5jkpOpgj+EBtYPyHRjXampJfC0yUZZzfzLuUWVZvCuKqSdJVC8UhdWipIw7VKNTfwfAPiOWzYkAwuIhiAg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@types/json-schema': 7.0.11
+      '@typescript-eslint/scope-manager': 5.39.0
+      '@typescript-eslint/types': 5.39.0
+      '@typescript-eslint/typescript-estree': 5.39.0(typescript@4.8.4)
+      eslint-scope: 5.1.1
+      eslint-utils: 3.0.0
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -4399,6 +4437,15 @@ packages:
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
+  /eslint-utils@3.0.0:
+    resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
+    engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
+    peerDependencies:
+      eslint: '>=5'
+    dependencies:
+      eslint-visitor-keys: 2.1.0
+    dev: true
+
   /eslint-utils@3.0.0(eslint@8.25.0):
     resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
     engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
@@ -5675,18 +5722,11 @@ packages:
       sourcemap-codec: 1.4.8
     dev: true
 
-  /magic-string@0.27.0:
-    resolution: {integrity: sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==}
+  /magic-string@0.30.4:
+    resolution: {integrity: sha512-Q/TKtsC5BPm0kGqgBIF9oXAs/xEf2vRKiIB4wCRQTJOQIByZ1d+NnUOotvJOvNpi5RNIgVOMC3pOuaP1ZTDlVg==}
     engines: {node: '>=12'}
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.4.14
-    dev: false
-
-  /magic-string@0.30.0:
-    resolution: {integrity: sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==}
-    engines: {node: '>=12'}
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.4.14
+      '@jridgewell/sourcemap-codec': 1.4.15
     dev: false
 
   /make-dir@2.1.0:
@@ -5915,7 +5955,6 @@ packages:
 
   /node-noop@1.0.0:
     resolution: {integrity: sha512-1lpWqKwZ9yUosQfW1uy3jm6St4ZbmeDKKGmdzwzedbyBI4LgHtGyL1ofDdqiSomgaYaSERi+qWtj64huJQjl7g==}
-    dev: true
 
   /node-preload@0.2.1:
     resolution: {integrity: sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==}
@@ -6399,7 +6438,7 @@ packages:
       postcss: 8.4.17
     dev: true
 
-  /postcss-load-config@3.1.4(postcss@8.4.17)(ts-node@10.9.1):
+  /postcss-load-config@3.1.4(postcss@8.4.17):
     resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
     engines: {node: '>= 10'}
     peerDependencies:
@@ -6413,7 +6452,6 @@ packages:
     dependencies:
       lilconfig: 2.0.6
       postcss: 8.4.17
-      ts-node: 10.9.1(@types/node@14.18.30)(typescript@4.8.4)
       yaml: 1.10.2
     dev: true
 
@@ -6716,6 +6754,13 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       fast-diff: 1.2.0
+    dev: true
+
+  /prettier-plugin-package@1.3.0:
+    resolution: {integrity: sha512-KPNHR/Jm2zTevBp1SnjzMnooO1BOQW2bixVbOp8flOJoW+dxdDwEncObfsKZdkjwrv6AIH4oWqm5EO/etDmK9Q==}
+    engines: {node: '>=10.13.0'}
+    peerDependencies:
+      prettier: ^2.0.0
     dev: true
 
   /prettier-plugin-package@1.3.0(prettier@2.8.0):
@@ -7023,7 +7068,7 @@ packages:
     dependencies:
       glob: 7.2.3
 
-  /rollup-plugin-postcss@4.0.2(postcss@8.4.17)(ts-node@10.9.1):
+  /rollup-plugin-postcss@4.0.2(postcss@8.4.17):
     resolution: {integrity: sha512-05EaY6zvZdmvPUDi3uCcAQoESDcYnv8ogJJQRp6V5kZ6J6P7uAVJlrTZcaaA20wTH527YTnKfkAoPxWI/jPp4w==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -7036,7 +7081,7 @@ packages:
       p-queue: 6.6.2
       pify: 5.0.0
       postcss: 8.4.17
-      postcss-load-config: 3.1.4(postcss@8.4.17)(ts-node@10.9.1)
+      postcss-load-config: 3.1.4(postcss@8.4.17)
       postcss-modules: 4.3.1(postcss@8.4.17)
       promise.series: 0.2.0
       resolve: 1.22.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 importers:
 
   .:
@@ -145,12 +141,6 @@ importers:
         specifier: ^4.8.3
         version: 4.8.4
 
-  packages/auto-install/test/fixtures/pnpm-bare:
-    dependencies:
-      node-noop:
-        specifier: ^1.0.0
-        version: 1.0.0
-
   packages/babel:
     dependencies:
       '@babel/helper-module-imports':
@@ -249,8 +239,8 @@ importers:
         specifier: 1.2.1
         version: 1.2.1
       magic-string:
-        specifier: ^0.30.4
-        version: 0.30.4
+        specifier: ^0.30.5
+        version: 0.30.5
     devDependencies:
       '@rollup/plugin-json':
         specifier: ^5.0.0
@@ -333,8 +323,8 @@ importers:
         specifier: ^3.2.12
         version: 3.2.12
       magic-string:
-        specifier: ^0.30.4
-        version: 0.30.4
+        specifier: ^0.30.5
+        version: 0.30.5
     devDependencies:
       acorn:
         specifier: ^8.8.0
@@ -374,8 +364,8 @@ importers:
   packages/esm-shim:
     dependencies:
       magic-string:
-        specifier: ^0.30.4
-        version: 0.30.4
+        specifier: ^0.30.5
+        version: 0.30.5
     devDependencies:
       rollup:
         specifier: ^4.0.0-24
@@ -446,8 +436,8 @@ importers:
         specifier: ^2.0.2
         version: 2.0.2
       magic-string:
-        specifier: ^0.30.4
-        version: 0.30.4
+        specifier: ^0.30.5
+        version: 0.30.5
     devDependencies:
       '@rollup/plugin-buble':
         specifier: ^1.0.0
@@ -608,8 +598,8 @@ importers:
         specifier: ^5.0.1
         version: 5.0.1(rollup@4.0.0-24)
       magic-string:
-        specifier: ^0.30.4
-        version: 0.30.4
+        specifier: ^0.30.5
+        version: 0.30.5
     devDependencies:
       '@rollup/plugin-buble':
         specifier: ^1.0.0
@@ -5729,6 +5719,13 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.15
     dev: false
 
+  /magic-string@0.30.5:
+    resolution: {integrity: sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.15
+    dev: false
+
   /make-dir@2.1.0:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
     engines: {node: '>=6'}
@@ -5955,6 +5952,7 @@ packages:
 
   /node-noop@1.0.0:
     resolution: {integrity: sha512-1lpWqKwZ9yUosQfW1uy3jm6St4ZbmeDKKGmdzwzedbyBI4LgHtGyL1ofDdqiSomgaYaSERi+qWtj64huJQjl7g==}
+    dev: true
 
   /node-preload@0.2.1:
     resolution: {integrity: sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==}
@@ -8050,3 +8048,7 @@ packages:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
     engines: {node: '>=12.20'}
     dev: true
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false


### PR DESCRIPTION

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `commonjs,dynamic-import-vars,inject,replace,strip,esm-shim`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

The current version of `magic-string` doesn't handle `sources` and `sourcesContent` correctly, so `vite` can't handle sourcemap correctly, the related issue is https://github.com/vitejs/vite/issues/13657. The latest version of `magic-string` has been fixed, you can see https://github.com/Rich-Harris/magic-string/pull/242

In addition, `magic-string` has no breaking changes so we can update it with confidence.