### PR TITLE
fix(typescript)!: correctly resolve filenames of declaration files for `output.file`

### DIFF
--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -178,20 +178,8 @@ export default function typescript(options: RollupTypescriptOptions = {}): Plugi
         if (outputOptions.dir) {
           baseDir = outputOptions.dir;
         } else if (outputOptions.file) {
-          // find common path of output.file and configured declation output
-          const outputDir = path.dirname(outputOptions.file);
-          const configured = path.resolve(
-            parsedOptions.options.declarationDir ||
-              parsedOptions.options.outDir ||
-              tsconfig ||
-              process.cwd()
-          );
-          const backwards = path
-            .relative(outputDir, configured)
-            .split(path.sep)
-            .filter((v) => v === '..')
-            .join(path.sep);
-          baseDir = path.normalize(`${outputDir}/${backwards}`);
+          // the bundle output directory used by rollup when outputOptions.file is used instead of outputOptions.dir
+          baseDir = path.dirname(outputOptions.file);
         }
         if (!baseDir) return;
 

--- a/packages/typescript/src/options/validate.ts
+++ b/packages/typescript/src/options/validate.ts
@@ -1,4 +1,4 @@
-import { relative } from 'path';
+import { relative, dirname } from 'path';
 
 import type { OutputOptions, PluginContext } from 'rollup';
 
@@ -51,14 +51,24 @@ export function validatePaths(
     );
   }
 
+  let outputDir: string | undefined = outputOptions.dir;
+  if (outputOptions.file) {
+    outputDir = dirname(outputOptions.file);
+  }
   for (const dirProperty of DIRECTORY_PROPS) {
-    if (compilerOptions[dirProperty] && outputOptions.dir) {
+    if (compilerOptions[dirProperty] && outputDir) {
       // Checks if the given path lies within Rollup output dir
-      const fromRollupDirToTs = relative(outputOptions.dir, compilerOptions[dirProperty]!);
+      const fromRollupDirToTs = relative(outputDir, compilerOptions[dirProperty]!);
       if (fromRollupDirToTs.startsWith('..')) {
-        context.error(
-          `@rollup/plugin-typescript: Path of Typescript compiler option '${dirProperty}' must be located inside Rollup 'dir' option.`
-        );
+        if (outputOptions.dir) {
+          context.error(
+            `@rollup/plugin-typescript: Path of Typescript compiler option '${dirProperty}' must be located inside Rollup 'dir' option.`
+          );
+        } else {
+          context.error(
+            `@rollup/plugin-typescript: Path of Typescript compiler option '${dirProperty}' must be located inside the same directory as the Rollup 'file' option.`
+          );
+        }
       }
     }
   }

--- a/packages/typescript/test/test.js
+++ b/packages/typescript/test/test.js
@@ -117,10 +117,15 @@ test.serial(
     });
 
     // this should throw an error just like the equivalent setup using output.dir above
-    await t.throwsAsync(() =>
+    const wrongDirError = await t.throwsAsync(() =>
       getCode(bundle, { format: 'es', file: 'fixtures/basic/dist/index.js' }, true)
     );
-    // TODO add check for specific error message
+    t.true(
+      wrongDirError.message.includes(
+        `Path of Typescript compiler option 'declarationDir' must be located inside the same directory as the Rollup 'file' option`
+      ),
+      `Unexpected error message: ${wrongDirError.message}`
+    );
   }
 );
 

--- a/packages/typescript/test/test.js
+++ b/packages/typescript/test/test.js
@@ -101,6 +101,29 @@ test.serial('ensures declarationDir is located in Rollup output dir', async (t) 
   );
 });
 
+test.serial(
+  'ensures declarationDir is located in Rollup output directory when output.file is used',
+  async (t) => {
+    const bundle = await rollup({
+      input: 'fixtures/basic/main.ts',
+      plugins: [
+        typescript({
+          tsconfig: 'fixtures/basic/tsconfig.json',
+          declarationDir: 'fixtures/basic/other/',
+          declaration: true
+        })
+      ],
+      onwarn
+    });
+
+    // this should throw an error just like the equivalent setup using output.dir above
+    await t.throwsAsync(() =>
+      getCode(bundle, { format: 'es', file: 'fixtures/basic/dist/index.js' }, true)
+    );
+    // TODO add check for specific error message
+  }
+);
+
 test.serial('ensures multiple outputs can be built', async (t) => {
   // In a rollup.config.js we would pass an array
   // The rollup method that's exported as a library won't do that so we must make two calls


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `@rollup/plugin-typescript`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

Currently, when `output.file` is specified instead of `output.dir`, the filename for emitting declaration files with `this.emitFile` is resolved incorrectly. This means that given a `declarationDir` that is outside of the bundle output directory (which is `output.dir || dirname(output.file!)`), the declarations will still be generated inside the bundle, albeit in a location not actually matching `declarationDir` that does not respect the absolute file path generated by typescript. 

Whereas when using `output.dir`, `declarationDir` is actually validated and filenames for declarations are resolved correctly.

For example, with `output.file = 'some-path/index.js'` and `declarationDir = 'types'`, the declaration files will be generated at `some-path/types/index.d.ts`, instead of `types/index.d.ts` which is the correct location (but invalid as it would be output the bundle directory). When `output.dir = 'some-path'` is used instead, validation fails as expected.

This can be fixed by just using `dirname(output.file)` in place of `output.dir` when `output.file` is specified, and including a validation check that `declarationDir` is valid when using `output.file`.