### PR TITLE
feat(typescript): add transformers factory.

### DIFF
--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -125,7 +125,7 @@ typescript({
 
 ### `transformers`
 
-Type: `{ [before | after | afterDeclarations]: TransformerFactory[] }`<br>
+Type: `{ [before | after | afterDeclarations]: TransformerFactory[] } | ((program: ts.Program) => ts.CustomTransformers)`<br>
 Default: `undefined`
 
 Allows registration of TypeScript custom transformers at any of the supported stages:
@@ -195,6 +195,48 @@ typescript({
         };
       }
     ]
+  }
+});
+```
+
+Alternatively, the transformers can be created inside a factory.
+
+Supported transformer factories:
+
+- all **built-in** TypeScript custom transformer factories:
+
+  - `import('typescript').TransformerFactory` annotated **TransformerFactory** bellow
+  - `import('typescript').CustomTransformerFactory` annotated **CustomTransformerFactory** bellow
+
+The example above could be written like this:
+
+```js
+typescript({
+  transformers: function (program) {
+    return {
+      before: [
+        ProgramRequiringTransformerFactory(program),
+        TypeCheckerRequiringTransformerFactory(program.getTypeChecker())
+      ],
+      after: [
+        // You can use normal transformers directly
+        require('custom-transformer-based-on-Context')
+      ],
+      afterDeclarations: [
+        // Or even define in place
+        function fixDeclarationFactory(context) {
+          return function fixDeclaration(source) {
+            function visitor(node) {
+              // Do real work here
+
+              return ts.visitEachChild(node, visitor, context);
+            }
+
+            return ts.visitEachChild(source, visitor, context);
+          };
+        }
+      ]
+    };
   }
 });
 ```

--- a/packages/typescript/src/moduleResolution.ts
+++ b/packages/typescript/src/moduleResolution.ts
@@ -20,7 +20,9 @@ export type Resolver = (
 
 /**
  * Create a helper for resolving modules using Typescript.
- * @param host Typescript host that extends `ModuleResolutionHost`
+ * @param ts custom typescript implementation
+ * @param host Typescript host that extends {@link ModuleResolutionHost}
+ * @param filter
  * with methods for sanitizing filenames and getting compiler options.
  */
 export default function createModuleResolver(

--- a/packages/typescript/src/options/tsconfig.ts
+++ b/packages/typescript/src/options/tsconfig.ts
@@ -45,6 +45,7 @@ function makeForcedCompilerOptions(noForceEmit: boolean) {
 
 /**
  * Finds the path to the tsconfig file relative to the current working directory.
+ * @param ts Custom typescript implementation
  * @param relativePath Relative tsconfig path given by the user.
  * If `false` is passed, then a null path is returned.
  * @returns The absolute path, or null if the file does not exist.
@@ -69,9 +70,8 @@ function getTsConfigPath(ts: typeof typescript, relativePath?: string | false) {
 
 /**
  * Tries to read the tsconfig file at `tsConfigPath`.
+ * @param ts Custom typescript implementation
  * @param tsConfigPath Absolute path to tsconfig JSON file.
- * @param explicitPath If true, the path was set by the plugin user.
- * If false, the path was computed automatically.
  */
 function readTsConfigFile(ts: typeof typescript, tsConfigPath: string) {
   const { config, error } = ts.readConfigFile(tsConfigPath, (path) => readFileSync(path, 'utf8'));
@@ -122,13 +122,14 @@ function setModuleResolutionKind(parsedConfig: ParsedCommandLine): ParsedCommand
   };
 }
 
-const configCache = new Map() as typescript.Map<ExtendedConfigCacheEntry>;
+const configCache = new Map() as typescript.ESMap<string, ExtendedConfigCacheEntry>;
 
 /**
  * Parse the Typescript config to use with the plugin.
  * @param ts Typescript library instance.
  * @param tsconfig Path to the tsconfig file, or `false` to ignore the file.
  * @param compilerOptions Options passed to the plugin directly for Typescript.
+ * @param noForceEmit Whether to respect emit options from {@link tsconfig}
  *
  * @returns Parsed tsconfig.json file with some important properties:
  * - `options`: Parsed compiler options.

--- a/packages/typescript/test/test.js
+++ b/packages/typescript/test/test.js
@@ -1236,6 +1236,119 @@ test('supports custom transformers', async (t) => {
   );
 });
 
+test('supports passing a custom transformers factory', async (t) => {
+  const warnings = [];
+
+  let program = null;
+  let typeChecker = null;
+
+  const bundle = await rollup({
+    input: 'fixtures/transformers/main.ts',
+    plugins: [
+      typescript({
+        tsconfig: 'fixtures/transformers/tsconfig.json',
+        outDir: 'fixtures/transformers/dist',
+        declaration: true,
+        transformers: (p) => {
+          program = p;
+          typeChecker = p.getTypeChecker();
+          return {
+            before: [
+              function removeOneParameterFactory(context) {
+                return function removeOneParameter(source) {
+                  function visitor(node) {
+                    if (ts.isArrowFunction(node)) {
+                      return ts.factory.createArrowFunction(
+                        node.modifiers,
+                        node.typeParameters,
+                        [node.parameters[0]],
+                        node.type,
+                        node.equalsGreaterThanToken,
+                        node.body
+                      );
+                    }
+
+                    return ts.visitEachChild(node, visitor, context);
+                  }
+
+                  return ts.visitEachChild(source, visitor, context);
+                };
+              }
+            ],
+            after: [
+              // Enforce a constant numeric output
+              function enforceConstantReturnFactory(context) {
+                return function enforceConstantReturn(source) {
+                  function visitor(node) {
+                    if (ts.isReturnStatement(node)) {
+                      return ts.factory.createReturnStatement(ts.factory.createNumericLiteral('1'));
+                    }
+
+                    return ts.visitEachChild(node, visitor, context);
+                  }
+
+                  return ts.visitEachChild(source, visitor, context);
+                };
+              }
+            ],
+            afterDeclarations: [
+              // Change the return type to numeric
+              function fixDeclarationFactory(context) {
+                return function fixDeclaration(source) {
+                  function visitor(node) {
+                    if (ts.isFunctionTypeNode(node)) {
+                      return ts.factory.createFunctionTypeNode(
+                        node.typeParameters,
+                        [node.parameters[0]],
+                        ts.factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword)
+                      );
+                    }
+
+                    return ts.visitEachChild(node, visitor, context);
+                  }
+
+                  return ts.visitEachChild(source, visitor, context);
+                };
+              }
+            ]
+          };
+        }
+      })
+    ],
+    onwarn(warning) {
+      warnings.push(warning);
+    }
+  });
+
+  const output = await getCode(bundle, { format: 'esm', dir: 'fixtures/transformers' }, true);
+
+  t.is(warnings.length, 0);
+  t.deepEqual(
+    output.map((out) => out.fileName),
+    ['main.js', 'dist/main.d.ts']
+  );
+
+  // Expect the function to have one less arguments from before transformer and return 1 from after transformer
+  t.true(output[0].code.includes('var HashFn = function (val) { return 1; };'), output[0].code);
+
+  // Expect the definition file to reflect the resulting function type after transformer modifications
+  t.true(
+    output[1].source.includes('export declare const HashFn: (val: string) => number;'),
+    output[1].source
+  );
+
+  // Expect a Program to have been forwarded for transformers with custom factories requesting one
+  t.deepEqual(program && program.emit && typeof program.emit === 'function', true);
+
+  // Expect a TypeChecker to have been forwarded for transformers with custom factories requesting one
+  t.deepEqual(
+    typeChecker &&
+      typeChecker.getTypeAtLocation &&
+      typeof typeChecker.getTypeAtLocation === 'function',
+    true
+  );
+});
+
 // This test randomly fails with a segfault directly at the first "await waitForWatcherEvent" before any event occurred.
 // Skipping it until we can figure out what the cause is.
 test.serial.skip('picks up on newly included typescript files in watch mode', async (t) => {

--- a/packages/typescript/types/index.d.ts
+++ b/packages/typescript/types/index.d.ts
@@ -75,7 +75,7 @@ export interface RollupTypescriptPluginOptions {
   /**
    * TypeScript custom transformers
    */
-  transformers?: CustomTransformerFactories;
+  transformers?: CustomTransformerFactories | ((program: Program) => CustomTransformers);
   /**
    * When set to false, force non-cached files to always be emitted in the output directory.output
    * If not set, will default to true with a warning.


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary 

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: typescript

This PR contains:

- [ ] bugfix
- [x] feature
- [x] refactor
- [x] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

resolves #1667 

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

This allows creating custom transformers in the typescript plugin together ahead-of-time in a factory function. This allows for shorter rollup configs in certain cases and enables using similar factory-style transformers like the angular compiler API.

This also cleans up a few places minor internals in the typescript plugin (missing parameter descriptions, deprecated APIs, generic identifiers)