### PR TITLE
feat(swc): sets filename property, so to make additional swc features…

### DIFF
--- a/packages/swc/src/module.ts
+++ b/packages/swc/src/module.ts
@@ -37,7 +37,8 @@ export function swc(input: Options = {}): Plugin {
 
       return transform(code, {
         ...swcOptions,
-        sourceMaps: true
+        sourceMaps: true,
+        filename: id
       });
     }
   };


### PR DESCRIPTION
## Rollup Plugin Name: swc

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:
-

### Description

Background: When using the swc rollup plugin in vitest, debugging will not work. I assume this comes from the filename property not being set, as the documentation states:
```
The filename is optional, but not all of Swc's
functionality is available when the filename is unknown, because a subset of options rely on the filename for their functionality.
```

Setting a filename should not have any side effects, just make debugging and other features work.
