### PR TITLE
fix(typescript): Ensure rollup 4 compatibility

### DIFF
--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -64,7 +64,7 @@
     }
   },
   "dependencies": {
-    "@rollup/pluginutils": "^5.0.1",
+    "@rollup/pluginutils": "^5.1.0",
     "resolve": "^1.22.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -728,8 +728,8 @@ importers:
   packages/typescript:
     dependencies:
       '@rollup/pluginutils':
-        specifier: ^5.0.1
-        version: 5.0.1(rollup@4.0.0-24)
+        specifier: ^5.1.0
+        version: 5.1.0(rollup@4.0.0-24)
       resolve:
         specifier: ^1.22.1
         version: 1.22.1


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `typescript`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

Existing v3 setup:
1. repo has `rollup@3` installed
2. repo has `@rollup/plugin-typescript@11.1.0` installed which peer depends on `rollup@3`
4. `@rollup/plugin-typescript@11.1.0` depends on `@rollup/pluginutils@^5.0.1`
5. `@rollup/pluginutils@5.0.2` is resolved and saved in the lockfile

Trying to upgrade to v4:
1. upgrade to `rollup@4` and `@rollup/plugin-typescript@11.1.5` which peer depends on `rollup@4`
1. `@rollup/plugin-typescript@11.1.5` still depends on `@rollup/pluginutils@^5.0.1`
1. `@rollup/pluginutils@5.0.2` is not upgraded because it still matches
1. `@rollup/pluginutils@5.0.2` doesn't peer depend on `rollup@4`
1. upgrade fails

This PR bumps the `pluginutils` dependency to `^5.1.0` which is the earliest version that peer depends on `rollup@4`. 

There are a bunch more errors like this throughout the whole repo, but I'm only fixing this one for now. It's unfortunate that it ended up this way and `pnpm install` happily passes. I opened https://github.com/pnpm/pnpm/issues/6893 a while ago to report this behaviour.