### PR TITLE
fix(replace): add missing sourceMap documentation

### DIFF
--- a/packages/replace/README.md
+++ b/packages/replace/README.md
@@ -154,6 +154,19 @@ Default: `null`
 
 A [picomatch pattern](https://github.com/micromatch/picomatch), or array of patterns, which specifies the files in the build the plugin should operate on. By default all files are targeted.
 
+### `sourceMap` or `sourcemap`
+
+Type: `Boolean`<br>
+Default: `false`
+
+Enables generating sourcemaps for the bundled code. For example, where the plugin is called as follows:
+
+```js
+replace({
+  sourcemap: true
+});
+```
+
 ### `values`
 
 Type: `{ [key: String]: Replacement }`, where `Replacement` is either a string or a `function` that returns a string.
@@ -176,19 +189,6 @@ replace({
   values: {
     changed: 'replaced'
   }
-});
-```
-
-### `sourceMap` or `sourcemap`
-
-Type: `Boolean`<br>
-Default: `false`
-
-Enables generating sourcemaps for the bundled code. For example, where the plugin is called as follows:
-
-```js
-replace({
-  sourcemap: true
 });
 ```
 

--- a/packages/replace/README.md
+++ b/packages/replace/README.md
@@ -179,6 +179,19 @@ replace({
 });
 ```
 
+### `sourceMap` or `sourcemap`
+
+Type: `Boolean`<br>
+Default: `false`
+
+Enables generating sourcemaps for the bundled code. For example, where the plugin is called as follows:
+
+```js
+replace({
+  sourcemap: true
+});
+```
+
 ## Word Boundaries
 
 By default, values will only match if they are surrounded by _word boundaries_.


### PR DESCRIPTION
## Rollup Plugin Name: `@rollup/plugin-replace`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [X] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [X] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [X] no

List any relevant issue numbers:

resolves #1697 

### Description

Documentation missing for `sourceMap` inclusion, fixed by adding the option as documented in #1697 
