### PR TITLE
fix(dynamic-import-vars): Allow a "no files found" error to be emitted as warning

### DIFF
--- a/packages/dynamic-import-vars/README.md
+++ b/packages/dynamic-import-vars/README.md
@@ -68,7 +68,7 @@ Default: `false`
 
 By default, the plugin will not throw errors when target files are not found. Setting this option to true will result in errors thrown when encountering files which don't exist.
 
-When used in combination for `warnOnError` it will throw a warning instead.
+⚠️ _Important:_ Enabling this option when `warnOnError` is set to `true` will result in a warning and _not_ an error
 
 #### `warnOnError`
 

--- a/packages/dynamic-import-vars/README.md
+++ b/packages/dynamic-import-vars/README.md
@@ -68,6 +68,8 @@ Default: `false`
 
 By default, the plugin will not throw errors when target files are not found. Setting this option to true will result in errors thrown when encountering files which don't exist.
 
+When used in combination for `warnOnError` it will throw a warning instead.
+
 #### `warnOnError`
 
 Type: `Boolean`<br>

--- a/packages/dynamic-import-vars/src/index.js
+++ b/packages/dynamic-import-vars/src/index.js
@@ -56,11 +56,14 @@ function dynamicImportVariables({ include, exclude, warnOnError, errorWhenNoFile
             );
 
             if (errorWhenNoFilesFound && paths.length === 0) {
-              this.error(
-                new Error(
-                  `No files found in ${glob} when trying to dynamically load concatted string from ${id}`
-                )
+              const error = new Error(
+                `No files found in ${glob} when trying to dynamically load concatted string from ${id}`
               );
+              if (warnOnError) {
+                this.warn(error);
+              } else {
+                this.error(error);
+              }
             }
 
             // create magic string if it wasn't created already

--- a/packages/dynamic-import-vars/test/rollup-plugin-dynamic-import-vars.test.js
+++ b/packages/dynamic-import-vars/test/rollup-plugin-dynamic-import-vars.test.js
@@ -218,7 +218,7 @@ test("doesn't throw if no files in dir when option isn't set", async (t) => {
   t.false(thrown);
 });
 
-test('throws if no files in dir when option is set', async (t) => {
+test('throws if no files in dir when `errorWhenNoFilesFound` is set', async (t) => {
   let thrown = false;
   try {
     await rollup({
@@ -235,4 +235,22 @@ test('throws if no files in dir when option is set', async (t) => {
     thrown = true;
   }
   t.true(thrown);
+});
+
+test('warns if no files in dir when `errorWhenNoFilesFound` and `warnOnError` are both set', async (t) => {
+  let warningEmitted = false;
+  await rollup({
+    input: 'fixture-no-files.js',
+    plugins: [dynamicImportVars({ errorWhenNoFilesFound: true, warnOnError: true })],
+    onwarn(warning) {
+      t.deepEqual(
+        warning.message,
+        `No files found in ./module-dir-c/*.js when trying to dynamically load concatted string from ${require.resolve(
+          './fixtures/fixture-no-files.js'
+        )}`
+      );
+      warningEmitted = true;
+    }
+  });
+  t.true(warningEmitted);
 });


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `dynamic-import-vars`

This PR contains:

- [x] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers: https://github.com/rollup/plugins/pull/1611

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

This PR allows the "no files found" error introduced in https://github.com/rollup/plugins/pull/1611 to be emitted as a warning using the existing `warnOnError` option.