### PR TITLE
fix(node-resolve): add `ignoreSideEffectsForRoot` to exported interface

### DIFF
--- a/packages/node-resolve/README.md
+++ b/packages/node-resolve/README.md
@@ -181,6 +181,9 @@ rootDir: path.join(process.cwd(), '..')
 
 ### `ignoreSideEffectsForRoot`
 
+Type: `Boolean`<br>
+Default: `false`
+
 If you use the `sideEffects` property in the package.json, by default this is respected for files in the root package. Set to `true` to ignore the `sideEffects` configuration for the root package.
 
 ### `allowExportsFolderMapping`

--- a/packages/node-resolve/types/index.d.ts
+++ b/packages/node-resolve/types/index.d.ts
@@ -100,6 +100,13 @@ export interface RollupNodeResolveOptions {
   rootDir?: string;
 
   /**
+   * If you use the `sideEffects` property in the package.json, by default this is respected for files in the root package. Set to `true` to ignore the `sideEffects` configuration for the root package.
+   *
+   * @default false
+   */
+  ignoreSideEffectsForRoot?: boolean;
+
+  /**
    * Allow folder mappings in package exports (trailing /)
    * This was deprecated in Node 14 and removed with Node 17, see DEP0148.
    * So this option might be changed to default to `false` in a future release.


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `@rollup/plugin-node-resolve`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

fix #1824

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
This PR supplies definitions of `ignoreSideEffectsForRoot` to the exported interface `RollupNodeResolveOptions `