### PR TITLE
feat(pluginutils): add `exactRegex` and `prefixRegex`

### DIFF
--- a/packages/pluginutils/README.md
+++ b/packages/pluginutils/README.md
@@ -223,6 +223,22 @@ export default function myPlugin(options = {}) {
 }
 ```
 
+### exactRegex
+
+Constructs a RegExp that matches the exact string specified. This is useful for plugin hook filters.
+
+Parameters: `(str: String, flags?: String)`<br>
+Returns: `RegExp`
+
+#### Usage
+
+```js
+import { exactRegex } from '@rollup/pluginutils';
+
+exactRegex('foobar'); // /^foobar$/
+exactRegex('foo(bar)', 'i'); // /^foo\(bar\)$/i
+```
+
 ### makeLegalIdentifier
 
 Constructs a bundle-safe identifier from a `String`.
@@ -253,6 +269,22 @@ import { normalizePath } from '@rollup/pluginutils';
 
 normalizePath('foo\\bar'); // 'foo/bar'
 normalizePath('foo/bar'); // 'foo/bar'
+```
+
+### prefixRegex
+
+Constructs a RegExp that matches a value that has the specified prefix. This is useful for plugin hook filters.
+
+Parameters: `(str: String, flags?: String)`<br>
+Returns: `RegExp`
+
+#### Usage
+
+```js
+import { prefixRegex } from '@rollup/pluginutils';
+
+prefixRegex('foobar'); // /^foobar/
+prefixRegex('foo(bar)', 'i'); // /^foo\(bar\)/i
 ```
 
 ## Meta

--- a/packages/pluginutils/src/filterUtils.ts
+++ b/packages/pluginutils/src/filterUtils.ts
@@ -1,0 +1,12 @@
+export function exactRegex(str: string, flags?: string): RegExp {
+  return new RegExp(`^${escapeRegex(str)}$`, flags);
+}
+
+export function prefixRegex(str: string, flags?: string): RegExp {
+  return new RegExp(`^${escapeRegex(str)}`, flags);
+}
+
+const escapeRegexRE = /[-/\\^$*+?.()|[\]{}]/g;
+function escapeRegex(str: string): string {
+  return str.replace(escapeRegexRE, '\\$&');
+}

--- a/packages/pluginutils/src/index.ts
+++ b/packages/pluginutils/src/index.ts
@@ -5,15 +5,18 @@ import dataToEsm from './dataToEsm';
 import extractAssignedNames from './extractAssignedNames';
 import makeLegalIdentifier from './makeLegalIdentifier';
 import normalizePath from './normalizePath';
+import { exactRegex, prefixRegex } from './filterUtils';
 
 export {
   addExtension,
   attachScopes,
   createFilter,
   dataToEsm,
+  exactRegex,
   extractAssignedNames,
   makeLegalIdentifier,
-  normalizePath
+  normalizePath,
+  prefixRegex
 };
 
 // TODO: remove this in next major
@@ -22,7 +25,9 @@ export default {
   attachScopes,
   createFilter,
   dataToEsm,
+  exactRegex,
   extractAssignedNames,
   makeLegalIdentifier,
-  normalizePath
+  normalizePath,
+  prefixRegex
 };

--- a/packages/pluginutils/test/filterUtils.ts
+++ b/packages/pluginutils/test/filterUtils.ts
@@ -1,0 +1,27 @@
+import test from 'ava';
+
+import { exactRegex, prefixRegex } from '../';
+
+test('exactRegex supports without flag parameter', (t) => {
+  t.is(exactRegex('foo').toString(), '/^foo$/');
+});
+
+test('exactRegex supports with flag parameter', (t) => {
+  t.is(exactRegex('foo', 'i').toString(), '/^foo$/i');
+});
+
+test('exactRegex escapes special characters for Regex', (t) => {
+  t.is(exactRegex('foo(bar)').toString(), '/^foo\\(bar\\)$/');
+});
+
+test('prefixRegex supports without flag parameter', (t) => {
+  t.is(prefixRegex('foo').toString(), '/^foo/');
+});
+
+test('prefixRegex supports with flag parameter', (t) => {
+  t.is(prefixRegex('foo', 'i').toString(), '/^foo/i');
+});
+
+test('prefixRegex escapes special characters for Regex', (t) => {
+  t.is(prefixRegex('foo(bar)').toString(), '/^foo\\(bar\\)/');
+});

--- a/packages/pluginutils/types/index.d.ts
+++ b/packages/pluginutils/types/index.d.ts
@@ -63,6 +63,13 @@ export function createFilter(
 export function dataToEsm(data: unknown, options?: DataToEsmOptions): string;
 
 /**
+ * Constructs a RegExp that matches the exact string specified.
+ * @param str the string to match.
+ * @param flags flags for the RegExp.
+ */
+export function exactRegex(str: string, flags?: string): RegExp;
+
+/**
  * Extracts the names of all assignment targets based upon specified patterns.
  * @param param An `acorn` AST Node.
  */
@@ -78,21 +85,32 @@ export function makeLegalIdentifier(str: string): string;
  */
 export function normalizePath(filename: string): string;
 
+/**
+ * Constructs a RegExp that matches a value that has the specified prefix.
+ * @param str the string to match.
+ * @param flags flags for the RegExp.
+ */
+export function prefixRegex(str: string, flags?: string): RegExp;
+
 export type AddExtension = typeof addExtension;
 export type AttachScopes = typeof attachScopes;
 export type CreateFilter = typeof createFilter;
+export type ExactRegex = typeof exactRegex;
 export type ExtractAssignedNames = typeof extractAssignedNames;
 export type MakeLegalIdentifier = typeof makeLegalIdentifier;
 export type NormalizePath = typeof normalizePath;
 export type DataToEsm = typeof dataToEsm;
+export type PrefixRegex = typeof prefixRegex;
 
 declare const defaultExport: {
   addExtension: AddExtension;
   attachScopes: AttachScopes;
   createFilter: CreateFilter;
   dataToEsm: DataToEsm;
+  exactRegex: ExactRegex;
   extractAssignedNames: ExtractAssignedNames;
   makeLegalIdentifier: MakeLegalIdentifier;
   normalizePath: NormalizePath;
+  prefixRegex: PrefixRegex;
 };
 export default defaultExport;


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `{name}`

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

Rollup 4.38.0+ supports plugin hook filters. The id filter for `load` and `transform` supports glob (picomatch) patterns when a string is passed.
```js
const transformHandler = {
  filter: { id: '**/*.js' },
  handler() { /* omit */}
}
```
This is useful for many cases. However, since no reasonable semantic behavior can be defined for glob patterns against relative paths, `resolveId` does not support string values for the id filter (it still supports regex filters).

This PR adds `exactRegex` and `prefixRegex` so that it is easier to construct regexes that are commonly used for virtual modules.


<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
