### PR TITLE
Allow for noHeader option

### DIFF
--- a/packages/commonjs/CHANGELOG.md
+++ b/packages/commonjs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @rollup/plugin-commonjs ChangeLog
 
+## v26.0.1
+
+_2024-06-05_
+
+### Bugfixes
+
+- fix: correct import of glob (04a15b5)
+
 ## v26.0.0
 
 _2024-06-05_

--- a/packages/commonjs/package.json
+++ b/packages/commonjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rollup/plugin-commonjs",
-  "version": "26.0.0",
+  "version": "26.0.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/dsv/src/index.js
+++ b/packages/dsv/src/index.js
@@ -1,10 +1,10 @@
 import { extname } from 'path';
 
-import { csvParse, tsvParse } from 'd3-dsv';
+import { csvParse, csvParseRows, tsvParse, tsvParseRows } from 'd3-dsv';
 import toSource from 'tosource';
 import { createFilter } from '@rollup/pluginutils';
 
-const parsers = { '.csv': csvParse, '.tsv': tsvParse };
+const parsers = { '.csv': [csvParse, csvParseRows], '.tsv': [tsvParse, tsvParseRows] };
 
 export default function dsv(options = {}) {
   const filter = createFilter(options.include, options.exclude);
@@ -18,7 +18,7 @@ export default function dsv(options = {}) {
       const ext = extname(id);
       if (!(ext in parsers)) return null;
 
-      let rows = parsers[ext](code);
+      let rows = parsers[ext][options.noHeader ? 1 : 0](code);
 
       if (options.processRow) {
         rows = rows.map((row) => options.processRow(row, id) || row);


### PR DESCRIPTION
## Rollup Plugin Name: `dsv
`

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no (will write if feature would be accepted)

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
-

### Description

This feature allows to configure including csv/tsv files without the first row being used as the header line