### PR TITLE
chore(repo): use shell-emulator for better cross-platform compatibility

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,7 @@
 registry=https://registry.npmjs.org/
 
 enable-pre-post-scripts = true
+shell-emulator = true
 link-workspace-packages = false
 shamefully-hoist = true
 shared-workspace-shrinkwrap = true

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "ava": "^4.3.3",
     "chalk": "^4.1.0",
     "codecov-lite": "2.0.0",
-    "del-cli": "^5.0.0",
     "eslint-config-rollup": "^3.0.1",
     "esm": "^3.2.25",
     "execa": "^5.1.1",

--- a/packages/alias/package.json
+++ b/packages/alias/package.json
@@ -29,7 +29,7 @@
     "ci:lint": "pnpm build && pnpm lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose",
-    "prebuild": "del-cli dist",
+    "prebuild": "rm -rf dist",
     "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",
@@ -61,7 +61,6 @@
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.0.0",
     "@rollup/plugin-typescript": "^9.0.1",
-    "del-cli": "^5.0.0",
     "rollup": "^4.0.0-24",
     "typescript": "^4.8.3"
   },

--- a/packages/alias/package.json
+++ b/packages/alias/package.json
@@ -30,7 +30,7 @@
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose",
     "prebuild": "del-cli dist",
-    "prepare": "if [ ! -d 'dist' ]; then pnpm build; fi",
+    "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",
     "release": "pnpm --workspace-root package:release $(pwd)",

--- a/packages/auto-install/package.json
+++ b/packages/auto-install/package.json
@@ -29,7 +29,7 @@
     "ci:lint": "pnpm build && pnpm lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose",
-    "prebuild": "del-cli dist",
+    "prebuild": "rm -rf dist",
     "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",

--- a/packages/auto-install/package.json
+++ b/packages/auto-install/package.json
@@ -30,7 +30,7 @@
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose",
     "prebuild": "del-cli dist",
-    "prepare": "if [ ! -d 'dist' ]; then pnpm build; fi",
+    "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",
     "release": "pnpm --workspace-root package:release $(pwd)",

--- a/packages/babel/package.json
+++ b/packages/babel/package.json
@@ -29,7 +29,7 @@
     "ci:lint": "pnpm build && pnpm lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose",
-    "prebuild": "del-cli dist",
+    "prebuild": "rm -rf dist",
     "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",

--- a/packages/babel/package.json
+++ b/packages/babel/package.json
@@ -30,7 +30,7 @@
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose",
     "prebuild": "del-cli dist",
-    "prepare": "if [ ! -d 'dist' ]; then pnpm build; fi",
+    "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",
     "release": "pnpm --workspace-root package:release $(pwd)",

--- a/packages/buble/package.json
+++ b/packages/buble/package.json
@@ -29,7 +29,7 @@
     "ci:lint": "pnpm build && pnpm lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose",
-    "prebuild": "del-cli dist",
+    "prebuild": "rm -rf dist",
     "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",
@@ -67,7 +67,6 @@
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^9.0.1",
-    "del-cli": "^5.0.0",
     "rollup": "^4.0.0-24",
     "source-map": "^0.7.4",
     "typescript": "^4.8.3"

--- a/packages/buble/package.json
+++ b/packages/buble/package.json
@@ -30,7 +30,7 @@
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose",
     "prebuild": "del-cli dist",
-    "prepare": "if [ ! -d 'dist' ]; then pnpm build; fi",
+    "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",
     "release": "pnpm --workspace-root package:release $(pwd)",

--- a/packages/commonjs/package.json
+++ b/packages/commonjs/package.json
@@ -30,7 +30,7 @@
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose && pnpm test:ts",
     "prebuild": "del-cli dist",
-    "prepare": "if [ ! -d 'dist' ]; then pnpm build; fi",
+    "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prepublishOnly": "pnpm build",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",

--- a/packages/commonjs/package.json
+++ b/packages/commonjs/package.json
@@ -29,7 +29,7 @@
     "ci:lint": "pnpm build && pnpm lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose && pnpm test:ts",
-    "prebuild": "del-cli dist",
+    "prebuild": "rm -rf dist",
     "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prepublishOnly": "pnpm build",
     "prerelease": "pnpm build",

--- a/packages/data-uri/package.json
+++ b/packages/data-uri/package.json
@@ -30,7 +30,7 @@
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose",
     "prebuild": "del-cli dist",
-    "prepare": "if [ ! -d 'dist' ]; then pnpm build; fi",
+    "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build --sourcemap",
     "release": "pnpm --workspace-root package:release $(pwd)",

--- a/packages/data-uri/package.json
+++ b/packages/data-uri/package.json
@@ -29,7 +29,7 @@
     "ci:lint": "pnpm build && pnpm lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose",
