### PR TITLE
fix(esm-shim): missing exports in types

### DIFF
--- a/packages/esm-shim/types/index.d.ts
+++ b/packages/esm-shim/types/index.d.ts
@@ -1,4 +1,9 @@
-import type { Plugin } from 'rollup';
+import type { Plugin, SourceMapInput } from 'rollup';
+
+interface Output {
+  code: string;
+  map?: SourceMapInput;
+}
 
 /**
  * A Rollup plugin to replace cjs syntax for esm output bundles.
@@ -6,3 +11,4 @@ import type { Plugin } from 'rollup';
  * @returns Plugin instance.
  */
 export default function commonjsShim(): Plugin;
+export function provideCJSSyntax(code: string): Output | null;


### PR DESCRIPTION
## Rollup Plugin Name: `esm-shim`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

There's a `provideCJSSyntax` method exported from es-shim plugin but it's not typed, adding the method type to esm-shim plugin's type file