### PR TITLE
chore(node-resolve): remove is-builtin-module

### DIFF
--- a/packages/node-resolve/package.json
+++ b/packages/node-resolve/package.json
@@ -64,7 +64,6 @@
     "@rollup/pluginutils": "^5.0.1",
     "@types/resolve": "1.20.2",
     "deepmerge": "^4.2.2",
-    "is-builtin-module": "^3.2.1",
     "is-module": "^1.0.0",
     "resolve": "^1.22.1"
   },

--- a/packages/node-resolve/src/index.js
+++ b/packages/node-resolve/src/index.js
@@ -1,7 +1,8 @@
 /* eslint-disable no-param-reassign, no-shadow, no-undefined */
 import { dirname, normalize, resolve, sep } from 'path';
 
-import isBuiltinModule from 'is-builtin-module';
+import { builtinModules } from 'module';
+
 import deepMerge from 'deepmerge';
 import isModule from 'is-module';
 
@@ -42,6 +43,8 @@ const defaults = {
   // TODO: set to false in next major release or remove
   allowExportsFolderMapping: true
 };
+const nodeImportPrefix = /^node:/;
+
 export const DEFAULTS = deepFreeze(deepMerge({}, defaults));
 
 export function nodeResolve(opts = {}) {
@@ -190,7 +193,7 @@ export function nodeResolve(opts = {}) {
       allowExportsFolderMapping: options.allowExportsFolderMapping
     });
 
-    const importeeIsBuiltin = isBuiltinModule(importee);
+    const importeeIsBuiltin = builtinModules.includes(importee.replace(nodeImportPrefix, ''));
     const resolved =
       importeeIsBuiltin && preferBuiltins
         ? {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -521,9 +521,6 @@ importers:
       deepmerge:
         specifier: ^4.2.2
         version: 4.2.2
-      is-builtin-module:
-        specifier: ^3.2.1
-        version: 3.2.1
       is-module:
         specifier: ^1.0.0
         version: 1.0.0
@@ -3566,6 +3563,7 @@ packages:
   /builtin-modules@3.3.0:
     resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
     engines: {node: '>=6'}
+    dev: true
 
   /cacheable-lookup@5.0.4:
     resolution: {integrity: sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==}
@@ -5405,13 +5403,6 @@ packages:
     dependencies:
       builtin-modules: 3.3.0
     dev: true
-
-  /is-builtin-module@3.2.1:
-    resolution: {integrity: sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==}
-    engines: {node: '>=6'}
-    dependencies:
-      builtin-modules: 3.3.0
-    dev: false
 
   /is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}


### PR DESCRIPTION
Node has shipped `builtinModules` for some time now, so we no longer need a third party package to do this.

Once the `engines` constraint is bumped in the `package.json`, we can also move to using the built-in `isBuiltin` function (available since 16.x).

## Rollup Plugin Name: `node-resolve`

This PR contains:

- [ ] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no (existing tests should cover it)

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no