-    "prebuild": "del-cli dist",
+    "prebuild": "rm -rf dist",
     "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build --sourcemap",

--- a/packages/dsv/package.json
+++ b/packages/dsv/package.json
@@ -26,7 +26,7 @@
     "ci:lint": "pnpm build && pnpm lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose",
-    "prebuild": "del-cli dist",
+    "prebuild": "rm -rf dist",
     "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",
@@ -56,7 +56,6 @@
     "tosource": "^2.0.0-alpha.3"
   },
   "devDependencies": {
-    "del-cli": "^5.0.0",
     "rollup": "^4.0.0-24"
   },
   "types": "./types/index.d.ts",

--- a/packages/dsv/package.json
+++ b/packages/dsv/package.json
@@ -27,7 +27,7 @@
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose",
     "prebuild": "del-cli dist",
-    "prepare": "if [ ! -d 'dist' ]; then pnpm build; fi",
+    "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",
     "release": "pnpm --workspace-root package:release $(pwd)",

--- a/packages/dynamic-import-vars/package.json
+++ b/packages/dynamic-import-vars/package.json
@@ -30,7 +30,7 @@
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose",
     "prebuild": "del-cli dist",
-    "prepare": "if [ ! -d 'dist' ]; then pnpm build; fi",
+    "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build --sourcemap",
     "release": "pnpm --workspace-root package:release $(pwd)",

--- a/packages/dynamic-import-vars/package.json
+++ b/packages/dynamic-import-vars/package.json
@@ -29,7 +29,7 @@
     "ci:lint": "pnpm build && pnpm lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose",
-    "prebuild": "del-cli dist",
+    "prebuild": "rm -rf dist",
     "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build --sourcemap",

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -29,7 +29,7 @@
     "ci:lint": "pnpm build && pnpm lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose",
-    "prebuild": "del-cli dist",
+    "prebuild": "rm -rf dist",
     "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -30,7 +30,7 @@
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose",
     "prebuild": "del-cli dist",
-    "prepare": "if [ ! -d 'dist' ]; then pnpm build; fi",
+    "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",
     "release": "pnpm --workspace-root package:release $(pwd)",

--- a/packages/esm-shim/package.json
+++ b/packages/esm-shim/package.json
@@ -29,7 +29,7 @@
     "ci:lint": "pnpm build && pnpm lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose && pnpm test:ts",
-    "prebuild": "del-cli dist",
+    "prebuild": "rm -rf dist",
     "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",

--- a/packages/esm-shim/package.json
+++ b/packages/esm-shim/package.json
@@ -30,7 +30,7 @@
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose && pnpm test:ts",
     "prebuild": "del-cli dist",
-    "prepare": "if [ ! -d 'dist' ]; then pnpm build; fi",
+    "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",
     "release": "pnpm --workspace-root package:release $(pwd)",

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -31,7 +31,7 @@
     "ci:test": "pnpm test -- --verbose && pnpm test:ts",
     "lint:graphql": "prettier --write \"test/fixtures/**/*.graphql\"",
     "prebuild": "del-cli dist && pnpm lint:graphql",
-    "prepare": "if [ ! -d 'dist' ]; then pnpm build; fi",
+    "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",
     "release": "pnpm --workspace-root package:release $(pwd)",

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -30,7 +30,7 @@
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose && pnpm test:ts",
     "lint:graphql": "prettier --write \"test/fixtures/**/*.graphql\"",
-    "prebuild": "del-cli dist && pnpm lint:graphql",
+    "prebuild": "rm -rf dist && pnpm lint:graphql",
     "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -29,7 +29,7 @@
     "ci:lint": "pnpm build && pnpm lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose",
-    "prebuild": "del-cli dist",
+    "prebuild": "rm -rf dist",
     "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -30,7 +30,7 @@
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose",
     "prebuild": "del-cli dist",
-    "prepare": "if [ ! -d 'dist' ]; then pnpm build; fi",
+    "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",
     "release": "pnpm --workspace-root package:release $(pwd)",

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -29,7 +29,7 @@
     "ci:lint": "pnpm build && pnpm lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose",
-    "prebuild": "del-cli dist",
+    "prebuild": "rm -rf dist",
     "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -30,7 +30,7 @@
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose",
     "prebuild": "del-cli dist",
-    "prepare": "if [ ! -d 'dist' ]; then pnpm build; fi",
+    "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",
     "release": "pnpm --workspace-root package:release $(pwd)",

--- a/packages/inject/package.json
+++ b/packages/inject/package.json
@@ -30,7 +30,7 @@
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose && pnpm test:ts",
     "prebuild": "del-cli dist",
-    "prepare": "if [ ! -d 'dist' ]; then pnpm build; fi",
+    "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",
     "release": "pnpm --workspace-root package:release $(pwd)",

