### PR TITLE
fix(pluginutils): improve regex performance

### DIFF
--- a/packages/pluginutils/src/attachScopes.ts
+++ b/packages/pluginutils/src/attachScopes.ts
@@ -66,7 +66,7 @@ const attachScopes: AttachScopes = function attachScopes(ast, propertyName = 'sc
       const node = n as estree.Node;
       // function foo () {...}
       // class Foo {...}
-      if (/(Function|Class)Declaration/.test(node.type)) {
+      if (/(?:Function|Class)Declaration/.test(node.type)) {
         scope.addDeclaration(node, false, false);
       }
 
@@ -98,7 +98,7 @@ const attachScopes: AttachScopes = function attachScopes(ast, propertyName = 'sc
       }
 
       // create new for scope
-      if (/For(In|Of)?Statement/.test(node.type)) {
+      if (/For(?:In|Of)?Statement/.test(node.type)) {
         newScope = new Scope({
           parent: scope,
           block: true

--- a/packages/pluginutils/src/dataToEsm.ts
+++ b/packages/pluginutils/src/dataToEsm.ts
@@ -91,7 +91,7 @@ const dataToEsm: DataToEsm = function dataToEsm(data, options = {}) {
 
   let maxUnderbarPrefixLength = 0;
   for (const key of Object.keys(data)) {
-    const underbarPrefixLength = key.match(/^(_+)/)?.[0].length ?? 0;
+    const underbarPrefixLength = /^(_+)/.exec(key)?.[0].length ?? 0;
     if (underbarPrefixLength > maxUnderbarPrefixLength) {
       maxUnderbarPrefixLength = underbarPrefixLength;
     }


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `pluginutils`

This PR contains:

- [ ] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:
n/a

### Description

Refactors some regex to use non-capturing groups (as captured groups are a little slower), and use `regexp.prototype.exec` instead of `string.prototype.match` for perf.

For the former change, it's hard to use an online tool to measure as the difference is quite small, but here's a local file you can copy using `tinybench` that you can run:

<details>
<summary>File</summary>

```js
import { Bench } from 'tinybench'

const b = new Bench({ iterations: 1000 })

const choices = ['FunctionDeclaration', 'ClassDeclaration', 'VariableDeclaration', 'Identifier']
const strs = Array.from({ length: 10 }).map(_ => choices[Math.floor(Math.random() * choices.length)])

b.add('non-capture', () => {
  strs.forEach(s => { /(?:Function|Class)Declaration/.test(s) })
})

b.add('capture', () => {
  strs.forEach(s => { /(Function|Class)Declaration/.test(s) })
})

await b.warmup();
await b.run();

console.table(b.table());
```


</details>

node18.20.3 results:
```
┌─────────┬───────────────┬─────────────┬────────────────────┬──────────┬─────────┐
│ (index) │   Task Name   │   ops/sec   │ Average Time (ns)  │  Margin  │ Samples │
├─────────┼───────────────┼─────────────┼────────────────────┼──────────┼─────────┤
│    0    │ 'non-capture' │ '5,088,404' │ 196.5252384844669  │ '±0.63%' │ 2544203 │
│    1    │   'capture'   │ '4,831,673' │ 206.96762775341406 │ '±0.67%' │ 2415837 │
└─────────┴───────────────┴─────────────┴────────────────────┴──────────┴─────────┘
```

For the latter change, I've benchmarked this at https://github.com/lukeed/polka/pull/210 which you can run the perf.link test for the results too.
