### PR TITLE
fix(html): template function first arg is always provided

### DIFF
--- a/packages/html/types/index.d.ts
+++ b/packages/html/types/index.d.ts
@@ -15,7 +15,7 @@ export interface RollupHtmlOptions {
   fileName?: string;
   meta?: Record<string, any>[];
   publicPath?: string;
-  template?: (templateoptions?: RollupHtmlTemplateOptions) => string;
+  template?: (templateoptions: RollupHtmlTemplateOptions) => string;
 }
 
 export function makeHtmlAttributes(attributes: Record<string, string>): string;


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `html`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

Types incorrectly indicate that the `template()` function can sometimes be called without the `RollupHtmlTemplateOptions` argument. This yields to errors in IDE:

![Capture d’écran 2024-05-15 à 11 29 15](https://github.com/rollup/plugins/assets/813661/d4598dea-e3f3-406a-a23d-99991549c09d)

The workaround yields to poor DX:

![Capture d’écran 2024-05-15 à 11 29 35](https://github.com/rollup/plugins/assets/813661/60e8f129-f9a6-4e97-a0ef-50ae9f8af539)

There should not be any error when destructuring.