--- a/packages/inject/package.json
+++ b/packages/inject/package.json
@@ -29,7 +29,7 @@
     "ci:lint": "pnpm build && pnpm lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose && pnpm test:ts",
-    "prebuild": "del-cli dist",
+    "prebuild": "rm -rf dist",
     "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",
@@ -67,7 +67,6 @@
   },
   "devDependencies": {
     "@rollup/plugin-buble": "^1.0.0",
-    "del-cli": "^5.0.0",
     "locate-character": "^2.0.5",
     "rollup": "^4.0.0-24",
     "source-map": "^0.7.4",

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -29,7 +29,7 @@
     "ci:lint": "pnpm build && pnpm lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose && pnpm test:ts",
-    "prebuild": "del-cli dist",
+    "prebuild": "rm -rf dist",
     "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -30,7 +30,7 @@
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose && pnpm test:ts",
     "prebuild": "del-cli dist",
-    "prepare": "if [ ! -d 'dist' ]; then pnpm build; fi",
+    "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",
     "release": "pnpm --workspace-root package:release $(pwd)",

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -29,7 +29,7 @@
     "ci:lint": "pnpm build && pnpm lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose",
-    "prebuild": "del-cli dist",
+    "prebuild": "rm -rf dist",
     "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@rollup/plugin-buble": "^1.0.0",
-    "del-cli": "^5.0.0",
     "rollup": "^4.0.0-24"
   },
   "types": "./types/index.d.ts",

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -30,7 +30,7 @@
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose",
     "prebuild": "del-cli dist",
-    "prepare": "if [ ! -d 'dist' ]; then pnpm build; fi",
+    "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",
     "release": "pnpm --workspace-root package:release $(pwd)",

--- a/packages/multi-entry/package.json
+++ b/packages/multi-entry/package.json
@@ -29,7 +29,7 @@
     "ci:lint": "pnpm build && pnpm lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose",
-    "prebuild": "del-cli dist",
+    "prebuild": "rm -rf dist",
     "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",

--- a/packages/multi-entry/package.json
+++ b/packages/multi-entry/package.json
@@ -30,7 +30,7 @@
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose",
     "prebuild": "del-cli dist",
-    "prepare": "if [ ! -d 'dist' ]; then pnpm build; fi",
+    "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",
     "release": "pnpm --workspace-root package:release $(pwd)",

--- a/packages/node-resolve/package.json
+++ b/packages/node-resolve/package.json
@@ -29,7 +29,7 @@
     "ci:lint": "pnpm build && pnpm lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose",
-    "prebuild": "del-cli dist",
+    "prebuild": "rm -rf dist",
     "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prepublishOnly": "pnpm build",
     "prerelease": "pnpm build",

--- a/packages/node-resolve/package.json
+++ b/packages/node-resolve/package.json
@@ -30,7 +30,7 @@
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose",
     "prebuild": "del-cli dist",
-    "prepare": "if [ ! -d 'dist' ]; then pnpm build; fi",
+    "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prepublishOnly": "pnpm build",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",

--- a/packages/pluginutils/package.json
+++ b/packages/pluginutils/package.json
@@ -32,7 +32,7 @@
     "ci:lint": "pnpm build && pnpm lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose",
-    "prebuild": "del-cli dist",
+    "prebuild": "rm -rf dist",
     "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build --sourcemap",

--- a/packages/pluginutils/package.json
+++ b/packages/pluginutils/package.json
@@ -33,7 +33,7 @@
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose",
     "prebuild": "del-cli dist",
-    "prepare": "if [ ! -d 'dist' ]; then pnpm build; fi",
+    "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build --sourcemap",
     "release": "pnpm --workspace-root package:release $(pwd)",

--- a/packages/replace/package.json
+++ b/packages/replace/package.json
@@ -30,7 +30,7 @@
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose && pnpm test:ts",
     "prebuild": "del-cli dist",
-    "prepare": "if [ ! -d 'dist' ]; then pnpm build; fi",
+    "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",
     "release": "pnpm --workspace-root package:release $(pwd)",

--- a/packages/replace/package.json
+++ b/packages/replace/package.json
@@ -29,7 +29,7 @@
     "ci:lint": "pnpm build && pnpm lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose && pnpm test:ts",
-    "prebuild": "del-cli dist",
+    "prebuild": "rm -rf dist",
     "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",
