### PR TITLE
fix(repo): type definitions not being exported correctly for esm modules

### DIFF
--- a/packages/alias/package.json
+++ b/packages/alias/package.json
@@ -16,7 +16,9 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": "./types/index.d.ts",
+    "types": {
+      "import": "./dist/es/index.d.ts"
+    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },

--- a/packages/alias/package.json
+++ b/packages/alias/package.json
@@ -16,9 +16,6 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": {
-      "import": "./dist/es/index.d.ts"
-    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },
@@ -70,7 +67,6 @@
     "rollup": "^4.0.0-24",
     "typescript": "^4.8.3"
   },
-  "types": "./types/index.d.ts",
   "ava": {
     "files": [
       "!**/fixtures/**",

--- a/packages/auto-install/package.json
+++ b/packages/auto-install/package.json
@@ -16,7 +16,9 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": "./types/index.d.ts",
+    "types": {
+      "import": "./dist/es/index.d.ts"
+    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },

--- a/packages/auto-install/package.json
+++ b/packages/auto-install/package.json
@@ -16,9 +16,6 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": {
-      "import": "./dist/es/index.d.ts"
-    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },
@@ -70,7 +67,6 @@
     "rollup": "^4.0.0-24",
     "typescript": "^4.8.3"
   },
-  "types": "./types/index.d.ts",
   "ava": {
     "workerThreads": false,
     "files": [

--- a/packages/babel/package.json
+++ b/packages/babel/package.json
@@ -16,7 +16,9 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": "./types/index.d.ts",
+    "types": {
+      "import": "./dist/es/index.d.ts"
+    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },

--- a/packages/babel/package.json
+++ b/packages/babel/package.json
@@ -16,9 +16,6 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": {
-      "import": "./dist/es/index.d.ts"
-    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },
@@ -84,7 +81,6 @@
     "rollup": "^4.0.0-24",
     "source-map": "^0.7.4"
   },
-  "types": "./types/index.d.ts",
   "ava": {
     "files": [
       "!**/fixtures/**",

--- a/packages/buble/package.json
+++ b/packages/buble/package.json
@@ -16,7 +16,9 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": "./types/index.d.ts",
+    "types": {
+      "import": "./dist/es/index.d.ts"
+    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },

--- a/packages/buble/package.json
+++ b/packages/buble/package.json
@@ -16,9 +16,6 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": {
-      "import": "./dist/es/index.d.ts"
-    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },
@@ -74,7 +71,6 @@
     "source-map": "^0.7.4",
     "typescript": "^4.8.3"
   },
-  "types": "./types/index.d.ts",
   "ava": {
     "workerThreads": false,
     "files": [

--- a/packages/commonjs/package.json
+++ b/packages/commonjs/package.json
@@ -16,7 +16,9 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": "./types/index.d.ts",
+    "types": {
+      "import": "./dist/es/index.d.ts"
+    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },

--- a/packages/commonjs/package.json
+++ b/packages/commonjs/package.json
@@ -16,9 +16,6 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": {
-      "import": "./dist/es/index.d.ts"
-    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },
@@ -81,7 +78,6 @@
     "source-map-support": "^0.5.21",
     "typescript": "^4.8.3"
   },
-  "types": "./types/index.d.ts",
   "ava": {
     "workerThreads": false,
     "files": [

--- a/packages/data-uri/package.json
+++ b/packages/data-uri/package.json
@@ -16,7 +16,9 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": "./types/index.d.ts",
+    "types": {
+      "import": "./dist/es/index.d.ts"
+    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },

--- a/packages/data-uri/package.json
+++ b/packages/data-uri/package.json
@@ -16,9 +16,6 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": {
-      "import": "./dist/es/index.d.ts"
-    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },
@@ -71,7 +68,6 @@
     "rollup": "^4.0.0-24",
     "typescript": "^4.8.3"
   },
-  "types": "./types/index.d.ts",
   "ava": {
     "workerThreads": false,
     "files": [

--- a/packages/dsv/package.json
+++ b/packages/dsv/package.json
@@ -16,7 +16,9 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": "./types/index.d.ts",
+    "types": {
+      "import": "./dist/es/index.d.ts"
+    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },

--- a/packages/dsv/package.json
+++ b/packages/dsv/package.json
@@ -16,9 +16,6 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": {
-      "import": "./dist/es/index.d.ts"
-    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },
@@ -60,7 +57,6 @@
     "del-cli": "^5.0.0",
     "rollup": "^4.0.0-24"
   },
