### PR TITLE
fix(node-resolve): Add exception to allow fallbacks when resolving exports fail.

### DIFF
--- a/packages/node-resolve/src/index.js
+++ b/packages/node-resolve/src/index.js
@@ -58,6 +58,7 @@ export function nodeResolve(opts = {}) {
   const isPreferBuiltinsSet = options.preferBuiltins === true || options.preferBuiltins === false;
   const preferBuiltins = isPreferBuiltinsSet ? options.preferBuiltins : true;
   const rootDir = resolve(options.rootDir || process.cwd());
+  const expectExportsError = options.expectExportsError ?? false;
   let { dedupe } = options;
   let rollupOptions;
 
@@ -187,7 +188,8 @@ export function nodeResolve(opts = {}) {
       modulePaths,
       rootDir,
       ignoreSideEffectsForRoot,
-      allowExportsFolderMapping: options.allowExportsFolderMapping
+      allowExportsFolderMapping: options.allowExportsFolderMapping,
+      expectExportsError
     });
 
     const importeeIsBuiltin = isBuiltinModule(importee);

--- a/packages/node-resolve/src/package/resolvePackageExports.ts
+++ b/packages/node-resolve/src/package/resolvePackageExports.ts
@@ -11,7 +11,7 @@ import resolvePackageImportsExports from './resolvePackageImportsExports';
 /**
  * Implementation of PACKAGE_EXPORTS_RESOLVE
  */
-async function resolvePackageExports(context: any, subpath: string, exports: any) {
+async function resolvePackageExports(context: any, subpath: string, exports: any, expectError?: boolean) {
   // If exports is an Object with both a key starting with "." and a key not starting with "."
   if (isMixedExports(exports)) {
     // throw an Invalid Package Configuration error.
@@ -62,6 +62,11 @@ async function resolvePackageExports(context: any, subpath: string, exports: any
     if (resolvedMatch) {
       return resolvedMatch;
     }
+  }
+
+  if (expectError) {
+    console.log(`Could not find valid exports for ${context?.importSpecifier}, falling back`);
+    return;
   }
 
   // Throw a Package Path Not Exported error.

--- a/packages/node-resolve/src/resolveImportSpecifiers.js
+++ b/packages/node-resolve/src/resolveImportSpecifiers.js
@@ -116,7 +116,8 @@ async function resolveWithExportMap({
   modulePaths,
   rootDir,
   ignoreSideEffectsForRoot,
-  allowExportsFolderMapping
+  allowExportsFolderMapping,
+  expectExportsError
 }) {
   if (importSpecifier.startsWith('#')) {
     // this is a package internal import, resolve using package imports field
@@ -208,16 +209,18 @@ async function resolveWithExportMap({
         allowExportsFolderMapping,
         conditions: exportConditions
       };
-      const resolvedPackageExport = await resolvePackageExports(context, subpath, pkgJson.exports);
-      const location = fileURLToPath(resolvedPackageExport);
-      if (location) {
-        return {
-          location: preserveSymlinks ? location : await resolveSymlink(location),
-          hasModuleSideEffects,
-          hasPackageEntry,
-          packageBrowserField,
-          packageInfo
-        };
+      const resolvedPackageExport = await resolvePackageExports(context, subpath, pkgJson.exports, expectExportsError);
+      if (resolvedPackageExport) {
+        const location = fileURLToPath(resolvedPackageExport);
+        if (location) {
+          return {
+            location: preserveSymlinks ? location : await resolveSymlink(location),
+            hasModuleSideEffects,
+            hasPackageEntry,
+            packageBrowserField,
+            packageInfo
+          };
+        }
       }
     }
   }
@@ -287,7 +290,8 @@ export default async function resolveImportSpecifiers({
   modulePaths,
   rootDir,
   ignoreSideEffectsForRoot,
-  allowExportsFolderMapping
+  allowExportsFolderMapping,
+  expectExportsError
 }) {
   try {
     const exportMapRes = await resolveWithExportMap({
@@ -304,7 +308,8 @@ export default async function resolveImportSpecifiers({
       modulePaths,
       rootDir,
       ignoreSideEffectsForRoot,
-      allowExportsFolderMapping
+      allowExportsFolderMapping,
+      expectExportsError
     });
     if (exportMapRes) return exportMapRes;
   } catch (error) {


### PR DESCRIPTION
Allow exceptions to allow fallbacks for "exports" defined dependencies to allow them bundled.

Should address the following error

```
(!) [plugin node-resolve] Could not resolve import "ffjavascript" in node_modules\circomlibjs\src\eddsa.js using exports defined in node_modules\ffjavascript\package.json.
(!) [plugin node-resolve] Could not resolve import "ffjavascript" in node_modules\circomlibjs\src\poseidon_opt.js using exports defined in node_modules\ffjavascript\package.json.
(!) [plugin node-resolve] Could not resolve import "ffjavascript" in node_modules\circomlibjs\src\mimc7.js using exports defined in node_modules\ffjavascript\package.json.
(!) [plugin node-resolve] Could not resolve import "ffjavascript" in node_modules\circomlibjs\src\babyjub.js using exports defined in node_modules\ffjavascript\package.json.
(!) [plugin node-resolve] Could not resolve import "ffjavascript" in node_modules\circomlibjs\src\evmasm.js using exports defined in node_modules\ffjavascript\package.json.
(!) [plugin node-resolve] Could not resolve import "ffjavascript" in node_modules\circomlibjs\src\mimcsponge.js using exports defined in node_modules\ffjavascript\package.json.
(!) [plugin node-resolve] Could not resolve import "ffjavascript" in node_modules\circomlibjs\src\poseidon_wasm.js using exports defined in node_modules\ffjavascript\package.json.
(!) [plugin node-resolve] Could not resolve import "ffjavascript" in node_modules\circomlibjs\src\pedersen_hash.js using exports defined in node_modules\ffjavascript\package.json.
(!) [plugin node-resolve] Could not resolve import "ffjavascript" in node_modules\circomlibjs\src\poseidon_gencontract.js using exports defined in node_modules\ffjavascript\package.json.
(!) [plugin node-resolve] Could not resolve import "ffjavascript" in node_modules\circomlibjs\src\smt.js using exports defined in node_modules\ffjavascript\package.json.
(!) [plugin node-resolve] Could not resolve import "ffjavascript" in node_modules\circomlibjs\src\poseidon_reference.js using exports defined in node_modules\ffjavascript\package.json.
(!) [plugin node-resolve] Could not resolve import "ffjavascript" in node_modules\circomlibjs\src\smt_hashes_poseidon.js using exports defined in node_modules\ffjavascript\package.json.
```