### PR TITLE
feat(pluginutils): add `includeArbitraryNames: true` to `dataToEsm`

### DIFF
--- a/packages/pluginutils/README.md
+++ b/packages/pluginutils/README.md
@@ -167,7 +167,8 @@ const esModuleSource = dataToEsm(
     indent: '\t',
     preferConst: true,
     objectShorthand: true,
-    namedExports: true
+    namedExports: true,
+    includeArbitraryNames: false
   }
 );
 /*

--- a/packages/pluginutils/README.md
+++ b/packages/pluginutils/README.md
@@ -143,7 +143,7 @@ export default function myPlugin(options = {}) {
 
 Transforms objects into tree-shakable ES Module imports.
 
-Parameters: `(data: Object)`<br>
+Parameters: `(data: Object, options: DataToEsmOptions)`<br>
 Returns: `String`
 
 #### `data`
@@ -151,6 +151,12 @@ Returns: `String`
 Type: `Object`
 
 An object to transform into an ES module.
+
+#### `options`
+
+Type: `DataToEsmOptions`
+
+_Note: Please see the TypeScript definition for complete documentation of these options_
 
 #### Usage
 

--- a/packages/pluginutils/src/dataToEsm.ts
+++ b/packages/pluginutils/src/dataToEsm.ts
@@ -59,6 +59,17 @@ function serialize(obj: unknown, indent: Indent, baseIndent: string): string {
   return stringify(obj);
 }
 
+// isWellFormed exists from Node.js 20
+const hasStringIsWellFormed = 'isWellFormed' in String.prototype;
+
+function isWellFormedString(input: string): boolean {
+  // @ts-expect-error String::isWellFormed exists from ES2024. tsconfig lib is set to ES6
+  if (hasStringIsWellFormed) return input.isWellFormed();
+
+  // https://github.com/tc39/proposal-is-usv-string/blob/main/README.md#algorithm
+  return !/\p{Surrogate}/u.test(input);
+}
+
 const dataToEsm: DataToEsm = function dataToEsm(data, options = {}) {
   const t = options.compact ? '' : 'indent' in options ? options.indent : '\t';
   const _ = options.compact ? '' : ' ';
@@ -78,8 +89,19 @@ const dataToEsm: DataToEsm = function dataToEsm(data, options = {}) {
     return `export default${magic}${code};`;
   }
 
+  let maxUnderbarPrefixLength = 0;
+  for (const key of Object.keys(data)) {
+    const underbarPrefixLength = key.match(/^(_+)/)?.[0].length ?? 0;
+    if (underbarPrefixLength > maxUnderbarPrefixLength) {
+      maxUnderbarPrefixLength = underbarPrefixLength;
+    }
+  }
+
+  const arbitraryNamePrefix = `${'_'.repeat(maxUnderbarPrefixLength + 1)}arbitrary`;
+
   let namedExportCode = '';
   const defaultExportRows = [];
+  const arbitraryNameExportRows: string[] = [];
   for (const [key, value] of Object.entries(data)) {
     if (key === makeLegalIdentifier(key)) {
       if (options.objectShorthand) defaultExportRows.push(key);
@@ -93,11 +115,27 @@ const dataToEsm: DataToEsm = function dataToEsm(data, options = {}) {
       defaultExportRows.push(
         `${stringify(key)}:${_}${serialize(value, options.compact ? null : t, '')}`
       );
+      if (options.namedExports === 'include-arbitrary-name' && isWellFormedString(key)) {
+        const variableName = `${arbitraryNamePrefix}${arbitraryNameExportRows.length}`;
+        namedExportCode += `${declarationType} ${variableName}${_}=${_}${serialize(
+          value,
+          options.compact ? null : t,
+          ''
+        )};${n}`;
+        arbitraryNameExportRows.push(`${variableName} as ${JSON.stringify(key)}`);
+      }
     }
   }
-  return `${namedExportCode}export default${_}{${n}${t}${defaultExportRows.join(
+
+  const arbitraryExportCode =
+    arbitraryNameExportRows.length > 0
+      ? `export${_}{${n}${t}${arbitraryNameExportRows.join(`,${n}${t}`)}${n}};${n}`
+      : '';
+  const defaultExportCode = `export default${_}{${n}${t}${defaultExportRows.join(
     `,${n}${t}`
   )}${n}};${n}`;
+
+  return `${namedExportCode}${arbitraryExportCode}${defaultExportCode}`;
 };
 
 export { dataToEsm as default };

--- a/packages/pluginutils/src/dataToEsm.ts
+++ b/packages/pluginutils/src/dataToEsm.ts
@@ -115,7 +115,7 @@ const dataToEsm: DataToEsm = function dataToEsm(data, options = {}) {
       defaultExportRows.push(
         `${stringify(key)}:${_}${serialize(value, options.compact ? null : t, '')}`
       );
-      if (options.namedExports === 'include-arbitrary-name' && isWellFormedString(key)) {
+      if (options.includeArbitraryNames && isWellFormedString(key)) {
         const variableName = `${arbitraryNamePrefix}${arbitraryNameExportRows.length}`;
         namedExportCode += `${declarationType} ${variableName}${_}=${_}${serialize(
           value,

--- a/packages/pluginutils/test/dataToEsm.ts
+++ b/packages/pluginutils/test/dataToEsm.ts
@@ -115,14 +115,14 @@ test('support arbitrary module namespace identifier names', (t) => {
   t.is(
     dataToEsm(
       { foo: 'foo', 'foo.bar': 'foo.bar', '\udfff': 'non wellformed' },
-      { namedExports: 'include-arbitrary-name' }
+      { namedExports: true, includeArbitraryNames: true }
     ),
     'export var foo = "foo";\nvar _arbitrary0 = "foo.bar";\nexport {\n\t_arbitrary0 as "foo.bar"\n};\nexport default {\n\tfoo: foo,\n\t"foo.bar": "foo.bar",\n\t"\\udfff": "non wellformed"\n};\n'
   );
   t.is(
     dataToEsm(
       { foo: 'foo', 'foo.bar': 'foo.bar', '\udfff': 'non wellformed' },
-      { namedExports: 'include-arbitrary-name', compact: true }
+      { namedExports: true, includeArbitraryNames: true, compact: true }
     ),
     'export var foo="foo";var _arbitrary0="foo.bar";export{_arbitrary0 as "foo.bar"};export default{foo:foo,"foo.bar":"foo.bar","\\udfff":"non wellformed"};'
   );

--- a/packages/pluginutils/test/dataToEsm.ts
+++ b/packages/pluginutils/test/dataToEsm.ts
@@ -110,3 +110,20 @@ test('avoid U+2029 U+2029 -0 be ignored by JSON.stringify, and avoid it return n
     'export default[-0,"\\u2028\\u2029",undefined,undefined];'
   );
 });
+
+test('support arbitrary module namespace identifier names', (t) => {
+  t.is(
+    dataToEsm(
+      { foo: 'foo', 'foo.bar': 'foo.bar', '\udfff': 'non wellformed' },
+      { namedExports: 'include-arbitrary-name' }
+    ),
+    'export var foo = "foo";\nvar _arbitrary0 = "foo.bar";\nexport {\n\t_arbitrary0 as "foo.bar"\n};\nexport default {\n\tfoo: foo,\n\t"foo.bar": "foo.bar",\n\t"\\udfff": "non wellformed"\n};\n'
+  );
+  t.is(
+    dataToEsm(
+      { foo: 'foo', 'foo.bar': 'foo.bar', '\udfff': 'non wellformed' },
+      { namedExports: 'include-arbitrary-name', compact: true }
+    ),
+    'export var foo="foo";var _arbitrary0="foo.bar";export{_arbitrary0 as "foo.bar"};export default{foo:foo,"foo.bar":"foo.bar","\\udfff":"non wellformed"};'
+  );
+});

--- a/packages/pluginutils/types/index.d.ts
+++ b/packages/pluginutils/types/index.d.ts
@@ -10,9 +10,14 @@ export interface AttachedScope {
 
 export interface DataToEsmOptions {
   compact?: boolean;
+  /**
+   * @desc When this option is set, dataToEsm will generate a named export for keys that
+   * are not a valid identifier, by leveraging the "Arbitrary Module Namespace Identifier
+   * Names" feature. See: https://github.com/tc39/ecma262/pull/2154
+   */
+  includeArbitraryNames?: boolean;
   indent?: string;
   namedExports?: boolean;