-  "types": "./types/index.d.ts",
   "ava": {
     "workerThreads": false,
     "files": [

--- a/packages/dynamic-import-vars/package.json
+++ b/packages/dynamic-import-vars/package.json
@@ -16,7 +16,9 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": "./types/index.d.ts",
+    "types": {
+      "import": "./dist/es/index.d.ts"
+    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },

--- a/packages/dynamic-import-vars/package.json
+++ b/packages/dynamic-import-vars/package.json
@@ -16,9 +16,6 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": {
-      "import": "./dist/es/index.d.ts"
-    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },
@@ -76,7 +73,6 @@
     "prettier": "^2.7.1",
     "rollup": "^4.0.0-24"
   },
-  "types": "./types/index.d.ts",
   "ava": {
     "workerThreads": false,
     "files": [

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -16,7 +16,9 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": "./types/index.d.ts",
+    "types": {
+      "import": "./dist/es/index.d.ts"
+    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -16,9 +16,6 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": {
-      "import": "./dist/es/index.d.ts"
-    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },
@@ -74,7 +71,6 @@
     "rollup": "^4.0.0-24",
     "typescript": "^4.8.3"
   },
-  "types": "./types/index.d.ts",
   "ava": {
     "files": [
       "!**/fixtures/**",

--- a/packages/esm-shim/package.json
+++ b/packages/esm-shim/package.json
@@ -16,9 +16,6 @@
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",
   "exports": {
-    "types": {
-      "import": "./dist/es/index.d.ts"
-    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },
@@ -67,6 +64,5 @@
   "devDependencies": {
     "rollup": "^4.0.0-24",
     "typescript": "^4.8.3"
-  },
-  "types": "./types/index.d.ts"
+  }
 }

--- a/packages/esm-shim/package.json
+++ b/packages/esm-shim/package.json
@@ -16,7 +16,9 @@
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",
   "exports": {
-    "types": "./types/index.d.ts",
+    "types": {
+      "import": "./dist/es/index.d.ts"
+    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -16,7 +16,9 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": "./types/index.d.ts",
+    "types": {
+      "import": "./dist/es/index.d.ts"
+    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -16,9 +16,6 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": {
-      "import": "./dist/es/index.d.ts"
-    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },
@@ -73,7 +70,6 @@
     "graphql": "^16.6.0",
     "rollup": "^4.0.0-24"
   },
-  "types": "./types/index.d.ts",
   "ava": {
     "workerThreads": false,
     "files": [

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -16,7 +16,9 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": "./types/index.d.ts",
+    "types": {
+      "import": "./dist/es/index.d.ts"
+    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -16,9 +16,6 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": {
-      "import": "./dist/es/index.d.ts"
-    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },
@@ -67,7 +64,6 @@
     "rollup-plugin-postcss": "^4.0.2",
     "typescript": "^4.8.3"
   },
-  "types": "./types/index.d.ts",
   "ava": {
     "workerThreads": false,
     "files": [

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -16,7 +16,9 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": "./types/index.d.ts",
+    "types": {
+      "import": "./dist/es/index.d.ts"
+    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -16,9 +16,6 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": {
-      "import": "./dist/es/index.d.ts"
-    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },
@@ -67,7 +64,6 @@
     "@rollup/plugin-buble": "^1.0.0",
     "rollup": "^4.0.0-24"
   },
-  "types": "./types/index.d.ts",
   "ava": {
     "workerThreads": false,
     "files": [

--- a/packages/inject/package.json
+++ b/packages/inject/package.json
@@ -16,9 +16,6 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": {
-      "import": "./dist/es/index.d.ts"
-    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },
@@ -75,7 +72,6 @@
     "source-map": "^0.7.4",
     "typescript": "^4.8.3"
   },
-  "types": "./types/index.d.ts",
   "ava": {
     "files": [
       "!**/fixtures/**",

--- a/packages/inject/package.json
+++ b/packages/inject/package.json
@@ -16,7 +16,9 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": "./types/index.d.ts",
+    "types": {
+      "import": "./dist/es/index.d.ts"
+    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -16,7 +16,9 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": "./types/index.d.ts",
+    "types": {
+      "import": "./dist/es/index.d.ts"
+    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -16,9 +16,6 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": {
-      "import": "./dist/es/index.d.ts"
-    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },
@@ -71,7 +68,6 @@
     "rollup": "^4.0.0-24",
     "source-map-support": "^0.5.21"
   },
-  "types": "./types/index.d.ts",
   "ava": {
     "workerThreads": false,
     "files": [

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -16,7 +16,9 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": "./types/index.d.ts",
+    "types": {
+      "import": "./dist/es/index.d.ts"
+    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -16,9 +16,6 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": {
-      "import": "./dist/es/index.d.ts"
-    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },
@@ -65,7 +62,6 @@
     "del-cli": "^5.0.0",
     "rollup": "^4.0.0-24"
   },
-  "types": "./types/index.d.ts",
   "ava": {
     "workerThreads": false,
     "files": [

--- a/packages/multi-entry/package.json
+++ b/packages/multi-entry/package.json
@@ -16,7 +16,9 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": "./types/index.d.ts",
+    "types": {
+      "import": "./dist/es/index.d.ts"
+    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },

--- a/packages/multi-entry/package.json
+++ b/packages/multi-entry/package.json
@@ -16,9 +16,6 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": {
-      "import": "./dist/es/index.d.ts"
-    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },
@@ -68,7 +65,6 @@
   "devDependencies": {
     "rollup": "^4.0.0-24"
   },
-  "types": "./types/index.d.ts",
   "ava": {
     "files": [
       "!**/fixtures/**",

--- a/packages/node-resolve/package.json
+++ b/packages/node-resolve/package.json
@@ -16,7 +16,9 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": "./types/index.d.ts",
+    "types": {
+      "import": "./dist/es/index.d.ts"
+    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },

--- a/packages/node-resolve/package.json
+++ b/packages/node-resolve/package.json
@@ -16,9 +16,6 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": {
-      "import": "./dist/es/index.d.ts"
-    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },
@@ -81,7 +78,6 @@
     "source-map": "^0.7.4",
     "string-capitalize": "^1.0.1"
   },
-  "types": "./types/index.d.ts",
   "ava": {
     "workerThreads": false,
     "files": [

--- a/packages/pluginutils/package.json
+++ b/packages/pluginutils/package.json
@@ -19,7 +19,9 @@
   "module": "./dist/es/index.js",
   "type": "commonjs",
   "exports": {
-    "types": "./types/index.d.ts",
+    "types": {
+      "import": "./dist/es/index.d.ts"
+    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },

--- a/packages/pluginutils/package.json
+++ b/packages/pluginutils/package.json
@@ -19,9 +19,6 @@
   "module": "./dist/es/index.js",
   "type": "commonjs",
   "exports": {
-    "types": {
-      "import": "./dist/es/index.d.ts"
-    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },
@@ -77,7 +74,6 @@
     "rollup": "^4.0.0-24",
     "typescript": "^4.8.3"
   },
-  "types": "./types/index.d.ts",
   "ava": {
     "extensions": [
       "ts"

--- a/packages/replace/package.json
+++ b/packages/replace/package.json
@@ -16,7 +16,9 @@
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",
   "exports": {
-    "types": "./types/index.d.ts",
+    "types": {
+      "import": "./dist/es/index.d.ts"
+    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },

--- a/packages/replace/package.json
+++ b/packages/replace/package.json
@@ -16,9 +16,6 @@
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",
   "exports": {
-    "types": {
-      "import": "./dist/es/index.d.ts"
-    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },
@@ -74,7 +71,6 @@
     "source-map": "^0.7.4",
     "typescript": "^4.8.3"
   },
-  "types": "./types/index.d.ts",
   "ava": {
     "workerThreads": false,
     "files": [

--- a/packages/run/package.json
+++ b/packages/run/package.json
@@ -16,7 +16,9 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": "./types/index.d.ts",
+    "types": {
+      "import": "./dist/es/index.d.ts"
+    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },

--- a/packages/run/package.json
+++ b/packages/run/package.json
@@ -16,9 +16,6 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": {
-      "import": "./dist/es/index.d.ts"
-    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },
@@ -68,7 +65,6 @@
     "sinon": "^14.0.0",
     "typescript": "^4.8.3"
   },
-  "types": "./types/index.d.ts",
   "ava": {
     "workerThreads": false,
     "files": [

--- a/packages/strip/package.json
+++ b/packages/strip/package.json
@@ -16,9 +16,6 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": {
-      "import": "./dist/es/index.d.ts"
-    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },
@@ -65,7 +62,6 @@
     "acorn": "^8.8.0",
     "rollup": "^4.0.0-24"
   },
-  "types": "./types/index.d.ts",
   "ava": {
     "files": [
       "!**/fixtures/**",

--- a/packages/strip/package.json
+++ b/packages/strip/package.json
@@ -16,7 +16,9 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": "./types/index.d.ts",
+    "types": {
+      "import": "./dist/es/index.d.ts"
+    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },

--- a/packages/sucrase/package.json
+++ b/packages/sucrase/package.json
@@ -17,7 +17,9 @@
   "module": "./dist/es/index.js",
   "type": "commonjs",
   "exports": {
-    "types": "./types/index.d.ts",
+    "types": {
+      "import": "./dist/es/index.d.ts"
+    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },

--- a/packages/sucrase/package.json
+++ b/packages/sucrase/package.json
@@ -17,9 +17,6 @@
   "module": "./dist/es/index.js",
   "type": "commonjs",
   "exports": {
-    "types": {
-      "import": "./dist/es/index.d.ts"
-    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },
@@ -71,7 +68,6 @@
     "@rollup/plugin-alias": "^4.0.0",
     "rollup": "^4.0.0-24"
   },
-  "types": "./types/index.d.ts",
   "ava": {
     "workerThreads": false,
     "files": [

--- a/packages/swc/package.json
+++ b/packages/swc/package.json
@@ -16,7 +16,9 @@
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",
   "exports": {
-    "types": "./types/index.d.ts",
+    "types": {
+      "import": "./dist/es/index.d.ts"
+    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },

--- a/packages/swc/package.json
+++ b/packages/swc/package.json
@@ -16,9 +16,6 @@
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",
   "exports": {
-    "types": {
-      "import": "./dist/es/index.d.ts"
-    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },
@@ -71,6 +68,5 @@
     "@swc/core": "^1.3.78",
     "rollup": "^4.0.0-24",
     "typescript": "^4.8.3"
-  },
-  "types": "./types/index.d.ts"
+  }
 }

--- a/packages/terser/package.json
+++ b/packages/terser/package.json
@@ -16,9 +16,6 @@
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",
   "exports": {
-    "types": {
-      "import": "./dist/es/index.d.ts"
-    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },
@@ -71,6 +68,5 @@
     "@types/serialize-javascript": "^5.0.2",
     "rollup": "^4.0.0-24",
     "typescript": "^4.8.3"
-  },
-  "types": "./types/index.d.ts"
+  }
 }

--- a/packages/terser/package.json
+++ b/packages/terser/package.json
@@ -16,7 +16,9 @@
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",
   "exports": {
-    "types": "./types/index.d.ts",
+    "types": {
+      "import": "./dist/es/index.d.ts"
+    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -16,7 +16,9 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": "./types/index.d.ts",
+    "types": {
+      "import": "./dist/es/index.d.ts"
+    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -16,9 +16,6 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": {
-      "import": "./dist/es/index.d.ts"
-    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },
@@ -77,6 +74,5 @@
     "buble": "^0.20.0",
     "rollup": "^4.0.0-24",
     "typescript": "^4.8.3"
-  },
-  "types": "./types/index.d.ts"
+  }
 }

--- a/packages/url/package.json
+++ b/packages/url/package.json
@@ -16,7 +16,9 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": "./types/index.d.ts",
+    "types": {
+      "import": "./dist/es/index.d.ts"
+    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },

--- a/packages/url/package.json
+++ b/packages/url/package.json
@@ -16,9 +16,6 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": {
-      "import": "./dist/es/index.d.ts"
-    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },
@@ -68,7 +65,6 @@
     "globby": "^11.1.0",
     "rollup": "^4.0.0-24"
   },
-  "types": "./types/index.d.ts",
   "ava": {
     "workerThreads": false,
     "files": [

--- a/packages/virtual/package.json
+++ b/packages/virtual/package.json
@@ -16,7 +16,9 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": "./types/index.d.ts",
+    "types": {
+      "import": "./dist/es/index.d.ts"
+    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },

--- a/packages/virtual/package.json
+++ b/packages/virtual/package.json
@@ -16,9 +16,6 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": {
-      "import": "./dist/es/index.d.ts"
-    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },
@@ -68,7 +65,6 @@
     "rollup": "^4.0.0-24",
     "typescript": "^4.8.3"
   },
-  "types": "./types/index.d.ts",
   "ava": {
     "files": [
       "!**/fixtures/**",

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -16,7 +16,9 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": "./types/index.d.ts",
+    "types": {
+      "import": "./dist/es/index.d.ts"
+    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -16,9 +16,6 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": {
-      "import": "./dist/es/index.d.ts"
-    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },
@@ -74,7 +71,6 @@
     "source-map": "^0.7.4",
     "typescript": "^4.8.3"
   },
-  "types": "./types/index.d.ts",
   "ava": {
     "workerThreads": false,
     "files": [

--- a/packages/yaml/package.json
+++ b/packages/yaml/package.json
@@ -16,7 +16,9 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": "./types/index.d.ts",
+    "types": {
+      "import": "./dist/es/index.d.ts"
+    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },

--- a/packages/yaml/package.json
+++ b/packages/yaml/package.json
@@ -16,9 +16,6 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": {
-      "import": "./dist/es/index.d.ts"
-    },
     "import": "./dist/es/index.js",
     "default": "./dist/cjs/index.js"
   },
@@ -69,7 +66,6 @@
     "rollup": "^4.0.0-24",
     "source-map-support": "^0.5.21"
   },
-  "types": "./types/index.d.ts",
   "ava": {
     "workerThreads": false,
     "files": [

--- a/shared/rollup.config.mjs
+++ b/shared/rollup.config.mjs
@@ -1,4 +1,5 @@
 import { builtinModules } from 'module';
+import { promises as fs } from 'fs';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import typescript from '@rollup/plugin-typescript';
@@ -31,7 +32,7 @@ export function createConfig({ pkg, external = [] }) {
       {
         format: 'es',
         file: pkg.module,
-        plugins: [emitModulePackageFile()],
+        plugins: [emitModulePackageFile(), emitDeclarationFile()],
         sourcemap: true
       }
     ],
@@ -47,6 +48,19 @@ export function emitModulePackageFile() {
         type: 'asset',
         fileName: 'package.json',
         source: `{"type":"module"}`
+      });
+    }
+  };
+}
+
+export function emitDeclarationFile() {
+  return {
+    name: 'emit-declaration-file',
+    async generateBundle() {
+      this.emitFile({
+        type: 'asset',
+        fileName: 'index.d.ts',
+        source: await fs.readFile('./types/index.d.ts')
       });
     }
   };

--- a/shared/rollup.config.mjs
+++ b/shared/rollup.config.mjs
@@ -27,6 +27,7 @@ export function createConfig({ pkg, external = [] }) {
         file: pkg.main,
         exports: 'named',
         footer: 'module.exports = Object.assign(exports.default, exports);',
+        plugins: [emitDeclarationFile()],
         sourcemap: true
       },
       {

--- a/shared/rollup.config.mjs
+++ b/shared/rollup.config.mjs
@@ -33,7 +33,7 @@ export function createConfig({ pkg, external = [] }) {
       {
         format: 'es',
         file: pkg.module,
-        plugins: [emitModulePackageFile(), emitDeclarationFile()],
+        plugins: [emitDeclarationFile('m')],
         sourcemap: true
       }
     ],
@@ -41,26 +41,13 @@ export function createConfig({ pkg, external = [] }) {
   };
 }
 
-export function emitModulePackageFile() {
-  return {
-    name: 'emit-module-package-file',
-    generateBundle() {
-      this.emitFile({
-        type: 'asset',
-        fileName: 'package.json',
-        source: `{"type":"module"}`
-      });
-    }
-  };
-}
-
-export function emitDeclarationFile() {
+export function emitDeclarationFile(m = '') {
   return {
     name: 'emit-declaration-file',
     async generateBundle() {
       this.emitFile({
         type: 'asset',
-        fileName: 'index.d.ts',
+        fileName: `index.d.${m}ts`,
         source: await fs.readFile('./types/index.d.ts')
       });
     }


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `{name}`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

Picking up the baton from @Geylnu in #1578 …

I also ran into this. As mentioned elsewhere, [the types are wrong](https://arethetypeswrong.github.io/?p=%40rollup%2Fplugin-strip%403.0.4) in all Rollup plugins! Meaning they do not play nice with TypeScript.

More detailed explanations can be found [here](https://publint.dev/rules#export_types_invalid_format) and [here](https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/FalseCJS.md).

Fixes #1541.
Fixes #1329.
