### PR TITLE
fix(replace): add missing objectGuards option to RollupReplaceOptions

### DIFF
--- a/packages/replace/types/index.d.ts
+++ b/packages/replace/types/index.d.ts
@@ -24,6 +24,12 @@ export interface RollupReplaceOptions {
    */
   exclude?: FilterPattern;
   /**
+   * When replacing dot-separated object properties like `process.env.NODE_ENV`,
+   * will also replace `typeof process` object guard checks against the objects
+   * with the string `"object"`
+   */
+  objectGuards?: boolean;
+  /**
    * If false, skips source map generation. This will improve performance.
    * @default true
    */


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `replace`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_) `Only the type definitions were modified, so testing is not added`
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers: https://github.com/rollup/plugins/pull/1764#issuecomment-2492251956

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

Add missing objectGuards option to RollupReplaceOptions