### PR TITLE
fix(typescript): allow for files to be nested in folders within outDir

### DIFF
--- a/packages/typescript/src/options/validate.ts
+++ b/packages/typescript/src/options/validate.ts
@@ -58,13 +58,16 @@ export function validatePaths(
   for (const dirProperty of DIRECTORY_PROPS) {
     if (compilerOptions[dirProperty] && outputDir) {
       // Checks if the given path lies within Rollup output dir
-      const fromRollupDirToTs = relative(outputDir, compilerOptions[dirProperty]!);
-      if (fromRollupDirToTs.startsWith('..')) {
-        if (outputOptions.dir) {
+      if (outputOptions.dir) {
+        const fromRollupDirToTs = relative(outputDir, compilerOptions[dirProperty]!);
+        if (fromRollupDirToTs.startsWith('..')) {
           context.error(
             `@rollup/plugin-typescript: Path of Typescript compiler option '${dirProperty}' must be located inside Rollup 'dir' option.`
           );
-        } else {
+        }
+      } else {
+        const fromTsDirToRollup = relative(compilerOptions[dirProperty]!, outputDir);
+        if (fromTsDirToRollup.startsWith('..')) {
           context.error(
             `@rollup/plugin-typescript: Path of Typescript compiler option '${dirProperty}' must be located inside the same directory as the Rollup 'file' option.`
           );

--- a/packages/typescript/test/test.js
+++ b/packages/typescript/test/test.js
@@ -129,6 +129,36 @@ test.serial(
   }
 );
 
+test.serial(
+  'ensures output files can be written to subdirectories within the tsconfig outDir',
+  async (t) => {
+    const warnings = [];
+    const outputOpts = { format: 'es', file: 'fixtures/basic/dist/esm/main.js' };
+    const bundle = await rollup({
+      input: 'fixtures/basic/main.ts',
+      output: outputOpts,
+      plugins: [
+        typescript({
+          tsconfig: 'fixtures/basic/tsconfig.json',
+          outDir: 'fixtures/basic/dist'
+        })
+      ],
+      onwarn(warning) {
+        warnings.push(warning);
+      }
+    });
+
+    // This should not throw an error
+    const output = await getFiles(bundle, outputOpts);
+
+    t.deepEqual(
+      output.map((out) => out.fileName),
+      ['fixtures/basic/dist/esm/main.js']
+    );
+    t.is(warnings.length, 0);
+  }
+);
+
 test.serial('ensures multiple outputs can be built', async (t) => {
   // In a rollup.config.js we would pass an array
   // The rollup method that's exported as a library won't do that so we must make two calls


### PR DESCRIPTION
## Rollup Plugin Name: `typescript`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no


### Description

This change corrects a regression introduced by #1728, preventing dual bundle configs from writing output files to directories nested within the directory defined in the tsconfig's outDir property.

Example:
```js
export default {
  input: 'src/index.ts', 
  output: [
    {
      file: 'dist/cjs/index.cjs',
      format: 'cjs',
    },
    {
      file: 'dist/esm/index.mjs',
      format: 'esm',
    }
  ],
  plugins: [
    typescript({
      tsconfig: 'tsconfig.json',
      compilerOptions: {
        outDir: 'dist'
      }
    })
  ],
};
```

Fixes #1773 
