### PR TITLE
fix(dynamic-import-vars): escape special glob characters

### DIFF
--- a/packages/dynamic-import-vars/src/dynamic-import-to-glob.js
+++ b/packages/dynamic-import-vars/src/dynamic-import-to-glob.js
@@ -1,15 +1,18 @@
 import path from 'path';
 
+import fastGlob from 'fast-glob';
+
 export class VariableDynamicImportError extends Error {}
 
 /* eslint-disable-next-line no-template-curly-in-string */
 const example = 'For example: import(`./foo/${bar}.js`).';
 
 function sanitizeString(str) {
+  if (str === '') return str;
   if (str.includes('*')) {
     throw new VariableDynamicImportError('A dynamic import cannot contain * characters.');
   }
-  return str;
+  return fastGlob.escapePath(str);
 }
 
 function templateLiteralToGlob(node) {

--- a/packages/dynamic-import-vars/test/src/dynamic-import-to-glob.test.mjs
+++ b/packages/dynamic-import-vars/test/src/dynamic-import-to-glob.test.mjs
@@ -268,3 +268,21 @@ test('throws when dynamic import imports does not contain a file extension', (t)
   );
   t.true(error instanceof VariableDynamicImportError);
 });
+
+test('escapes ()', (t) => {
+  const ast = parse('import(`./${foo}/(foo).js`);', {
+    sourceType: 'module'
+  });
+
+  const glob = dynamicImportToGlob(ast.body[0].expression.source);
+  t.is(glob, './*/\\(foo\\).js');
+});
+
+test('escapes []', (t) => {
+  const ast = parse('import(`./${foo}/[foo].js`);', {
+    sourceType: 'module'
+  });
+
+  const glob = dynamicImportToGlob(ast.body[0].expression.source);
+  t.is(glob, './*/\\[foo\\].js');
+});


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `dynamic-import-vars`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

refs https://github.com/vitejs/vite/issues/11824

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

`dynamicImportToGlob(parse('import(`./${foo}/(foo).js`)'))` returned `./*/(foo).js`. But because `(` has a meaning in glob syntax, it meant a different thing. This PR add a escape process to handle special characters like these.
