### PR TITLE
feat(node-resolve)!: set development or production condition

### DIFF
--- a/packages/node-resolve/README.md
+++ b/packages/node-resolve/README.md
@@ -53,7 +53,7 @@ This plugin supports the package entrypoints feature from node js, specified in 
 Type: `Array[...String]`<br>
 Default: `[]`
 
-Additional conditions of the package.json exports field to match when resolving modules. By default, this plugin looks for the `['default', 'module', 'import']` conditions when resolving imports.
+Additional conditions of the package.json exports field to match when resolving modules. By default, this plugin looks for the `['default', 'module', 'import', 'development|production']` conditions when resolving imports. If neither the `development` or `production` conditions are provided it will default to `production` - or `development` if `NODE_ENV` is set to a value other than `production`.
 
 When using `@rollup/plugin-commonjs` v16 or higher, this plugin will use the `['default', 'module', 'require']` conditions when resolving require statements.
 

--- a/packages/node-resolve/test/fixtures/dev-prod-conditions.js
+++ b/packages/node-resolve/test/fixtures/dev-prod-conditions.js
@@ -1,0 +1,3 @@
+import mode from 'dev-prod-conditions';
+
+export default mode;

--- a/packages/node-resolve/test/fixtures/node_modules/dev-prod-conditions/dev.js
+++ b/packages/node-resolve/test/fixtures/node_modules/dev-prod-conditions/dev.js
@@ -1,0 +1,1 @@
+export default 'DEV'

--- a/packages/node-resolve/test/fixtures/node_modules/dev-prod-conditions/index.js
+++ b/packages/node-resolve/test/fixtures/node_modules/dev-prod-conditions/index.js
@@ -1,0 +1,1 @@
+export default 'PROD'

--- a/packages/node-resolve/test/fixtures/node_modules/dev-prod-conditions/package.json
+++ b/packages/node-resolve/test/fixtures/node_modules/dev-prod-conditions/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "dev-prod-conditions",
+	"type": "module",
+	"exports": {
+		"development": "./dev.js",
+		"default": "./index.js"
+	}
+}

--- a/packages/node-resolve/test/package-entry-points.js
+++ b/packages/node-resolve/test/package-entry-points.js
@@ -413,3 +413,13 @@ test('custom condition takes precedence over browser field with `browser: true`'
 
   t.deepEqual(module.exports, 'FROM WEBWORKER CONDITION');
 });
+
+test('development condition is used when NODE_ENV is not production', async (t) => {
+  const bundle = await rollup({
+    input: 'dev-prod-conditions.js',
+    plugins: [nodeResolve()]
+  });
+  const { module } = await testBundle(t, bundle);
+
+  t.deepEqual(module.exports, 'DEV');
+});


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `@rollup/plugin-node-resolve`

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [x] yes  - while hopefully no one is relying on having development code in their production bundle, it's a breaking change strictly speaking
- [ ] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

closes https://github.com/rollup/plugins/issues/1819
<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
Ensure that `development` or `production` is always set in `conditions`