### PR TITLE
fix(dynamic-import-vars): simplify regex

### DIFF
--- a/packages/dynamic-import-vars/src/dynamic-import-to-glob.js
+++ b/packages/dynamic-import-vars/src/dynamic-import-to-glob.js
@@ -107,7 +107,7 @@ export function dynamicImportToGlob(node, sourceString) {
   }
 
   // Disallow ./*.ext
-  const ownDirectoryStarExtension = /^\.\/\*\.[\w]+$/;
+  const ownDirectoryStarExtension = /^\.\/\*\.\w+$/;
   if (ownDirectoryStarExtension.test(glob)) {
     throw new VariableDynamicImportError(
       `${


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `dynamic-import-vars`

This PR contains:

- [ ] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

n/a

### Description

It looks like we can remove the unneeded `[]` for the regex as it contains only the `\w`. I discovered this while running `eslint-plugin-regexp`:

```
/Users/bjorn/Work/oss/vite/node_modules/.pnpm/@rollup+plugin-dynamic-import-vars@2.1.2_rollup@4.18.1/node_modules/@rollup/plugin-dynamic-import-vars/dist/cjs/index.js
  117:47  error  Unexpected character class with one character class escape. Can remove brackets  regexp/no-useless-character-class
```

It's not a significant change and unlikely to affect perf, but should help with readability.