### PR TITLE
chore(dynamic-import-vars): revert 2.1.4 changes

### DIFF
--- a/packages/dynamic-import-vars/package.json
+++ b/packages/dynamic-import-vars/package.json
@@ -66,8 +66,8 @@
     "@rollup/pluginutils": "^5.0.1",
     "astring": "^1.8.5",
     "estree-walker": "^2.0.2",
-    "magic-string": "^0.30.3",
-    "tinyglobby": "^0.2.8"
+    "fast-glob": "^3.2.12",
+    "magic-string": "^0.30.3"
   },
   "devDependencies": {
     "acorn": "^8.8.0",

--- a/packages/dynamic-import-vars/src/dynamic-import-to-glob.js
+++ b/packages/dynamic-import-vars/src/dynamic-import-to-glob.js
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import { escapePath } from 'tinyglobby';
+import fastGlob from 'fast-glob';
 
 export class VariableDynamicImportError extends Error {}
 
@@ -12,7 +12,7 @@ function sanitizeString(str) {
   if (str.includes('*')) {
     throw new VariableDynamicImportError('A dynamic import cannot contain * characters.');
   }
-  return escapePath(str);
+  return fastGlob.escapePath(str);
 }
 
 function templateLiteralToGlob(node) {

--- a/packages/dynamic-import-vars/src/index.js
+++ b/packages/dynamic-import-vars/src/index.js
@@ -2,7 +2,7 @@ import path from 'path';
 
 import { walk } from 'estree-walker';
 import MagicString from 'magic-string';
-import { globSync } from 'tinyglobby';
+import fastGlob from 'fast-glob';
 import { generate } from 'astring';
 
 import { createFilter } from '@rollup/pluginutils';
@@ -50,7 +50,7 @@ function dynamicImportVariables({ include, exclude, warnOnError, errorWhenNoFile
             }
 
             // execute the glob
-            const result = globSync(glob, { cwd: path.dirname(id), expandDirectories: false });
+            const result = fastGlob.sync(glob, { cwd: path.dirname(id) });
             const paths = result.map((r) =>
               r.startsWith('./') || r.startsWith('../') ? r : `./${r}`
             );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -295,12 +295,12 @@ importers:
       estree-walker:
         specifier: ^2.0.2
         version: 2.0.2
+      fast-glob:
+        specifier: ^3.2.12
+        version: 3.2.12
       magic-string:
         specifier: ^0.30.3
         version: 0.30.3
-      tinyglobby:
-        specifier: ^0.2.8
-        version: 0.2.8
     devDependencies:
       acorn:
         specifier: ^8.8.0
@@ -2731,14 +2731,6 @@ packages:
       picomatch:
         optional: true
 
-  fdir@6.4.0:
-    resolution: {integrity: sha512-3oB133prH1o4j/L5lLW7uOCF1PlD+/It2L0eL/iAqWMB91RBbqTewABqxhj0ibBd90EEmWZq7ntIWzVaWcXTGQ==}
-    peerDependencies:
-      picomatch: ^3 || ^4
-    peerDependenciesMeta:
-      picomatch:
-        optional: true
-
   figures@4.0.1:
     resolution: {integrity: sha512-rElJwkA/xS04Vfg+CaZodpso7VqBknOYbzi6I76hI4X80RUjkSxO2oAyPmGbuXUppywjqndOrQDl817hDnI++w==}
     engines: {node: '>=12'}
@@ -4414,10 +4406,6 @@ packages:
   time-zone@1.0.0:
     resolution: {integrity: sha512-TIsDdtKo6+XrPtiTm1ssmMngN1sAhyKnTO2kunQWqNPWIVvCm15Wmw4SWInwTVgJ5u/Tr04+8Ei9TNcw4x4ONA==}
     engines: {node: '>=4'}
-
-  tinyglobby@0.2.8:
-    resolution: {integrity: sha512-AMLZywN0vbhiZi2neFEaj9VIIxC+PjDMsp0nAK6tpR86LJavZgHqGz0S/FOONwBygC+mu7R0/TyAQw0gx0Mu9Q==}
-    engines: {node: '>=12.0.0'}
 
   to-fast-properties@2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
@@ -6979,10 +6967,6 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.2
 
-  fdir@6.4.0(picomatch@4.0.2):
-    optionalDependencies:
-      picomatch: 4.0.2
-
   figures@4.0.1:
     dependencies:
       escape-string-regexp: 5.0.0
@@ -8641,11 +8625,6 @@ snapshots:
   through@2.3.8: {}
 
   time-zone@1.0.0: {}
-
-  tinyglobby@0.2.8:
-    dependencies:
-      fdir: 6.4.0(picomatch@4.0.2)
-      picomatch: 4.0.2
 
   to-fast-properties@2.0.0: {}
 


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `{name}`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

This reverts #1780 after the move to tinyglobby introduced a breaking change to normalized paths. See #1791 for more information.