### PR TITLE
fix(replace): add missing types for `objectGuards` option

### DIFF
--- a/packages/replace/test/types.ts
+++ b/packages/replace/test/types.ts
@@ -16,6 +16,7 @@ const config: RollupOptions = {
       include: 'config.js',
       exclude: 'node_modules/**',
       delimiters: ['<@', '@>'],
+      objectGuards: true,
       preventAssignment: true,
       VERSION: '1.0.0',
       ENVIRONMENT: JSON.stringify('development'),

--- a/packages/replace/types/index.d.ts
+++ b/packages/replace/types/index.d.ts
@@ -12,6 +12,7 @@ export interface RollupReplaceOptions {
     | Replacement
     | RollupReplaceOptions['include']
     | RollupReplaceOptions['values']
+    | RollupReplaceOptions['objectGuards']
     | RollupReplaceOptions['preventAssignment'];
 
   /**
@@ -33,6 +34,12 @@ export interface RollupReplaceOptions {
    * of `foo`, supply delimiters
    */
   delimiters?: [string, string];
+  /**
+   * When replacing dot-separated object properties like `process.env.NODE_ENV`,
+   * will also replace `typeof process` object guard checks against the objects
+   * with the string `"object"`.
+   */
+  objectGuards?: boolean;
   /**
    * Prevents replacing strings where they are followed by a single equals
    * sign.


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `@rollup/replace`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

Adds types for `objectGuards` which were missed in PR #1084.