@@ -66,7 +66,6 @@
   },
   "devDependencies": {
     "@rollup/plugin-buble": "^1.0.0",
-    "del-cli": "^5.0.0",
     "locate-character": "^2.0.5",
     "rollup": "^4.0.0-24",
     "source-map": "^0.7.4",

--- a/packages/run/package.json
+++ b/packages/run/package.json
@@ -29,7 +29,7 @@
     "ci:lint": "pnpm build && pnpm lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose",
-    "prebuild": "del-cli dist",
+    "prebuild": "rm -rf dist",
     "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",

--- a/packages/run/package.json
+++ b/packages/run/package.json
@@ -30,7 +30,7 @@
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose",
     "prebuild": "del-cli dist",
-    "prepare": "if [ ! -d 'dist' ]; then pnpm build; fi",
+    "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",
     "release": "pnpm --workspace-root package:release $(pwd)",

--- a/packages/strip/package.json
+++ b/packages/strip/package.json
@@ -29,7 +29,7 @@
     "ci:lint": "pnpm lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose",
-    "prepare": "if [ ! -d 'dist' ]; then pnpm build; fi",
+    "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",
     "release": "pnpm --workspace-root package:release $(pwd)",

--- a/packages/sucrase/package.json
+++ b/packages/sucrase/package.json
@@ -31,7 +31,7 @@
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose && pnpm test:ts",
     "prebuild": "del-cli dist",
-    "prepare": "if [ ! -d 'dist' ]; then pnpm build; fi",
+    "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",
     "release": "pnpm --workspace-root package:release $(pwd)",

--- a/packages/sucrase/package.json
+++ b/packages/sucrase/package.json
@@ -30,7 +30,7 @@
     "ci:lint": "pnpm build && pnpm lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose && pnpm test:ts",
-    "prebuild": "del-cli dist",
+    "prebuild": "rm -rf dist",
     "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",

--- a/packages/swc/package.json
+++ b/packages/swc/package.json
@@ -29,7 +29,7 @@
     "ci:lint": "pnpm build && pnpm lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose && pnpm test:ts",
-    "prebuild": "del-cli dist",
+    "prebuild": "rm -rf dist",
     "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",

--- a/packages/swc/package.json
+++ b/packages/swc/package.json
@@ -30,7 +30,7 @@
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose && pnpm test:ts",
     "prebuild": "del-cli dist",
-    "prepare": "if [ ! -d 'dist' ]; then pnpm build; fi",
+    "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",
     "release": "pnpm --workspace-root package:release $(pwd)",

--- a/packages/terser/package.json
+++ b/packages/terser/package.json
@@ -29,7 +29,7 @@
     "ci:lint": "pnpm build && pnpm lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose && pnpm test:ts",
-    "prebuild": "del-cli dist",
+    "prebuild": "rm -rf dist",
     "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",

--- a/packages/terser/package.json
+++ b/packages/terser/package.json
@@ -30,7 +30,7 @@
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose && pnpm test:ts",
     "prebuild": "del-cli dist",
-    "prepare": "if [ ! -d 'dist' ]; then pnpm build; fi",
+    "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",
     "release": "pnpm --workspace-root package:release $(pwd)",

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -29,7 +29,7 @@
     "ci:lint": "pnpm build && pnpm lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose --serial",
-    "prebuild": "del-cli dist",
+    "prebuild": "rm -rf dist",
     "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -30,7 +30,7 @@
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose --serial",
     "prebuild": "del-cli dist",
-    "prepare": "if [ ! -d 'dist' ]; then pnpm build; fi",
+    "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",
     "release": "pnpm --workspace-root package:release $(pwd)",

--- a/packages/url/package.json
+++ b/packages/url/package.json
@@ -29,7 +29,7 @@
     "ci:lint": "pnpm build && pnpm lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose",
-    "prebuild": "del-cli dist",
+    "prebuild": "rm -rf dist",
     "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",

--- a/packages/url/package.json
+++ b/packages/url/package.json
@@ -30,7 +30,7 @@
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose",
     "prebuild": "del-cli dist",
-    "prepare": "if [ ! -d 'dist' ]; then pnpm build; fi",
+    "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",
     "release": "pnpm --workspace-root package:release $(pwd)",

--- a/packages/virtual/package.json
+++ b/packages/virtual/package.json
@@ -29,7 +29,7 @@
     "ci:lint": "pnpm build && pnpm lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose",
-    "prebuild": "del-cli dist",
+    "prebuild": "rm -rf dist",
     "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",

--- a/packages/virtual/package.json
+++ b/packages/virtual/package.json
@@ -30,7 +30,7 @@
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose",
     "prebuild": "del-cli dist",
-    "prepare": "if [ ! -d 'dist' ]; then pnpm build; fi",
+    "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",
     "release": "pnpm --workspace-root package:release $(pwd)",

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -29,7 +29,7 @@
     "ci:lint": "pnpm build && pnpm lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose",
-    "prebuild": "del-cli dist",
+    "prebuild": "rm -rf dist",
     "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",
@@ -67,7 +67,6 @@
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^9.0.1",
-    "del-cli": "^5.0.0",
     "rollup": "^4.0.0-24",
     "source-map": "^0.7.4",
     "typescript": "^4.8.3"

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -30,7 +30,7 @@
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose",
     "prebuild": "del-cli dist",
-    "prepare": "if [ ! -d 'dist' ]; then pnpm build; fi",
+    "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",
     "release": "pnpm --workspace-root package:release $(pwd)",

--- a/packages/yaml/package.json
+++ b/packages/yaml/package.json
@@ -29,7 +29,7 @@
     "ci:lint": "pnpm build && pnpm lint",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose",
-    "prebuild": "del-cli dist",
+    "prebuild": "rm -rf dist",
     "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",
@@ -63,7 +63,6 @@
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.0.0",
-    "del-cli": "^5.0.0",
     "rollup": "^4.0.0-24",
     "source-map-support": "^0.5.21"
   },

