### PR TITLE
fix(pluginutils): upgrade picomatch

### DIFF
--- a/packages/pluginutils/package.json
+++ b/packages/pluginutils/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@types/estree": "^1.0.0",
     "estree-walker": "^2.0.2",
-    "picomatch": "^2.3.1"
+    "picomatch": "^4.0.2"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^23.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -382,7 +382,7 @@ importers:
         version: 4.0.0-24
       rollup-plugin-postcss:
         specifier: ^4.0.2
-        version: 4.0.2(postcss@8.4.17)(ts-node@10.9.1(@swc/core@1.3.78)(@types/node@14.18.31)(typescript@4.8.4))
+        version: 4.0.2(postcss@8.4.17)(ts-node@10.9.1(@swc/core@1.3.78)(@types/node@14.18.30)(typescript@4.8.4))
       typescript:
         specifier: ^4.8.3
         version: 4.8.4
@@ -537,8 +537,8 @@ importers:
         specifier: ^2.0.2
         version: 2.0.2
       picomatch:
-        specifier: ^2.3.1
-        version: 2.3.1
+        specifier: ^4.0.2
+        version: 4.0.2
     devDependencies:
       '@rollup/plugin-commonjs':
         specifier: ^23.0.0
@@ -7963,13 +7963,13 @@ snapshots:
     dependencies:
       postcss: 8.4.17
 
-  postcss-load-config@3.1.4(postcss@8.4.17)(ts-node@10.9.1(@swc/core@1.3.78)(@types/node@14.18.31)(typescript@4.8.4)):
+  postcss-load-config@3.1.4(postcss@8.4.17)(ts-node@10.9.1(@swc/core@1.3.78)(@types/node@14.18.30)(typescript@4.8.4)):
     dependencies:
       lilconfig: 2.0.6
       yaml: 1.10.2
     optionalDependencies:
       postcss: 8.4.17
-      ts-node: 10.9.1(@swc/core@1.3.78)(@types/node@14.18.31)(typescript@4.8.4)
+      ts-node: 10.9.1(@swc/core@1.3.78)(@types/node@14.18.30)(typescript@4.8.4)
 
   postcss-merge-longhand@5.1.6(postcss@8.4.17):
     dependencies:
@@ -8313,7 +8313,7 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
-  rollup-plugin-postcss@4.0.2(postcss@8.4.17)(ts-node@10.9.1(@swc/core@1.3.78)(@types/node@14.18.31)(typescript@4.8.4)):
+  rollup-plugin-postcss@4.0.2(postcss@8.4.17)(ts-node@10.9.1(@swc/core@1.3.78)(@types/node@14.18.30)(typescript@4.8.4)):
     dependencies:
       chalk: 4.1.2
       concat-with-sourcemaps: 1.1.0
@@ -8322,7 +8322,7 @@ snapshots:
       p-queue: 6.6.2
       pify: 5.0.0
       postcss: 8.4.17
-      postcss-load-config: 3.1.4(postcss@8.4.17)(ts-node@10.9.1(@swc/core@1.3.78)(@types/node@14.18.31)(typescript@4.8.4))
+      postcss-load-config: 3.1.4(postcss@8.4.17)(ts-node@10.9.1(@swc/core@1.3.78)(@types/node@14.18.30)(typescript@4.8.4))
       postcss-modules: 4.3.1(postcss@8.4.17)
       promise.series: 0.2.0
       resolve: 1.22.1
@@ -8680,27 +8680,6 @@ snapshots:
       yn: 3.1.1
     optionalDependencies:
       '@swc/core': 1.3.78
-
-  ts-node@10.9.1(@swc/core@1.3.78)(@types/node@14.18.31)(typescript@4.8.4):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.9
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.3
-      '@types/node': 14.18.31
-      acorn: 8.8.0
-      acorn-walk: 8.2.0
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 4.8.4
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optionalDependencies:
-      '@swc/core': 1.3.78
-    optional: true
 
   tsconfig-paths@3.14.1:
     dependencies:


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `pluginutils`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

This PR upgrades picomatch used by pluginutils.
The only breaking change from 2.3.1 to 4.0.2 was the Node.js support range bump (from 8.6+ to 12+). pluginutils only support Node 14+, so this should be fine.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
