### PR TITLE
fix(typescript): path validation issue in validatePaths function

### DIFF
--- a/packages/typescript/src/options/validate.ts
+++ b/packages/typescript/src/options/validate.ts
@@ -66,7 +66,7 @@ export function validatePaths(
           );
         }
       } else if(dirProperty === 'outDir') {
-        const fromTsDirToRollup = relative(compilerOptions[dirProperty],outputDir);
+        const fromTsDirToRollup = relative(compilerOptions[dirProperty]!,outputDir);
         if (fromTsDirToRollup.startsWith('..')) {
             context.error(`@rollup/plugin-typescript: Path of Typescript compiler option '${dirProperty}' must be located inside the same directory as the Rollup 'file' option.`);
         }

--- a/packages/typescript/src/options/validate.ts
+++ b/packages/typescript/src/options/validate.ts
@@ -65,6 +65,11 @@ export function validatePaths(
             `@rollup/plugin-typescript: Path of Typescript compiler option '${dirProperty}' must be located inside Rollup 'dir' option.`
           );
         }
+      } else if(dirProperty === 'outDir') {
+        const fromTsDirToRollup = relative(compilerOptions[dirProperty],outputDir);
+        if (fromTsDirToRollup.startsWith('..')) {
+            context.error(`@rollup/plugin-typescript: Path of Typescript compiler option '${dirProperty}' must be located inside the same directory as the Rollup 'file' option.`);
+        }
       } else {
         const fromTsDirToRollup = relative(outputDir, compilerOptions[dirProperty]!);
         if (fromTsDirToRollup.startsWith('..')) {

--- a/packages/typescript/src/options/validate.ts
+++ b/packages/typescript/src/options/validate.ts
@@ -66,7 +66,7 @@ export function validatePaths(
           );
         }
       } else {
-        const fromTsDirToRollup = relative(compilerOptions[dirProperty]!, outputDir);
+        const fromTsDirToRollup = relative(outputDir, compilerOptions[dirProperty]!);
         if (fromTsDirToRollup.startsWith('..')) {
           context.error(
             `@rollup/plugin-typescript: Path of Typescript compiler option '${dirProperty}' must be located inside the same directory as the Rollup 'file' option.`

--- a/packages/typescript/src/options/validate.ts
+++ b/packages/typescript/src/options/validate.ts
@@ -65,10 +65,12 @@ export function validatePaths(
             `@rollup/plugin-typescript: Path of Typescript compiler option '${dirProperty}' must be located inside Rollup 'dir' option.`
           );
         }
-      } else if(dirProperty === 'outDir') {
-        const fromTsDirToRollup = relative(compilerOptions[dirProperty]!,outputDir);
+      } else if (dirProperty === 'outDir') {
+        const fromTsDirToRollup = relative(compilerOptions[dirProperty]!, outputDir);
         if (fromTsDirToRollup.startsWith('..')) {
-            context.error(`@rollup/plugin-typescript: Path of Typescript compiler option '${dirProperty}' must be located inside the same directory as the Rollup 'file' option.`);
+          context.error(
+            `@rollup/plugin-typescript: Path of Typescript compiler option '${dirProperty}' must be located inside the same directory as the Rollup 'file' option.`
+          );
         }
       } else {
         const fromTsDirToRollup = relative(outputDir, compilerOptions[dirProperty]!);

--- a/packages/typescript/test/test.js
+++ b/packages/typescript/test/test.js
@@ -130,6 +130,28 @@ test.serial(
 );
 
 test.serial(
+  'ensures declarationDir is allowed in Rollup output directory when output.file is used',
+  async (t) => {
+    const bundle = await rollup({
+      input: 'fixtures/basic/main.ts',
+      plugins: [
+        typescript({
+          tsconfig: 'fixtures/basic/tsconfig.json',
+          declarationDir: 'fixtures/basic/dist/other',
+          declaration: true
+        })
+      ],
+      onwarn
+    });
+
+    // this should not throw an error
+    await t.notThrowsAsync(() =>
+      getCode(bundle, { format: 'es', file: 'fixtures/basic/dist/index.js' }, true)
+    );
+  }
+);
+
+test.serial(
   'ensures output files can be written to subdirectories within the tsconfig outDir',
   async (t) => {
     const warnings = [];


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `@rollup/plugin-typescript`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

 resolves #1790

### Description

In the @rollup/plugin-typescript plugin, current code allows paths that are below the 'file' option but not nested directories. For example if file option is set to "C:/examplelib/output" directory, then "C:/examplelib" is fine while "C:/examplelib/output/decl" is not. The order change in this commit fixes this issue introduced in 12.1.1.