--- a/packages/yaml/package.json
+++ b/packages/yaml/package.json
@@ -30,7 +30,7 @@
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "ci:test": "pnpm test -- --verbose",
     "prebuild": "del-cli dist",
-    "prepare": "if [ ! -d 'dist' ]; then pnpm build; fi",
+    "prepare": "[ ! -d 'dist' ] && pnpm build || true",
     "prerelease": "pnpm build",
     "pretest": "pnpm build",
     "release": "pnpm --workspace-root package:release $(pwd)",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,9 +35,6 @@ importers:
       codecov-lite:
         specifier: 2.0.0
         version: 2.0.0
-      del-cli:
-        specifier: ^5.0.0
-        version: 5.0.0
       eslint-config-rollup:
         specifier: ^3.0.1
         version: 3.0.1(typescript@4.8.4)
@@ -83,9 +80,6 @@ importers:
       '@rollup/plugin-typescript':
         specifier: ^9.0.1
         version: 9.0.1(rollup@4.0.0-24)(tslib@2.4.0)(typescript@4.8.4)
-      del-cli:
-        specifier: ^5.0.0
-        version: 5.0.0
       rollup:
         specifier: ^4.0.0-24
         version: 4.0.0-24
@@ -181,9 +175,6 @@ importers:
       '@rollup/plugin-typescript':
         specifier: ^9.0.1
         version: 9.0.1(rollup@4.0.0-24)(tslib@2.4.0)(typescript@4.8.4)
-      del-cli:
-        specifier: ^5.0.0
-        version: 5.0.0
       rollup:
         specifier: ^4.0.0-24
         version: 4.0.0-24
@@ -277,9 +268,6 @@ importers:
         specifier: ^2.0.0-alpha.3
         version: 2.0.0-alpha.3
     devDependencies:
-      del-cli:
-        specifier: ^5.0.0
-        version: 5.0.0
       rollup:
         specifier: ^4.0.0-24
         version: 4.0.0-24
@@ -382,7 +370,7 @@ importers:
         version: 4.0.0-24
       rollup-plugin-postcss:
         specifier: ^4.0.2
-        version: 4.0.2(postcss@8.4.17)(ts-node@10.9.1(@swc/core@1.3.78)(@types/node@14.18.31)(typescript@4.8.4))
+        version: 4.0.2(postcss@8.4.17)(ts-node@10.9.1(@swc/core@1.3.78)(@types/node@14.18.30)(typescript@4.8.4))
       typescript:
         specifier: ^4.8.3
         version: 4.8.4
@@ -418,9 +406,6 @@ importers:
       '@rollup/plugin-buble':
         specifier: ^1.0.0
         version: 1.0.0(rollup@4.0.0-24)
-      del-cli:
-        specifier: ^5.0.0
-        version: 5.0.0
       locate-character:
         specifier: ^2.0.5
         version: 2.0.5
@@ -462,9 +447,6 @@ importers:
       '@rollup/plugin-buble':
         specifier: ^1.0.0
         version: 1.0.0(rollup@4.0.0-24)
-      del-cli:
-        specifier: ^5.0.0
-        version: 5.0.0
       rollup:
         specifier: ^4.0.0-24
         version: 4.0.0-24
@@ -577,9 +559,6 @@ importers:
       '@rollup/plugin-buble':
         specifier: ^1.0.0
         version: 1.0.0(rollup@4.0.0-24)
-      del-cli:
-        specifier: ^5.0.0
-        version: 5.0.0
       locate-character:
         specifier: ^2.0.5
         version: 2.0.5
@@ -771,9 +750,6 @@ importers:
       '@rollup/plugin-typescript':
         specifier: ^9.0.1
         version: 9.0.1(rollup@4.0.0-24)(tslib@2.4.0)(typescript@4.8.4)
-      del-cli:
-        specifier: ^5.0.0
-        version: 5.0.0
       rollup:
         specifier: ^4.0.0-24
         version: 4.0.0-24
