### PR TITLE
fix(commonjs): crawl dynamicRequireRoot outside cwd

### DIFF
--- a/packages/commonjs/src/dynamic-modules.js
+++ b/packages/commonjs/src/dynamic-modules.js
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, statSync } from 'fs';
-import { join, resolve, dirname } from 'path';
+import { join, resolve, dirname, relative } from 'path';
 
 import getCommonDir from 'commondir';
 
@@ -46,7 +46,7 @@ export function getDynamicRequireModules(patterns, dynamicRequireRoot) {
       .withBasePath()
       .withDirs()
       .glob(isNegated ? pattern.substr(1) : pattern)
-      .crawl()
+      .crawl(relative('.', dynamicRequireRoot))
       .sync()
       .sort((a, b) => a.localeCompare(b, 'en'))) {
       const resolvedPath = resolve(path);

--- a/packages/commonjs/test/fixtures/samples/dynamic-require-root-outside-cwd/cwd/main.js
+++ b/packages/commonjs/test/fixtures/samples/dynamic-require-root-outside-cwd/cwd/main.js
@@ -1,0 +1,6 @@
+function takeModule(path) {
+  // eslint-disable-next-line global-require,import/no-dynamic-require
+  return require(path);
+}
+
+takeModule('../outer.js');

--- a/packages/commonjs/test/fixtures/samples/dynamic-require-root-outside-cwd/outer.js
+++ b/packages/commonjs/test/fixtures/samples/dynamic-require-root-outside-cwd/outer.js
@@ -1,0 +1,1 @@
+module.exports = 'outer_export_value';

--- a/packages/commonjs/test/test-dynamic-require-root-outside-cwd.js
+++ b/packages/commonjs/test/test-dynamic-require-root-outside-cwd.js
@@ -1,0 +1,23 @@
+const path = require('path');
+
+const test = require('ava');
+const { rollup } = require('rollup');
+
+const { commonjs } = require('./helpers/util.js');
+
+process.chdir(path.join(__dirname, 'fixtures/samples/dynamic-require-root-outside-cwd/cwd'));
+
+test('crawls dynamicRequireRoot outside cwd', async (t) => {
+  const build = await rollup({
+    input: 'main.js',
+    plugins: [
+      commonjs({
+        dynamicRequireRoot: '..',
+        dynamicRequireTargets: ['../outer.js']
+      })
+    ]
+  });
+  const bundle = await build.generate({ format: 'cjs' });
+  const { code } = bundle.output[0];
+  t.true(code.includes('outer_export_value'), 'outer_export_value not found in the code');
+});


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `{name}`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

resolves #1855 

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

After switching to fdir for globbing, it was no longer possible to have dynamicRequireTargets outside cwd as fdir only crawls cwd by default. dynamicRequireTargets outside cwd is often required when using npm workspaces as packages are hoisted to the node_modules in workspace root.
dynamicRequireRoot is passed to fdir's `crawl()` to fix this.