### PR TITLE
fix(graphql): handle parentheses in fragment import file paths.

### DIFF
--- a/packages/graphql/src/toESModules.js
+++ b/packages/graphql/src/toESModules.js
@@ -29,15 +29,13 @@ function replaceRequires(source) {
   let index = 0;
 
   // replace a require statement with a variable
-  const replaceSource = source.replace(/require\(([^)]+)\)/gi, (match, path) => {
-    const replacePath = path.replace(/["']+/g, '');
-
-    if (!imports[replacePath]) {
+  const replaceSource = source.replace(/require\(["']([^"']+)["']\)/gi, (match, path) => {
+    if (!imports[path]) {
       index += 1;
-      imports[replacePath] = `frgmt${index}`;
+      imports[path] = `frgmt${index}`;
     }
 
-    return imports[replacePath];
+    return imports[path];
   });
 
   // prepare import statements

--- a/packages/graphql/test/fixtures/fragments-with-special-characters/(parentheses)/fragment.graphql
+++ b/packages/graphql/test/fixtures/fragments-with-special-characters/(parentheses)/fragment.graphql
@@ -1,0 +1,3 @@
+fragment ParenthesesFragment on Parentheses {
+  id
+}

--- a/packages/graphql/test/fixtures/fragments-with-special-characters/[brackets]/fragment.graphql
+++ b/packages/graphql/test/fixtures/fragments-with-special-characters/[brackets]/fragment.graphql
@@ -1,0 +1,3 @@
+fragment BracketsFragment on Brackets {
+  id
+}

--- a/packages/graphql/test/fixtures/fragments-with-special-characters/index.js
+++ b/packages/graphql/test/fixtures/fragments-with-special-characters/index.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export { default as doc } from './query.graphql';

--- a/packages/graphql/test/fixtures/fragments-with-special-characters/query.graphql
+++ b/packages/graphql/test/fixtures/fragments-with-special-characters/query.graphql
@@ -1,0 +1,7 @@
+#import "./(parentheses)/fragment.graphql"
+#import "./[brackets]/fragment.graphql"
+
+query Query {
+  ...ParenthesesFragment
+  ...BracketsFragment
+}

--- a/packages/graphql/test/test.js
+++ b/packages/graphql/test/test.js
@@ -62,3 +62,15 @@ test('should support graphqls schema files', async (t) => {
   t.truthy('doc' in module.exports);
   t.is(module.exports.doc.kind, 'Document');
 });
+
+test('should support fragment imports with brackets and parentheses in file paths', async (t) => {
+  const bundle = await rollup({
+    input: 'fixtures/fragments-with-special-characters/index.js',
+    plugins: [graphql()]
+  });
+
+  const { module } = await testBundle(t, bundle);
+
+  t.truthy('doc' in module.exports);
+  t.is(module.exports.doc.kind, 'Document');
+});


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `graphql`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

N/A

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

This PR fixes an issue in the GraphQL plugin where parentheses in file paths are not properly replaced with a fragment's variable, leading to a parsing error.

The fix works by updating the require statement replacement regex from `/require\(([^)]+)\)/gi` to `/require\(["']([^"']+)["']\)/gi`. The original regex considered a closing parenthesis as the terminator of a require statement, when in fact, we should be looking at a quote character before a parentheses as the terminator. In addition, by excluding the leading and trailing quote from the regex capture group, we can remove the additional `replacePath` variable.
