### PR TITLE
feat(node-resolve): allow preferBuiltins to be a function

### DIFF
--- a/packages/node-resolve/README.md
+++ b/packages/node-resolve/README.md
@@ -133,10 +133,18 @@ Specifies the properties to scan within a `package.json`, used to determine the 
 
 ### `preferBuiltins`
 
-Type: `Boolean`<br>
+Type: `Boolean | (module: string) => boolean`<br>
 Default: `true` (with warnings if a builtin module is used over a local version. Set to `true` to disable warning.)
 
 If `true`, the plugin will prefer built-in modules (e.g. `fs`, `path`). If `false`, the plugin will look for locally installed modules of the same name.
+
+Alternatively, you may pass in a function that returns a boolean to confirm whether the plugin should prefer built-in modules. e.g.
+
+```js
+preferBuiltins: (module) => module !== 'punycode';
+```
+
+will not treat `punycode` as a built-in module
 
 ### `modulesOnly`
 

--- a/packages/node-resolve/test/fixtures/prefer-builtin-local-and-builtin.js
+++ b/packages/node-resolve/test/fixtures/prefer-builtin-local-and-builtin.js
@@ -1,0 +1,4 @@
+import { sep } from 'path';
+import events from 'events';
+
+export default { sep, events };

--- a/packages/node-resolve/types/index.d.ts
+++ b/packages/node-resolve/types/index.d.ts
@@ -79,9 +79,11 @@ export interface RollupNodeResolveOptions {
   /**
    * If `true`, the plugin will prefer built-in modules (e.g. `fs`, `path`). If `false`,
    * the plugin will look for locally installed modules of the same name.
+   *
+   * If a function is provided, it will be called to determine whether to prefer built-ins.
    * @default true
    */
-  preferBuiltins?: boolean;
+  preferBuiltins?: boolean | ((module: string) => boolean);
 
   /**
    * An `Array` which instructs the plugin to limit module resolution to those whose


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `@rollup/plugin-node-resolve`

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers: resolves #1655

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

I think #1665 proposes a nice feature that gives `preferBuiltins` a more fine-grained control, so I'm trying to resolve this a little inactive issue.

This PR only makes `node-resolve` accept a function parameter to `preferBuiltins` to introduce as little as possible without changing the existing API.

#1665 also proposes that it should match the behavior of the `external` rollup configuration. But I think in most cases, we only need to mark some modules as non-builtins, e.g., deprecated modules like `punycode`. And this is somehow contrary to the behavior of the `external`.

Is accepting a function enough or should we add some extra configs? I'm willing to contribute if we need to make more changes.