### PR TITLE
fix(commonjs): fix crash with invalidated proxy modules

### DIFF
--- a/packages/commonjs/src/resolve-require-sources.js
+++ b/packages/commonjs/src/resolve-require-sources.js
@@ -141,7 +141,7 @@ export function getRequireResolver(extensions, detectCyclesAndConditional, curre
                 return (
                   (await getTypeForImportedModule(
                     (
-                      await this.load({ id: resolved.id })
+                      await this.load(resolved)
                     ).meta.commonjs.resolved,
                     this.load
                   )) !== IS_WRAPPED_COMMONJS


### PR DESCRIPTION
In watch mode when the code imports CommonJS from ESM, depending on the setup, it can happen that the ES to Commonjs proxy module is re-evaluated. If that happens, its meta information is lost, leading to a weird crash.

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `commonjs`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
I stumbled upon a case where in watch mode when changing a file, the CommonJS plugin would show a weird error. What happened is that a proxy module that was generated for a CommonJS from ESM import was being re-evaluated in its importer's `shouldTransformCachedModule` hook. Due to a small bug, the meta information of the proxy was lost, leading to a crash. This fixes it by supplying this meta information via loading the full resolved id object (that contains the meta information) instead of just using the id.