### PR TITLE
chore(dynamic-import-vars): switch to tinyglobby for fewer dependencies

### DIFF
--- a/packages/dynamic-import-vars/package.json
+++ b/packages/dynamic-import-vars/package.json
@@ -66,8 +66,8 @@
     "@rollup/pluginutils": "^5.0.1",
     "astring": "^1.8.5",
     "estree-walker": "^2.0.2",
-    "fast-glob": "^3.2.12",
-    "magic-string": "^0.30.3"
+    "magic-string": "^0.30.3",
+    "tinyglobby": "^0.2.8"
   },
   "devDependencies": {
     "acorn": "^8.8.0",

--- a/packages/dynamic-import-vars/src/dynamic-import-to-glob.js
+++ b/packages/dynamic-import-vars/src/dynamic-import-to-glob.js
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import fastGlob from 'fast-glob';
+import { escapePath } from 'tinyglobby';
 
 export class VariableDynamicImportError extends Error {}
 
@@ -12,7 +12,7 @@ function sanitizeString(str) {
   if (str.includes('*')) {
     throw new VariableDynamicImportError('A dynamic import cannot contain * characters.');
   }
-  return fastGlob.escapePath(str);
+  return escapePath(str);
 }
 
 function templateLiteralToGlob(node) {

--- a/packages/dynamic-import-vars/src/index.js
+++ b/packages/dynamic-import-vars/src/index.js
@@ -2,7 +2,7 @@ import path from 'path';
 
 import { walk } from 'estree-walker';
 import MagicString from 'magic-string';
-import fastGlob from 'fast-glob';
+import { globSync } from 'tinyglobby';
 import { generate } from 'astring';
 
 import { createFilter } from '@rollup/pluginutils';
@@ -50,7 +50,7 @@ function dynamicImportVariables({ include, exclude, warnOnError, errorWhenNoFile
             }
 
             // execute the glob
-            const result = fastGlob.sync(glob, { cwd: path.dirname(id) });
+            const result = globSync(glob, { cwd: path.dirname(id), expandDirectories: false });
             const paths = result.map((r) =>
               r.startsWith('./') || r.startsWith('../') ? r : `./${r}`
             );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -295,12 +295,12 @@ importers:
       estree-walker:
         specifier: ^2.0.2
         version: 2.0.2
-      fast-glob:
-        specifier: ^3.2.12
-        version: 3.2.12
       magic-string:
         specifier: ^0.30.3
         version: 0.30.3
+      tinyglobby:
+        specifier: ^0.2.8
+        version: 0.2.8
     devDependencies:
       acorn:
         specifier: ^8.8.0
@@ -2286,7 +2286,7 @@ packages:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
 
   concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
 
   concat-with-sourcemaps@1.1.0:
     resolution: {integrity: sha512-4gEjHJFT9e+2W/77h/DS5SGUgwDaOwprX8L/gl5+3ixnzkVJJsZWDSelmN3Oilw3LNDZjZV0yqH1hLG3k6nghg==}
@@ -2727,6 +2727,14 @@ packages:
     resolution: {integrity: sha512-QfKBVg453Dyn3mr0Q0O+Tkr1r79lOTAKSi9f/Ot4+qVEwxWhav2Z+SudrG9vQjM2aYRMQQZ2/Q1zdA8ACM1pDg==}
     peerDependencies:
       picomatch: 3.x
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fdir@6.4.0:
+    resolution: {integrity: sha512-3oB133prH1o4j/L5lLW7uOCF1PlD+/It2L0eL/iAqWMB91RBbqTewABqxhj0ibBd90EEmWZq7ntIWzVaWcXTGQ==}
+    peerDependencies:
+      picomatch: ^3 || ^4
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -3669,6 +3677,10 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
+  picomatch@4.0.2:
+    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+    engines: {node: '>=12'}
+
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
@@ -4402,6 +4414,10 @@ packages:
   time-zone@1.0.0:
     resolution: {integrity: sha512-TIsDdtKo6+XrPtiTm1ssmMngN1sAhyKnTO2kunQWqNPWIVvCm15Wmw4SWInwTVgJ5u/Tr04+8Ei9TNcw4x4ONA==}
     engines: {node: '>=4'}
+
+  tinyglobby@0.2.8:
+    resolution: {integrity: sha512-AMLZywN0vbhiZi2neFEaj9VIIxC+PjDMsp0nAK6tpR86LJavZgHqGz0S/FOONwBygC+mu7R0/TyAQw0gx0Mu9Q==}
+    engines: {node: '>=12.0.0'}
 
   to-fast-properties@2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
@@ -6963,6 +6979,10 @@ snapshots:
     optionalDependencies:
       picomatch: 2.3.1
 
+  fdir@6.4.0(picomatch@4.0.2):
+    optionalDependencies:
+      picomatch: 4.0.2
+
   figures@4.0.1:
     dependencies:
       escape-string-regexp: 5.0.0
@@ -7880,6 +7900,8 @@ snapshots:
 
   picomatch@2.3.1: {}
 
+  picomatch@4.0.2: {}
+
   pify@4.0.1: {}
 
   pify@5.0.0: {}
@@ -8619,6 +8641,11 @@ snapshots:
   through@2.3.8: {}
 
   time-zone@1.0.0: {}
+
+  tinyglobby@0.2.8:
+    dependencies:
+      fdir: 6.4.0(picomatch@4.0.2)
+      picomatch: 4.0.2
 
   to-fast-properties@2.0.0: {}
 


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `@rollup/plugin-dynamic-import-vars`

This PR contains:

- [ ] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
https://npmgraph.js.org/?q=fast-glob - 17 dependencies
https://npmgraph.js.org/?q=tinyglobby - 2 dependencies