### PR TITLE
chore(repo): fix incorrect import path in virtual plugin

### DIFF
--- a/packages/virtual/src/index.ts
+++ b/packages/virtual/src/index.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 
 import type { Plugin } from 'rollup';
 
-import type { RollupVirtualOptions } from '../';
+import type { RollupVirtualOptions } from '../types';
 
 const PREFIX = `\0virtual:`;
 


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `virtual`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (covered by existing tests)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

Might fix builds for PR #1578, so it probably could be accepted too then

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

The "virtual" plugin package currently [imports its own types from `../`](https://github.com/rollup/plugins/blob/9e7f576f33e26d65e9f2221d248a2e000923e03f/packages/virtual/src/index.ts#L5), even though its types are actually placed inside `../types`. Every other plugin appears to correctly import from `../types` too (see e.g. [alias](https://github.com/rollup/plugins/blob/9e7f576f33e26d65e9f2221d248a2e000923e03f/packages/alias/src/index.ts#L5), [auto-install](https://github.com/rollup/plugins/blob/9e7f576f33e26d65e9f2221d248a2e000923e03f/packages/auto-install/src/index.ts#L9), ...).
I stumbled across this while attempting to build the code of PR #1578 (which i need a fix for too) on my local machine, which errored due to the incorrect import. I noticed the current state is building solely because the virtual plugin lists its type definitions file in its [`package.json` via the `types` property](https://github.com/rollup/plugins/blob/9e7f576f33e26d65e9f2221d248a2e000923e03f/packages/virtual/package.json#L69), which miraculously lets `tsc` accept the faulty import (even though it shouldn't, in my opinion). My guess is it just works somehow because `../` points to the folder where the `package.json` lives in, which then references the types file 🤷‍♂️. Now, because in the PR #1578 the `types` property [is gone](https://github.com/rollup/plugins/commit/1b5ab9316c77c16c02b1b558ef0d7e990a71b272#diff-80feda48e3887b5e7f39974479e9c8220152072cd3ebb2898e6667b24fe09885L71), we get an error there.
I previously [opened a PR](https://github.com/Geylnu/rollup-plugins/pull/1) to fix the branch of the original PR, but @Geylnu did not respond yet. So why did i open this PR then? Because i think this import path is incorrect and should be fixed anyway, no matter if the other PR will at some point be accepted (or maybe never might be).