### PR TITLE
Provide typings for both cjs and es builds

### DIFF
--- a/packages/alias/package.json
+++ b/packages/alias/package.json
@@ -15,10 +15,16 @@
   "bugs": "https://github.com/rollup/plugins/issues",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
+  "type": "commonjs",
   "exports": {
-    "types": "./types/index.d.ts",
-    "import": "./dist/es/index.js",
-    "default": "./dist/cjs/index.js"
+    "require": {
+      "types": "./dist/cjs/index.d.ts",
+      "default": "./dist/cjs/index.js"
+    },
+    "import": {
+      "types": "./dist/es/index.d.ts",
+      "default": "./dist/es/index.js"
+    }
   },
   "engines": {
     "node": ">=14.0.0"
@@ -65,7 +71,7 @@
     "rollup": "^4.0.0-24",
     "typescript": "^4.8.3"
   },
-  "types": "./types/index.d.ts",
+  "types": "./dist/cjs/index.d.ts",
   "ava": {
     "files": [
       "!**/fixtures/**",

--- a/packages/auto-install/package.json
+++ b/packages/auto-install/package.json
@@ -15,10 +15,16 @@
   "bugs": "https://github.com/rollup/plugins/issues",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
+  "type": "commonjs",
   "exports": {
-    "types": "./types/index.d.ts",
-    "import": "./dist/es/index.js",
-    "default": "./dist/cjs/index.js"
+    "require": {
+      "types": "./dist/cjs/index.d.ts",
+      "default": "./dist/cjs/index.js"
+    },
+    "import": {
+      "types": "./dist/es/index.d.ts",
+      "default": "./dist/es/index.js"
+    }
   },
   "engines": {
     "node": ">=14.0.0"
@@ -68,7 +74,7 @@
     "rollup": "^4.0.0-24",
     "typescript": "^4.8.3"
   },
-  "types": "./types/index.d.ts",
+  "types": "./dist/cjs/index.d.ts",
   "ava": {
     "workerThreads": false,
     "files": [

--- a/packages/babel/package.json
+++ b/packages/babel/package.json
@@ -15,10 +15,16 @@
   "bugs": "https://github.com/rollup/plugins/issues",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
+  "type": "commonjs",
   "exports": {
-    "types": "./types/index.d.ts",
-    "import": "./dist/es/index.js",
-    "default": "./dist/cjs/index.js"
+    "require": {
+      "types": "./dist/cjs/index.d.ts",
+      "default": "./dist/cjs/index.js"
+    },
+    "import": {
+      "types": "./dist/es/index.d.ts",
+      "default": "./dist/es/index.js"
+    }
   },
   "engines": {
     "node": ">=14.0.0"
@@ -82,7 +88,7 @@
     "rollup": "^4.0.0-24",
     "source-map": "^0.7.4"
   },
-  "types": "./types/index.d.ts",
+  "types": "./dist/cjs/index.d.ts",
   "ava": {
     "files": [
       "!**/fixtures/**",

--- a/packages/buble/package.json
+++ b/packages/buble/package.json
@@ -15,10 +15,16 @@
   "bugs": "https://github.com/rollup/plugins/issues",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
+  "type": "commonjs",
   "exports": {
-    "types": "./types/index.d.ts",
-    "import": "./dist/es/index.js",
-    "default": "./dist/cjs/index.js"
+    "require": {
+      "types": "./dist/cjs/index.d.ts",
+      "default": "./dist/cjs/index.js"
+    },
+    "import": {
+      "types": "./dist/es/index.d.ts",
+      "default": "./dist/es/index.js"
+    }
   },
   "engines": {
     "node": ">=14.0.0"
@@ -72,7 +78,7 @@
     "source-map": "^0.7.4",
     "typescript": "^4.8.3"
   },
-  "types": "./types/index.d.ts",
+  "types": "./dist/cjs/index.d.ts",
   "ava": {
     "workerThreads": false,
     "files": [

--- a/packages/commonjs/package.json
+++ b/packages/commonjs/package.json
@@ -15,10 +15,16 @@
   "bugs": "https://github.com/rollup/plugins/issues",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
+  "type": "commonjs",
   "exports": {
-    "types": "./types/index.d.ts",
-    "import": "./dist/es/index.js",
-    "default": "./dist/cjs/index.js"
+    "require": {
+      "types": "./dist/cjs/index.d.ts",
+      "default": "./dist/cjs/index.js"
+    },
+    "import": {
+      "types": "./dist/es/index.d.ts",
+      "default": "./dist/es/index.js"
+    }
   },
   "engines": {
     "node": ">=16.0.0 || 14 >= 14.17"
@@ -80,7 +86,7 @@
     "source-map-support": "^0.5.21",
     "typescript": "^4.8.3"
   },
-  "types": "./types/index.d.ts",
+  "types": "./dist/cjs/index.d.ts",
   "ava": {
     "workerThreads": false,
     "files": [

--- a/packages/data-uri/package.json
+++ b/packages/data-uri/package.json
@@ -15,10 +15,16 @@
   "bugs": "https://github.com/rollup/plugins/issues",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
+  "type": "commonjs",
   "exports": {
-    "types": "./types/index.d.ts",
-    "import": "./dist/es/index.js",
-    "default": "./dist/cjs/index.js"
+    "require": {
+      "types": "./dist/cjs/index.d.ts",
+      "default": "./dist/cjs/index.js"
+    },
+    "import": {
+      "types": "./dist/es/index.d.ts",
+      "default": "./dist/es/index.js"
+    }
   },
   "engines": {
     "node": ">=14.0.0"
@@ -69,7 +75,7 @@
     "rollup": "^4.0.0-24",
     "typescript": "^4.8.3"
   },
-  "types": "./types/index.d.ts",
+  "types": "./dist/cjs/index.d.ts",
   "ava": {
     "workerThreads": false,
     "files": [

--- a/packages/dsv/package.json
+++ b/packages/dsv/package.json
@@ -15,10 +15,16 @@
   "bugs": "https://github.com/rollup/plugins/issues",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
+  "type": "commonjs",
   "exports": {
-    "types": "./types/index.d.ts",
-    "import": "./dist/es/index.js",
-    "default": "./dist/cjs/index.js"
+    "require": {
+      "types": "./dist/cjs/index.d.ts",
+      "default": "./dist/cjs/index.js"
+    },
+    "import": {
+      "types": "./dist/es/index.d.ts",
+      "default": "./dist/es/index.js"
+    }
   },
   "scripts": {
     "build": "rollup -c",
@@ -59,7 +65,7 @@
     "del-cli": "^5.0.0",
     "rollup": "^4.0.0-24"
   },
-  "types": "./types/index.d.ts",
+  "types": "./dist/cjs/index.d.ts",
   "ava": {
     "workerThreads": false,
     "files": [

--- a/packages/dynamic-import-vars/package.json
+++ b/packages/dynamic-import-vars/package.json
@@ -15,10 +15,16 @@
   "bugs": "https://github.com/rollup/plugins/issues",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
+  "type": "commonjs",
   "exports": {
-    "types": "./types/index.d.ts",
-    "import": "./dist/es/index.js",
-    "default": "./dist/cjs/index.js"
+    "require": {
+      "types": "./dist/cjs/index.d.ts",
+      "default": "./dist/cjs/index.js"
+    },
+    "import": {
+      "types": "./dist/es/index.d.ts",
+      "default": "./dist/es/index.js"
+    }
   },
   "engines": {
     "node": ">=14.0.0"
@@ -74,7 +80,7 @@
     "prettier": "^2.7.1",
     "rollup": "^4.0.0-24"
   },
-  "types": "./types/index.d.ts",
+  "types": "./dist/cjs/index.d.ts",
   "ava": {
     "workerThreads": false,
     "files": [

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -15,10 +15,16 @@
   "bugs": "https://github.com/rollup/plugins/issues",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
+  "type": "commonjs",
   "exports": {
-    "types": "./types/index.d.ts",
-    "import": "./dist/es/index.js",
-    "default": "./dist/cjs/index.js"
+    "require": {
+      "types": "./dist/cjs/index.d.ts",
+      "default": "./dist/cjs/index.js"
+    },
+    "import": {
+      "types": "./dist/es/index.d.ts",
+      "default": "./dist/es/index.js"
+    }
   },
   "engines": {
     "node": ">=14.0.0"
@@ -72,7 +78,7 @@
     "rollup": "^4.0.0-24",
     "typescript": "^4.8.3"
   },
-  "types": "./types/index.d.ts",
+  "types": "./dist/cjs/index.d.ts",
   "ava": {
     "files": [
       "!**/fixtures/**",

--- a/packages/esm-shim/package.json
+++ b/packages/esm-shim/package.json
@@ -13,12 +13,18 @@
   "author": "Peter Placzek <peter.placzek1996@gmail.com>",
   "homepage": "https://github.com/rollup/plugins/tree/master/packages/esm-shim#readme",
   "bugs": "https://github.com/rollup/plugins/issues",
-  "main": "dist/cjs/index.js",
-  "module": "dist/es/index.js",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/es/index.js",
+  "type": "commonjs",
   "exports": {
-    "types": "./types/index.d.ts",
-    "import": "./dist/es/index.js",
-    "default": "./dist/cjs/index.js"
+    "require": {
+      "types": "./dist/cjs/index.d.ts",
+      "default": "./dist/cjs/index.js"
+    },
+    "import": {
+      "types": "./dist/es/index.d.ts",
+      "default": "./dist/es/index.js"
+    }
   },
   "engines": {
     "node": ">=14.0.0"
@@ -66,5 +72,5 @@
     "rollup": "^4.0.0-24",
     "typescript": "^4.8.3"
   },
-  "types": "./types/index.d.ts"
+  "types": "./dist/cjs/index.d.ts"
 }

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -15,10 +15,16 @@
   "bugs": "https://github.com/rollup/plugins/issues",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
+  "type": "commonjs",
   "exports": {
-    "types": "./types/index.d.ts",
-    "import": "./dist/es/index.js",
-    "default": "./dist/cjs/index.js"
+    "require": {
+      "types": "./dist/cjs/index.d.ts",
+      "default": "./dist/cjs/index.js"
+    },
+    "import": {
+      "types": "./dist/es/index.d.ts",
+      "default": "./dist/es/index.js"
+    }
   },
   "engines": {
     "node": ">=14.0.0"
@@ -71,7 +77,7 @@
     "graphql": "^16.6.0",
     "rollup": "^4.0.0-24"
   },
-  "types": "./types/index.d.ts",
+  "types": "./dist/cjs/index.d.ts",
   "ava": {
     "workerThreads": false,
     "files": [

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -15,10 +15,16 @@
   "bugs": "https://github.com/rollup/plugins/issues",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
+  "type": "commonjs",
   "exports": {
-    "types": "./types/index.d.ts",
-    "import": "./dist/es/index.js",
-    "default": "./dist/cjs/index.js"
+    "require": {
+      "types": "./dist/cjs/index.d.ts",
+      "default": "./dist/cjs/index.js"
+    },
+    "import": {
+      "types": "./dist/es/index.d.ts",
+      "default": "./dist/es/index.js"
+    }
   },
   "engines": {
     "node": ">=14.0.0"
@@ -65,7 +71,7 @@
     "rollup-plugin-postcss": "^4.0.2",
     "typescript": "^4.8.3"
   },
-  "types": "./types/index.d.ts",
+  "types": "./dist/cjs/index.d.ts",
   "ava": {
     "workerThreads": false,
     "files": [

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -15,10 +15,16 @@
   "bugs": "https://github.com/rollup/plugins/issues",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
+  "type": "commonjs",
   "exports": {
-    "types": "./types/index.d.ts",
-    "import": "./dist/es/index.js",
-    "default": "./dist/cjs/index.js"
+    "require": {
+      "types": "./dist/cjs/index.d.ts",
+      "default": "./dist/cjs/index.js"
+    },
+    "import": {
+      "types": "./dist/es/index.d.ts",
+      "default": "./dist/es/index.js"
+    }
   },
   "engines": {
     "node": ">=14.0.0"
@@ -65,7 +71,7 @@
     "@rollup/plugin-buble": "^1.0.0",
     "rollup": "^4.0.0-24"
   },
-  "types": "./types/index.d.ts",
+  "types": "./dist/cjs/index.d.ts",
   "ava": {
     "workerThreads": false,
     "files": [

--- a/packages/inject/package.json
+++ b/packages/inject/package.json
@@ -15,10 +15,16 @@
   "bugs": "https://github.com/rollup/plugins/issues",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
+  "type": "commonjs",
   "exports": {
-    "types": "./types/index.d.ts",
-    "import": "./dist/es/index.js",
-    "default": "./dist/cjs/index.js"
+    "require": {
+      "types": "./dist/cjs/index.d.ts",
+      "default": "./dist/cjs/index.js"
+    },
+    "import": {
+      "types": "./dist/es/index.d.ts",
+      "default": "./dist/es/index.js"
+    }
   },
   "engines": {
     "node": ">=14.0.0"
@@ -73,7 +79,7 @@
     "source-map": "^0.7.4",
     "typescript": "^4.8.3"
   },
-  "types": "./types/index.d.ts",
+  "types": "./dist/cjs/index.d.ts",
   "ava": {
     "files": [
       "!**/fixtures/**",

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -15,10 +15,16 @@
   "bugs": "https://github.com/rollup/plugins/issues",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
+  "type": "commonjs",
   "exports": {
-    "types": "./types/index.d.ts",
-    "import": "./dist/es/index.js",
-    "default": "./dist/cjs/index.js"
+    "require": {
+      "types": "./dist/cjs/index.d.ts",
+      "default": "./dist/cjs/index.js"
+    },
+    "import": {
+      "types": "./dist/es/index.d.ts",
+      "default": "./dist/es/index.js"
+    }
   },
   "engines": {
     "node": ">=14.0.0"
@@ -69,7 +75,7 @@
     "rollup": "^4.0.0-24",
     "source-map-support": "^0.5.21"
   },
-  "types": "./types/index.d.ts",
+  "types": "./dist/cjs/index.d.ts",
   "ava": {
     "workerThreads": false,
     "files": [

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -15,10 +15,16 @@
   "bugs": "https://github.com/rollup/plugins/issues",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
+  "type": "commonjs",
   "exports": {
-    "types": "./types/index.d.ts",
-    "import": "./dist/es/index.js",
-    "default": "./dist/cjs/index.js"
+    "require": {
+      "types": "./dist/cjs/index.d.ts",
+      "default": "./dist/cjs/index.js"
+    },
+    "import": {
+      "types": "./dist/es/index.d.ts",
+      "default": "./dist/es/index.js"
+    }
   },
   "engines": {
     "node": ">=14.0.0"
@@ -63,7 +69,7 @@
     "del-cli": "^5.0.0",
     "rollup": "^4.0.0-24"
   },
-  "types": "./types/index.d.ts",
+  "types": "./dist/cjs/index.d.ts",
   "ava": {
     "workerThreads": false,
     "files": [

--- a/packages/multi-entry/package.json
+++ b/packages/multi-entry/package.json
@@ -15,10 +15,16 @@
   "bugs": "https://github.com/rollup/plugins/issues",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
+  "type": "commonjs",
   "exports": {
-    "types": "./types/index.d.ts",
-    "import": "./dist/es/index.js",
-    "default": "./dist/cjs/index.js"
+    "require": {
+      "types": "./dist/cjs/index.d.ts",
+      "default": "./dist/cjs/index.js"
+    },
+    "import": {
+      "types": "./dist/es/index.d.ts",
+      "default": "./dist/es/index.js"
+    }
   },
   "engines": {
     "node": ">=14.0.0"
@@ -66,7 +72,7 @@
   "devDependencies": {
     "rollup": "^4.0.0-24"
   },
-  "types": "./types/index.d.ts",
+  "types": "./dist/cjs/index.d.ts",
   "ava": {
     "files": [
       "!**/fixtures/**",

--- a/packages/node-resolve/package.json
+++ b/packages/node-resolve/package.json
@@ -15,10 +15,16 @@
   "bugs": "https://github.com/rollup/plugins/issues",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
+  "type": "commonjs",
   "exports": {
-    "types": "./types/index.d.ts",
-    "import": "./dist/es/index.js",
-    "default": "./dist/cjs/index.js"
+    "require": {
+      "types": "./dist/cjs/index.d.ts",
+      "default": "./dist/cjs/index.js"
+    },
+    "import": {
+      "types": "./dist/es/index.d.ts",
+      "default": "./dist/es/index.js"
+    }
   },
   "engines": {
     "node": ">=14.0.0"
@@ -78,7 +84,7 @@
     "source-map": "^0.7.4",
     "string-capitalize": "^1.0.1"
   },
-  "types": "./types/index.d.ts",
+  "types": "./dist/cjs/index.d.ts",
   "ava": {
     "workerThreads": false,
     "files": [

--- a/packages/pluginutils/package.json
+++ b/packages/pluginutils/package.json
@@ -19,9 +19,14 @@
   "module": "./dist/es/index.js",
   "type": "commonjs",
   "exports": {
-    "types": "./types/index.d.ts",
-    "import": "./dist/es/index.js",
-    "default": "./dist/cjs/index.js"
+    "require": {
+      "types": "./dist/cjs/index.d.ts",
+      "default": "./dist/cjs/index.js"
+    },
+    "import": {
+      "types": "./dist/es/index.d.ts",
+      "default": "./dist/es/index.js"
+    }
   },
   "engines": {
     "node": ">=14.0.0"
@@ -75,7 +80,7 @@
     "rollup": "^4.0.0-24",
     "typescript": "^4.8.3"
   },
-  "types": "./types/index.d.ts",
+  "types": "./dist/cjs/index.d.ts",
   "ava": {
     "extensions": [
       "ts"

--- a/packages/replace/package.json
+++ b/packages/replace/package.json
@@ -13,12 +13,18 @@
   "author": "Rich Harris <richard.a.harris@gmail.com>",
   "homepage": "https://github.com/rollup/plugins/tree/master/packages/replace#readme",
   "bugs": "https://github.com/rollup/plugins/issues",
-  "main": "dist/cjs/index.js",
-  "module": "dist/es/index.js",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/es/index.js",
+  "type": "commonjs",
   "exports": {
-    "types": "./types/index.d.ts",
-    "import": "./dist/es/index.js",
-    "default": "./dist/cjs/index.js"
+    "require": {
+      "types": "./dist/cjs/index.d.ts",
+      "default": "./dist/cjs/index.js"
+    },
+    "import": {
+      "types": "./dist/es/index.d.ts",
+      "default": "./dist/es/index.js"
+    }
   },
   "engines": {
     "node": ">=14.0.0"
@@ -72,7 +78,7 @@
     "source-map": "^0.7.4",
     "typescript": "^4.8.3"
   },
-  "types": "./types/index.d.ts",
+  "types": "./dist/cjs/index.d.ts",
   "ava": {
     "workerThreads": false,
     "files": [

--- a/packages/run/package.json
+++ b/packages/run/package.json
@@ -15,10 +15,16 @@
   "bugs": "https://github.com/rollup/plugins/issues",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
+  "type": "commonjs",
   "exports": {
-    "types": "./types/index.d.ts",
-    "import": "./dist/es/index.js",
-    "default": "./dist/cjs/index.js"
+    "require": {
+      "types": "./dist/cjs/index.d.ts",
+      "default": "./dist/cjs/index.js"
+    },
+    "import": {
+      "types": "./dist/es/index.d.ts",
+      "default": "./dist/es/index.js"
+    }
   },
   "engines": {
     "node": ">=14.0.0"
@@ -66,7 +72,7 @@
     "sinon": "^14.0.0",
     "typescript": "^4.8.3"
   },
-  "types": "./types/index.d.ts",
+  "types": "./dist/cjs/index.d.ts",
   "ava": {
     "workerThreads": false,
     "files": [

--- a/packages/strip/package.json
+++ b/packages/strip/package.json
@@ -15,10 +15,16 @@
   "bugs": "https://github.com/rollup/plugins/issues",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
+  "type": "commonjs",
   "exports": {
-    "types": "./types/index.d.ts",
-    "import": "./dist/es/index.js",
-    "default": "./dist/cjs/index.js"
+    "require": {
+      "types": "./dist/cjs/index.d.ts",
+      "default": "./dist/cjs/index.js"
+    },
+    "import": {
+      "types": "./dist/es/index.d.ts",
+      "default": "./dist/es/index.js"
+    }
   },
   "engines": {
     "node": ">=14.0.0"
@@ -63,7 +69,7 @@
     "acorn": "^8.8.0",
     "rollup": "^4.0.0-24"
   },
-  "types": "./types/index.d.ts",
+  "types": "./dist/cjs/index.d.ts",
   "ava": {
     "files": [
       "!**/fixtures/**",

--- a/packages/sucrase/package.json
+++ b/packages/sucrase/package.json
@@ -17,9 +17,14 @@
   "module": "./dist/es/index.js",
   "type": "commonjs",
   "exports": {
-    "types": "./types/index.d.ts",
-    "import": "./dist/es/index.js",
-    "default": "./dist/cjs/index.js"
+    "require": {
+      "types": "./dist/cjs/index.d.ts",
+      "default": "./dist/cjs/index.js"
+    },
+    "import": {
+      "types": "./dist/es/index.d.ts",
+      "default": "./dist/es/index.js"
+    }
   },
   "engines": {
     "node": ">=14.0.0"
@@ -69,7 +74,7 @@
     "@rollup/plugin-alias": "^4.0.0",
     "rollup": "^4.0.0-24"
   },
-  "types": "./types/index.d.ts",
+  "types": "./dist/cjs/index.d.ts",
   "ava": {
     "workerThreads": false,
     "files": [

--- a/packages/swc/package.json
+++ b/packages/swc/package.json
@@ -13,12 +13,18 @@
   "author": "Peter Placzek <peter.placzek1996@gmail.com>",
   "homepage": "https://github.com/rollup/plugins/tree/master/packages/swc#readme",
   "bugs": "https://github.com/rollup/plugins/issues",
-  "main": "dist/cjs/index.js",
-  "module": "dist/es/index.js",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/es/index.js",
+  "type": "commonjs",
   "exports": {
-    "types": "./types/index.d.ts",
-    "import": "./dist/es/index.js",
-    "default": "./dist/cjs/index.js"
+    "require": {
+      "types": "./dist/cjs/index.d.ts",
+      "default": "./dist/cjs/index.js"
+    },
+    "import": {
+      "types": "./dist/es/index.d.ts",
+      "default": "./dist/es/index.js"
+    }
   },
   "engines": {
     "node": ">=14.0.0"
@@ -70,5 +76,5 @@
     "rollup": "^4.0.0-24",
     "typescript": "^4.8.3"
   },
-  "types": "./types/index.d.ts"
+  "types": "./dist/cjs/index.d.ts"
 }

--- a/packages/terser/package.json
+++ b/packages/terser/package.json
@@ -13,12 +13,18 @@
   "author": "Peter Placzek <peter.placzek1996@gmail.com>",
   "homepage": "https://github.com/rollup/plugins/tree/master/packages/terser#readme",
   "bugs": "https://github.com/rollup/plugins/issues",
-  "main": "dist/cjs/index.js",
-  "module": "dist/es/index.js",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/es/index.js",
+  "type": "commonjs",
   "exports": {
-    "types": "./types/index.d.ts",
-    "import": "./dist/es/index.js",
-    "default": "./dist/cjs/index.js"
+    "require": {
+      "types": "./dist/cjs/index.d.ts",
+      "default": "./dist/cjs/index.js"
+    },
+    "import": {
+      "types": "./dist/es/index.d.ts",
+      "default": "./dist/es/index.js"
+    }
   },
   "engines": {
     "node": ">=14.0.0"
@@ -70,5 +76,5 @@
     "rollup": "^4.0.0-24",
     "typescript": "^4.8.3"
   },
-  "types": "./types/index.d.ts"
+  "types": "./dist/cjs/index.d.ts"
 }

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -15,10 +15,16 @@
   "bugs": "https://github.com/rollup/plugins/issues",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
+  "type": "commonjs",
   "exports": {
-    "types": "./types/index.d.ts",
-    "import": "./dist/es/index.js",
-    "default": "./dist/cjs/index.js"
+    "require": {
+      "types": "./dist/cjs/index.d.ts",
+      "default": "./dist/cjs/index.js"
+    },
+    "import": {
+      "types": "./dist/es/index.d.ts",
+      "default": "./dist/es/index.js"
+    }
   },
   "engines": {
     "node": ">=14.0.0"
@@ -76,5 +82,5 @@
     "rollup": "^4.0.0-24",
     "typescript": "^4.8.3"
   },
-  "types": "./types/index.d.ts"
+  "types": "./dist/cjs/index.d.ts"
 }

--- a/packages/url/package.json
+++ b/packages/url/package.json
@@ -15,10 +15,16 @@
   "bugs": "https://github.com/rollup/plugins/issues",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
+  "type": "commonjs",
   "exports": {
-    "types": "./types/index.d.ts",
-    "import": "./dist/es/index.js",
-    "default": "./dist/cjs/index.js"
+    "require": {
+      "types": "./dist/cjs/index.d.ts",
+      "default": "./dist/cjs/index.js"
+    },
+    "import": {
+      "types": "./dist/es/index.d.ts",
+      "default": "./dist/es/index.js"
+    }
   },
   "engines": {
     "node": ">=14.0.0"
@@ -66,7 +72,7 @@
     "globby": "^11.1.0",
     "rollup": "^4.0.0-24"
   },
-  "types": "./types/index.d.ts",
+  "types": "./dist/cjs/index.d.ts",
   "ava": {
     "workerThreads": false,
     "files": [

--- a/packages/virtual/package.json
+++ b/packages/virtual/package.json
@@ -15,10 +15,16 @@
   "bugs": "https://github.com/rollup/plugins/issues",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
+  "type": "commonjs",
   "exports": {
-    "types": "./types/index.d.ts",
-    "import": "./dist/es/index.js",
-    "default": "./dist/cjs/index.js"
+    "require": {
+      "types": "./dist/cjs/index.d.ts",
+      "default": "./dist/cjs/index.js"
+    },
+    "import": {
+      "types": "./dist/es/index.d.ts",
+      "default": "./dist/es/index.js"
+    }
   },
   "engines": {
     "node": ">=14.0.0"
@@ -66,7 +72,7 @@
     "rollup": "^4.0.0-24",
     "typescript": "^4.8.3"
   },
-  "types": "./types/index.d.ts",
+  "types": "./dist/cjs/index.d.ts",
   "ava": {
     "files": [
       "!**/fixtures/**",

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -15,10 +15,16 @@
   "bugs": "https://github.com/rollup/plugins/issues",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
+  "type": "commonjs",
   "exports": {
-    "types": "./types/index.d.ts",
-    "import": "./dist/es/index.js",
-    "default": "./dist/cjs/index.js"
+    "require": {
+      "types": "./dist/cjs/index.d.ts",
+      "default": "./dist/cjs/index.js"
+    },
+    "import": {
+      "types": "./dist/es/index.d.ts",
+      "default": "./dist/es/index.js"
+    }
   },
   "engines": {
     "node": ">=14.0.0"
@@ -72,7 +78,7 @@
     "source-map": "^0.7.4",
     "typescript": "^4.8.3"
   },
-  "types": "./types/index.d.ts",
+  "types": "./dist/cjs/index.d.ts",
   "ava": {
     "workerThreads": false,
     "files": [

--- a/packages/yaml/package.json
+++ b/packages/yaml/package.json
@@ -15,10 +15,16 @@
   "bugs": "https://github.com/rollup/plugins/issues",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
+  "type": "commonjs",
   "exports": {
-    "types": "./types/index.d.ts",
-    "import": "./dist/es/index.js",
-    "default": "./dist/cjs/index.js"
+    "require": {
+      "types": "./dist/cjs/index.d.ts",
+      "default": "./dist/cjs/index.js"
+    },
+    "import": {
+      "types": "./dist/es/index.d.ts",
+      "default": "./dist/es/index.js"
+    }
   },
   "engines": {
     "node": ">=14.0.0"
@@ -67,7 +73,7 @@
     "rollup": "^4.0.0-24",
     "source-map-support": "^0.5.21"
   },
-  "types": "./types/index.d.ts",
+  "types": "./dist/cjs/index.d.ts",
   "ava": {
     "workerThreads": false,
     "files": [


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `all (except Beep)`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:
resolves #1541, #1578 
supersedes #1744 

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

As soon as you start using `"moduleResolution": "Node16"` (or `"NodeNext"`) in `tsconfig.json`, TypeScript complains that the default export for the plugins in this repo _"is not callable"_ because it _"has no call signatures"_.

This PR fixes this by providing each package with distinct typings for the ESM build and the CJS build. It is a follow-up of the work @danielbayley started on #1744.

@shellscape > this passes all the current tests. However, given your past comment [here](https://github.com/rollup/plugins/pull/1744#issuecomment-2198411407), I think you'd prefer some specific tests to be added... Could you please just put me on the right track for this?
