### PR TITLE
fix: Cannot read properties of undefined (reading 'ssr')

### DIFF
--- a/packages/commonjs/src/resolve-require-sources.js
+++ b/packages/commonjs/src/resolve-require-sources.js
@@ -182,7 +182,7 @@ export function getRequireResolver(extensions, detectCyclesAndConditional, curre
               return { id: wrapId(childId, EXTERNAL_SUFFIX), allowProxy: false };
             }
             parentMeta.requires.push({ resolved, isConditional });
-            await analyzeRequiredModule(parentId, resolved, isConditional, rollupContext.load);
+            await analyzeRequiredModule(parentId, resolved, isConditional, rollupContext.load.bind(rollupContext));
             return { id: childId, allowProxy: true };
           })
         );


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

Fixes this while running vite 4.x.x with 25.0.7 of the commonjs rollup plugin here

```
12:25:55 AM [vite] Internal server error: Cannot read properties of undefined (reading 'ssr')
  Plugin: commonjs
  File: /home/dylanchong/partly-development/partly-2/packages/libs/dbids/build/index.js
      at load (file:///home/dylanchong/partly-development/partly-2/node_modules/.pnpm/vite@4.5.1_@types+node@17.0.45+sass@1.30.0/node_modules/vite/dist/node/chunks/dep-68d1a114.js:44006:78)
      at analyzeRequiredModule (/home/dylanchong/partly-development/partly-2/node_modules/.pnpm/@rollup+plugin-commonjs@25.0.7_rollup@3.20.2/node_modules/@rollup/plugin-commonjs/dist/cjs/index.js:694:13)
      at /home/dylanchong/partly-development/partly-2/node_modules/.pnpm/@rollup+plugin-commonjs@25.0.7_rollup@3.20.2/node_modules/@rollup/plugin-commonjs/dist/cjs/index.js:802:19
      at async Promise.all (index 1)
      at async /home/dylanchong/partly-development/partly-2/node_modules/.pnpm/@rollup+plugin-commonjs@25.0.7_rollup@3.20.2/node_modules/@rollup/plugin-commonjs/dist/cjs/index.js:781:32
      at async rewriteRequireExpressionsAndGetImportBlock (/home/dylanchong/partly-development/partly-2/node_modules/.pnpm/@rollup+plugin-commonjs@25.0.7_rollup@3.20.2/node_modules/@rollup/plugin-commonjs/dist/cjs/index.js:1358:28)
      at async transformCommonjs (/home/dylanchong/partly-development/partly-2/node_modules/.pnpm/@rollup+plugin-commonjs@25.0.7_rollup@3.20.2/node_modules/@rollup/plugin-commonjs/dist/cjs/index.js:1932:23)
      at async Object.transform (file:///home/dylanchong/partly-development/partly-2/node_modules/.pnpm/vite@4.5.1_@types+node@17.0.45+sass@1.30.0/node_modules/vite/dist/node/chunks/dep-68d1a114.js:44352:30)
      at async loadAndTransform (file:///home/dylanchong/partly-development/partly-2/node_modules/.pnpm/vite@4.5.1_@types+node@17.0.45+sass@1.30.0/node_modules/vite/dist/node/chunks/dep-68d1a114.js:55026:29)
```

In vite's code, this is the line that fails due to this being undefined

```javascript
        async load(options) {
            // We may not have added this to our module graph yet, so ensure it exists
            await moduleGraph?.ensureEntryFromUrl(unwrapId(options.id), this.ssr);
```

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `{name}`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
