### PR TITLE
fix(node-resolve): error thrown with empty entry

### DIFF
--- a/packages/node-resolve/src/index.js
+++ b/packages/node-resolve/src/index.js
@@ -152,7 +152,7 @@ export function nodeResolve(opts = {}) {
 
     const importSpecifierList = [importee];
 
-    if (importer === undefined && !importee[0].match(/^\.?\.?\//)) {
+    if (importer === undefined && importee[0] && !importee[0].match(/^\.?\.?\//)) {
       // For module graph roots (i.e. when importer is undefined), we
       // need to handle 'path fragments` like `foo/bar` that are commonly
       // found in rollup config files. If importee doesn't look like a

--- a/packages/node-resolve/test/test.mjs
+++ b/packages/node-resolve/test/test.mjs
@@ -745,13 +745,13 @@ test('allow other plugins to take over resolution', async (t) => {
 });
 
 test('error message for invalid entry', async (t) => {
-  const error = await t.throwsAsync(() => rollup({
-    input: "",
-    onwarn: failOnWarn(t),
-    plugins: [
-      nodeResolve()
-    ]
-  }));
+  const error = await t.throwsAsync(() =>
+    rollup({
+      input: '',
+      onwarn: failOnWarn(t),
+      plugins: [nodeResolve()]
+    })
+  );
 
   t.is(error.message, `Could not resolve entry module "".`);
 });

--- a/packages/node-resolve/test/test.mjs
+++ b/packages/node-resolve/test/test.mjs
@@ -745,7 +745,7 @@ test('allow other plugins to take over resolution', async (t) => {
 });
 
 test('error message for invalid entry', async (t) => {
-  const error = await t.throwsAsync(async () => await rollup({
+  const error = await t.throwsAsync(() => rollup({
     input: "",
     onwarn: failOnWarn(t),
     plugins: [

--- a/packages/node-resolve/test/test.mjs
+++ b/packages/node-resolve/test/test.mjs
@@ -743,3 +743,15 @@ test('allow other plugins to take over resolution', async (t) => {
     ]
   });
 });
+
+test('error message for invalid entry', async (t) => {
+  const error = await t.throwsAsync(async () => await rollup({
+    input: "",
+    onwarn: failOnWarn(t),
+    plugins: [
+      nodeResolve()
+    ]
+  }));
+
+  t.is(error.message, `Could not resolve entry module "".`);
+});


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `node-resolve`

This PR contains:

- [X] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [X] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [X] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

This improves the error message displayed to the user when the entry is `""` and the `node-resolve` plugin is used.

Before this change, the node-resolve plugin throws an error when the entry is `""` that is not helpful for the user to understand the problem ( `Cannot read properties of undefined (reading \'match\')`). Contrastingly, when not using the node-resolve plugin, rollup's error message is helpful: `Could not resolve entry module "".`

This pull request avoids the node-resolve error so that the clearer error message is displayed to the user.