-  includeArbitraryNames?: boolean;
   objectShorthand?: boolean;
   preferConst?: boolean;
 }

--- a/packages/pluginutils/types/index.d.ts
+++ b/packages/pluginutils/types/index.d.ts
@@ -11,7 +11,7 @@ export interface AttachedScope {
 export interface DataToEsmOptions {
   compact?: boolean;
   indent?: string;
-  namedExports?: boolean;
+  namedExports?: boolean | 'include-arbitrary-name';
   objectShorthand?: boolean;
   preferConst?: boolean;
 }

--- a/packages/pluginutils/types/index.d.ts
+++ b/packages/pluginutils/types/index.d.ts
@@ -11,7 +11,8 @@ export interface AttachedScope {
 export interface DataToEsmOptions {
   compact?: boolean;
   indent?: string;
-  namedExports?: boolean | 'include-arbitrary-name';
+  namedExports?: boolean;
+  includeArbitraryNames?: boolean;
   objectShorthand?: boolean;
   preferConst?: boolean;
 }


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `pluginutils`

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

resolves https://github.com/rollup/plugins/issues/1437

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

This PR adds `namedExports: 'include-arbitrary-name'` option to `dataToEsm` function in `pluginutils`.
When this option is set, `dataToEsm` will generate named export for keys that was not a valid identifier by leveraging Arbitrary module namespace identifier names feature (https://github.com/tc39/ecma262/pull/2154).

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