@@ -799,9 +775,6 @@ importers:
       '@rollup/plugin-node-resolve':
         specifier: ^15.0.0
         version: 15.0.0(rollup@4.0.0-24)
-      del-cli:
-        specifier: ^5.0.0
-        version: 5.0.0
       rollup:
         specifier: ^4.0.0-24
         version: 4.0.0-24
@@ -2160,17 +2133,9 @@ packages:
     resolution: {integrity: sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==}
     engines: {node: '>=8'}
 
-  camelcase-keys@7.0.2:
-    resolution: {integrity: sha512-Rjs1H+A9R+Ig+4E/9oyB66UC5Mj9Xq3N//vcLf2WzgdTi/3gUu3Z9KoqmlrEG4VuuLK8wJHofxzdQXz/knhiYg==}
-    engines: {node: '>=12'}
-
   camelcase@5.3.1:
     resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
     engines: {node: '>=6'}
-
-  camelcase@6.3.0:
-    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
-    engines: {node: '>=10'}
 
   caniuse-api@3.0.0:
     resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
@@ -2413,10 +2378,6 @@ packages:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
     engines: {node: '>=0.10.0'}
 
-  decamelize@5.0.1:
-    resolution: {integrity: sha512-VfxadyCECXgQlkoEAjeghAr5gY3Hf+IKjKb+X8tGVDtveCjN+USwprd2q3QXBR9T1+x2DG0XZF5/w+7HAtSaXA==}
-    engines: {node: '>=10'}
-
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
@@ -2443,18 +2404,9 @@ packages:
     resolution: {integrity: sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==}
     engines: {node: '>= 0.4'}
 
-  del-cli@5.0.0:
-    resolution: {integrity: sha512-rENFhUaYcjoMODwFhhlON+ogN7DoG+4+GFN+bsA1XeDt4w2OKQnQadFP1thHSAlK9FAtl88qgP66wOV+eFZZiQ==}
-    engines: {node: '>=14.16'}
-    hasBin: true
-
   del@6.1.1:
     resolution: {integrity: sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==}
     engines: {node: '>=10'}
-
-  del@7.0.0:
-    resolution: {integrity: sha512-tQbV/4u5WVB8HMJr08pgw0b6nG4RGt/tj+7Numvq+zqcvUFeMaIWWOUFltiU+6go8BSO2/ogsB4EasDaj0y68Q==}
-    engines: {node: '>=14.16'}
 
   detect-indent@5.0.0:
     resolution: {integrity: sha512-rlpvsxUtM0PQvy9iZe640/IWwWYyBsTApREbA1pHOpmOUIl9MkP/U4z7vTtg4Oaojvqhxt7sdufnT0EzGaR31g==}
@@ -3072,17 +3024,9 @@ packages:
     resolution: {integrity: sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==}
     engines: {node: '>=6'}
 
-  is-path-cwd@3.0.0:
-    resolution: {integrity: sha512-kyiNFFLU0Ampr6SDZitD/DwUo4Zs1nSdnygUBqsu3LooL00Qvb5j+UnvApUn/TTj1J3OuE6BTdQ5rudKmU2ZaA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   is-path-inside@3.0.3:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
     engines: {node: '>=8'}
-
-  is-path-inside@4.0.0:
-    resolution: {integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==}
-    engines: {node: '>=12'}
 
   is-plain-obj@1.1.0:
     resolution: {integrity: sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==}
@@ -3385,10 +3329,6 @@ packages:
   mem@9.0.2:
     resolution: {integrity: sha512-F2t4YIv9XQUBHt6AOJ0y7lSmP1+cY7Fm1DRh9GClTGzKST7UWLMx6ly9WZdLH/G/ppM5RL4MlQfRT71ri9t19A==}
     engines: {node: '>=12.20'}
-
-  meow@10.1.5:
-    resolution: {integrity: sha512-/d+PQ4GKmGvM9Bee/DPa8z3mXs/pkvJE2KEThngVNOqtmljC6K7NMPxtc2JeZYTmpWb9k/TmxjeL18ez3h7vCw==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   meow@8.1.2:
     resolution: {integrity: sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==}
@@ -3975,17 +3915,9 @@ packages:
     resolution: {integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==}
     engines: {node: '>=8'}
 
-  read-pkg-up@8.0.0:
-    resolution: {integrity: sha512-snVCqPczksT0HS2EC+SxUndvSzn6LRCwpfSvLrIfR5BKDQQZMaI6jPRC9dYvYFDRAuFEAnkwww8kBBNE/3VvzQ==}
-    engines: {node: '>=12'}
-
   read-pkg@5.2.0:
     resolution: {integrity: sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==}
     engines: {node: '>=8'}
-
-  read-pkg@6.0.0:
-    resolution: {integrity: sha512-X1Fu3dPuk/8ZLsMhEj5f4wFAF0DWoK7qhGJvgaijocXxBmSToKfbFtqbxMO7bVjNA1dmE5huAzjXj/ey86iw9Q==}
-    engines: {node: '>=12'}
 
   readable-stream@3.6.0:
     resolution: {integrity: sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==}
@@ -3998,10 +3930,6 @@ packages:
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
-
-  redent@4.0.0:
-    resolution: {integrity: sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag==}
-    engines: {node: '>=12'}
 
   regenerate-unicode-properties@10.1.0:
     resolution: {integrity: sha512-d1VudCLoIGitcU/hEg2QqvyGZQmdC0Lf8BqdOMXGFSvJP4bNV1+XqbPQeHHLD51Jh4QJJ225dlIFvY4Ly6MXmQ==}
@@ -4323,10 +4251,6 @@ packages:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
 
-  strip-indent@4.0.0:
-    resolution: {integrity: sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==}
-    engines: {node: '>=12'}
-
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -4419,10 +4343,6 @@ packages:
     resolution: {integrity: sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==}
     engines: {node: '>=8'}
 
-  trim-newlines@4.0.2:
-    resolution: {integrity: sha512-GJtWyq9InR/2HRiLZgpIKv+ufIKrVrvjQWEj7PxAXNc5dwbNJkqhAUoAGgzRmULAnoOM5EIpveYd3J2VeSAIew==}
-    engines: {node: '>=12'}
-
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
@@ -4490,10 +4410,6 @@ packages:
   type-fest@0.8.1:
     resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
     engines: {node: '>=8'}
-
-  type-fest@1.4.0:
-    resolution: {integrity: sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==}
-    engines: {node: '>=10'}
 
   type@1.2.0:
     resolution: {integrity: sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==}
@@ -6245,16 +6161,7 @@ snapshots:
       map-obj: 4.3.0
       quick-lru: 4.0.1
 
-  camelcase-keys@7.0.2:
-    dependencies:
-      camelcase: 6.3.0
-      map-obj: 4.3.0
-      quick-lru: 5.1.1
-      type-fest: 1.4.0
-
   camelcase@5.3.1: {}
-
-  camelcase@6.3.0: {}
 
   caniuse-api@3.0.0:
     dependencies:
@@ -6532,8 +6439,6 @@ snapshots:
 
   decamelize@1.2.0: {}
 
-  decamelize@5.0.1: {}
-
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
@@ -6555,11 +6460,6 @@ snapshots:
       has-property-descriptors: 1.0.0
       object-keys: 1.1.1
 
-  del-cli@5.0.0:
-    dependencies:
-      del: 7.0.0
-      meow: 10.1.5
-
   del@6.1.1:
     dependencies:
       globby: 11.1.0
@@ -6570,17 +6470,6 @@ snapshots:
       p-map: 4.0.0
       rimraf: 3.0.2
       slash: 3.0.0
-
-  del@7.0.0:
-    dependencies:
-      globby: 13.1.2
-      graceful-fs: 4.2.10
-      is-glob: 4.0.3
-      is-path-cwd: 3.0.0
-      is-path-inside: 4.0.0
-      p-map: 5.5.0
-      rimraf: 3.0.2
-      slash: 4.0.0
 
   detect-indent@5.0.0: {}
 
@@ -7287,11 +7176,7 @@ snapshots:
 
   is-path-cwd@2.2.0: {}
 
-  is-path-cwd@3.0.0: {}
-
   is-path-inside@3.0.3: {}
-
-  is-path-inside@4.0.0: {}
 
   is-plain-obj@1.1.0: {}
 
@@ -7578,21 +7463,6 @@ snapshots:
     dependencies:
       map-age-cleaner: 0.1.3
       mimic-fn: 4.0.0
-
-  meow@10.1.5:
-    dependencies:
-      '@types/minimist': 1.2.2
-      camelcase-keys: 7.0.2
-      decamelize: 5.0.1
-      decamelize-keys: 1.1.0
-      hard-rejection: 2.1.0
-      minimist-options: 4.1.0
-      normalize-package-data: 3.0.3
-      read-pkg-up: 8.0.0
-      redent: 4.0.0
-      trim-newlines: 4.0.2
-      type-fest: 1.4.0
-      yargs-parser: 20.2.9
 
   meow@8.1.2:
     dependencies:
@@ -7941,13 +7811,13 @@ snapshots:
     dependencies:
       postcss: 8.4.17
 
-  postcss-load-config@3.1.4(postcss@8.4.17)(ts-node@10.9.1(@swc/core@1.3.78)(@types/node@14.18.31)(typescript@4.8.4)):
+  postcss-load-config@3.1.4(postcss@8.4.17)(ts-node@10.9.1(@swc/core@1.3.78)(@types/node@14.18.30)(typescript@4.8.4)):
     dependencies:
       lilconfig: 2.0.6
       yaml: 1.10.2
     optionalDependencies:
       postcss: 8.4.17
-      ts-node: 10.9.1(@swc/core@1.3.78)(@types/node@14.18.31)(typescript@4.8.4)
+      ts-node: 10.9.1(@swc/core@1.3.78)(@types/node@14.18.30)(typescript@4.8.4)
 
   postcss-merge-longhand@5.1.6(postcss@8.4.17):
     dependencies:
@@ -8154,25 +8024,12 @@ snapshots:
       read-pkg: 5.2.0
       type-fest: 0.8.1
 
-  read-pkg-up@8.0.0:
-    dependencies:
-      find-up: 5.0.0
-      read-pkg: 6.0.0
-      type-fest: 1.4.0
-
   read-pkg@5.2.0:
     dependencies:
       '@types/normalize-package-data': 2.4.1
       normalize-package-data: 2.5.0
       parse-json: 5.2.0
       type-fest: 0.6.0
-
-  read-pkg@6.0.0:
-    dependencies:
-      '@types/normalize-package-data': 2.4.1
-      normalize-package-data: 3.0.3
-      parse-json: 5.2.0
-      type-fest: 1.4.0
 
   readable-stream@3.6.0:
     dependencies:
@@ -8188,11 +8045,6 @@ snapshots:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
-
-  redent@4.0.0:
-    dependencies:
-      indent-string: 5.0.0
-      strip-indent: 4.0.0
 
   regenerate-unicode-properties@10.1.0:
     dependencies:
@@ -8291,7 +8143,7 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
-  rollup-plugin-postcss@4.0.2(postcss@8.4.17)(ts-node@10.9.1(@swc/core@1.3.78)(@types/node@14.18.31)(typescript@4.8.4)):
+  rollup-plugin-postcss@4.0.2(postcss@8.4.17)(ts-node@10.9.1(@swc/core@1.3.78)(@types/node@14.18.30)(typescript@4.8.4)):
     dependencies:
       chalk: 4.1.2
       concat-with-sourcemaps: 1.1.0
@@ -8300,7 +8152,7 @@ snapshots:
       p-queue: 6.6.2
       pify: 5.0.0
       postcss: 8.4.17
-      postcss-load-config: 3.1.4(postcss@8.4.17)(ts-node@10.9.1(@swc/core@1.3.78)(@types/node@14.18.31)(typescript@4.8.4))
+      postcss-load-config: 3.1.4(postcss@8.4.17)(ts-node@10.9.1(@swc/core@1.3.78)(@types/node@14.18.30)(typescript@4.8.4))
       postcss-modules: 4.3.1(postcss@8.4.17)
       promise.series: 0.2.0
       resolve: 1.22.1
@@ -8535,10 +8387,6 @@ snapshots:
     dependencies:
       min-indent: 1.0.1
 
-  strip-indent@4.0.0:
-    dependencies:
-      min-indent: 1.0.1
-
   strip-json-comments@3.1.1: {}
 
   style-inject@0.3.0: {}
@@ -8630,8 +8478,6 @@ snapshots:
 
   trim-newlines@3.0.1: {}
 
-  trim-newlines@4.0.2: {}
-
   ts-interface-checker@0.1.13: {}
 
   ts-node@10.9.1(@swc/core@1.3.78)(@types/node@14.18.30)(typescript@4.8.4):
@@ -8653,27 +8499,6 @@ snapshots:
       yn: 3.1.1
     optionalDependencies:
       '@swc/core': 1.3.78
-
-  ts-node@10.9.1(@swc/core@1.3.78)(@types/node@14.18.31)(typescript@4.8.4):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.9
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.3
-      '@types/node': 14.18.31
-      acorn: 8.8.0
-      acorn-walk: 8.2.0
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 4.8.4
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optionalDependencies:
-      '@swc/core': 1.3.78
-    optional: true
 
   tsconfig-paths@3.14.1:
     dependencies:
@@ -8710,8 +8535,6 @@ snapshots:
   type-fest@0.6.0: {}
 
   type-fest@0.8.1: {}
-
-  type-fest@1.4.0: {}
 
   type@1.2.0: {}
 


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `*`

This PR contains:

- [x] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

I started work on a separate PR, but quickly ran into errors with the `prepare` `scripts` apparently not being cross-platform (`if` command not found—I am on macOS). Since this is a `pnpm` monorepo, and the `scripts` are very simple, why not make use of the [`shell-emulator`](https://pnpm.io/cli/run#shell-emulator) `.npmrc` config option (which uses [yarnpkg-shell](https://yarnpkg.com/features/scripting#portable-shell))? This also means the dependency on `del-cli` is no longer necessary.
