### PR TITLE
feat(alias): add warning to avoid unintended duplicate modules

### DIFF
--- a/packages/alias/src/index.ts
+++ b/packages/alias/src/index.ts
@@ -1,3 +1,5 @@
+import path from 'path';
+
 import type { Plugin } from 'rollup';
 
 import type { ResolvedAlias, ResolverFunction, ResolverObject, RollupAliasOptions } from '../types';
@@ -97,7 +99,18 @@ export default function alias(options: RollupAliasOptions = {}): Plugin {
         updatedId,
         importer,
         Object.assign({ skipSelf: true }, resolveOptions)
-      ).then((resolved) => resolved || { id: updatedId });
+      ).then((resolved) => {
+        if (resolved) return resolved;
+
+        if (!path.isAbsolute(updatedId)) {
+          this.warn(
+            `rewrote ${importee} to ${updatedId} but was not an abolute path and was not handled by other plugins. ` +
+              `This will lead to duplicated modules for the same path. ` +
+              `To avoid duplicating modules, you should resolve to an absolute path.`
+          );
+        }
+        return { id: updatedId };
+      });
     }
   };
 }

--- a/packages/alias/test/fixtures/folder/warn-importee.js
+++ b/packages/alias/test/fixtures/folder/warn-importee.js
@@ -1,0 +1,1 @@
+console.log()

--- a/packages/alias/test/fixtures/warn.js
+++ b/packages/alias/test/fixtures/warn.js
@@ -1,0 +1,2 @@
+import '@/warn-importee.js'
+import './folder/warn-importee.js'

--- a/packages/alias/test/test.mjs
+++ b/packages/alias/test/test.mjs
@@ -656,7 +656,8 @@ test('show warning for non-absolute non-plugin resolved id', async (t) => {
       })
     ],
     onwarn(log) {
-      warnList.push(log);
+      const formattedLog = { ...log, message: log.message.replace(/\//g, '/') };
+      warnList.push(formattedLog);
     }
   });
   t.deepEqual(warnList, [

--- a/packages/alias/test/test.mjs
+++ b/packages/alias/test/test.mjs
@@ -195,10 +195,10 @@ test('i/am/a/file', (t) =>
 test('Windows absolute path aliasing', (t) => {
   if (!isWindows) {
     t.deepEqual(1, 1);
-    return;
+    return null;
   }
 
-  resolveAliasWithRollup(
+  return resolveAliasWithRollup(
     {
       entries: [
         {

--- a/packages/alias/test/test.mjs
+++ b/packages/alias/test/test.mjs
@@ -656,7 +656,7 @@ test('show warning for non-absolute non-plugin resolved id', async (t) => {
       })
     ],
     onwarn(log) {
-      const formattedLog = { ...log, message: log.message.replace(/\//g, '/') };
+      const formattedLog = { ...log, message: log.message.replace(/\\/g, '/') };
       warnList.push(formattedLog);
     }
   });


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `alias`

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

resolves https://github.com/rollup/rollup/issues/5250

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
When the alias plugin is configured like this
```js
// rollup.config.js
alias({ entries: { $: 'src' } })
```
and there a file like
```js
import { test as test1 } from './sub.js';
import { test as test2 } from '$/sub.js';

console.log(test1);
console.log(test2);
```
https://stackblitz.com/edit/rollup-repro-s5tmli?file=src%2Fmain.js

then, `import './sub.js'` and `import '$/sub.js'` resolves to different module. (The same file is included in the bundle twice.)
I believe this is not what people expect. Also IMO the fact that "`import 'src/sub.js'` doesn't work but `$/sub.js` works" is difficult to understand.

This PR adds a warning to catch these cases.

The warning will be shown for those that is using the alias plugin to duplicate the module, but I guess no one would do that. It'd be easier to create a different plugin in that case.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
