### PR TITLE
Support node16+ `moduleResolution` in ESM directories through named exports

### DIFF
--- a/packages/alias/README.md
+++ b/packages/alias/README.md
@@ -67,6 +67,13 @@ export default {
 };
 ```
 
+> [!NOTE]
+> If your editor complains that _"alias is not a function"_, then use the named export instead:
+>
+> ```js
+> import { alias } from '@rollup/plugin-alias';
+> ```
+
 Then call `rollup` either via the [CLI](https://www.rollupjs.org/guide/en/#command-line-reference) or the [API](https://www.rollupjs.org/guide/en/#javascript-api). If the build produces any errors, the plugin will write a 'alias' character to stderr, which should be audible on most systems.
 
 ## Options

--- a/packages/alias/src/index.ts
+++ b/packages/alias/src/index.ts
@@ -62,7 +62,7 @@ function resolveCustomResolver(
   return null;
 }
 
-export default function alias(options: RollupAliasOptions = {}): Plugin {
+function alias(options: RollupAliasOptions = {}): Plugin {
   const entries = getEntries(options);
 
   if (entries.length === 0) {
@@ -114,3 +114,4 @@ export default function alias(options: RollupAliasOptions = {}): Plugin {
     }
   };
 }
+export { alias, alias as default };

--- a/packages/alias/types/index.d.ts
+++ b/packages/alias/types/index.d.ts
@@ -41,4 +41,5 @@ export interface RollupAliasOptions {
 /**
  * 🍣 A Rollup plugin for defining aliases when bundling packages.
  */
-export default function alias(options?: RollupAliasOptions): Plugin;
+declare function alias(options?: RollupAliasOptions): Plugin;
+export { alias, alias as default };

--- a/packages/auto-install/README.md
+++ b/packages/auto-install/README.md
@@ -28,7 +28,7 @@ npm install @rollup/plugin-auto-install --save-dev
 Create a `rollup.config.js` [configuration file](https://www.rollupjs.org/guide/en/#configuration-files) and import the plugin:
 
 ```js
-import auto from '@rollup/plugin-auto-install';
+import autoInstall from '@rollup/plugin-auto-install';
 import resolve from '@rollup/plugin-node-resolve';
 
 export default {
@@ -37,11 +37,19 @@ export default {
     dir: 'output',
     format: 'cjs'
   },
-  plugins: [auto(), resolve()]
+  plugins: [autoInstall(), resolve()]
 };
 ```
 
-_Note: ensure that this plugin is added to the `plugins` array *before* [@rollup/plugin-node-resolve](https://github.com/rollup/plugins/tree/master/packages/node-resolve)._
+> [!NOTE]
+> If your editor complains that _"autoInstall is not a function"_, then use the named export instead:
+>
+> ```js
+> import { autoInstall } from '@rollup/plugin-auto-install';
+> ```
+
+> [!IMPORTANT]
+> Ensure that this plugin is added to the `plugins` array _before_ [@rollup/plugin-node-resolve](https://github.com/rollup/plugins/tree/master/packages/node-resolve).
 
 Then call `rollup` either via the [CLI](https://www.rollupjs.org/guide/en/#command-line-reference) or the [API](https://www.rollupjs.org/guide/en/#javascript-api).
 

--- a/packages/auto-install/src/index.ts
+++ b/packages/auto-install/src/index.ts
@@ -10,7 +10,7 @@ import type { RollupAutoInstallOptions } from '../types';
 
 const execAsync = promisify(exec);
 
-export default function autoInstall(opts: RollupAutoInstallOptions = {}): Plugin {
+function autoInstall(opts: RollupAutoInstallOptions = {}): Plugin {
   const defaults = {
     // intentionally undocumented options. used for tests
     commands: {
@@ -73,3 +73,4 @@ export default function autoInstall(opts: RollupAutoInstallOptions = {}): Plugin
     }
   };
 }
+export { autoInstall, autoInstall as default };

--- a/packages/auto-install/types/index.d.ts
+++ b/packages/auto-install/types/index.d.ts
@@ -19,4 +19,5 @@ export interface RollupAutoInstallOptions {
 /**
  * 🍣 A Rollup plugin which automatically installs dependencies that are imported by a bundle, even if not yet in `package.json`.
  */
-export default function auto(options?: RollupAutoInstallOptions): Plugin;
+declare function autoInstall(options?: RollupAutoInstallOptions): Plugin;
+export { autoInstall, autoInstall as default };

--- a/packages/babel/types/index.d.ts
+++ b/packages/babel/types/index.d.ts
@@ -129,5 +129,5 @@ export function createBabelOutputPluginFactory(
  * @param options - Plugin options.
  * @returns Plugin instance.
  */
-export function babel(options?: RollupBabelInputPluginOptions): Plugin;
-export default babel;
+declare function babel(options?: RollupBabelInputPluginOptions): Plugin;
+export { babel, babel as default };

--- a/packages/beep/README.md
+++ b/packages/beep/README.md
@@ -28,9 +28,9 @@ npm install @rollup/plugin-beep --save-dev
 Create a `rollup.config.js` [configuration file](https://www.rollupjs.org/guide/en/#configuration-files) and import the plugin:
 
 ```js
-const beep = require('@rollup/plugin-beep');
+import beep from '@rollup/plugin-beep';
 
-module.exports = {
+export default {
   input: 'src/index.js',
   output: {
     dir: 'output',
@@ -39,6 +39,13 @@ module.exports = {
   plugins: [beep()]
 };
 ```
+
+> [!NOTE]
+> If your editor complains that _"beep is not a function"_, then use the named export instead:
+>
+> ```javascript
+> import { alias } from '@rollup/plugin-alias';
+> ```
 
 Then call `rollup` either via the [CLI](https://www.rollupjs.org/guide/en/#command-line-reference) or the [API](https://www.rollupjs.org/guide/en/#javascript-api). If the build produces any errors, the plugin will write a "beep" character to stderr, which should be audible on most systems.
 

--- a/packages/beep/lib/index.js
+++ b/packages/beep/lib/index.js
@@ -15,3 +15,4 @@ const beep = (opts) => {
 };
 
 module.exports = beep;
+module.exports.beep = beep;

--- a/packages/beep/types/index.d.ts
+++ b/packages/beep/types/index.d.ts
@@ -3,4 +3,5 @@ import type { Plugin } from 'rollup';
 /**
  * 🍣 A Rollup plugin that beeps when a build ends with errors.
  */
-export default function beep(): Plugin;
+declare function beep(): Plugin;
+export { beep, beep as default };

--- a/packages/buble/README.md
+++ b/packages/buble/README.md
@@ -40,6 +40,13 @@ export default {
 };
 ```
 
+> [!NOTE]
+> If your editor complains that _"buble is not a function"_, then use the named export instead:
+>
+> ```js
+> import { buble } from '@rollup/plugin-buble';
+> ```
+
 Then call `rollup` either via the [CLI](https://www.rollupjs.org/guide/en/#command-line-reference) or the [API](https://www.rollupjs.org/guide/en/#javascript-api).
 
 ## Options

--- a/packages/buble/src/index.ts
+++ b/packages/buble/src/index.ts
@@ -4,7 +4,7 @@ import { createFilter } from '@rollup/pluginutils';
 
 import type { RollupBubleOptions } from '../types';
 
-export default function buble(options: RollupBubleOptions = {}): Plugin {
+export function buble(options: RollupBubleOptions = {}): Plugin {
   const filter = createFilter(options.include, options.exclude);
   const transformOptions = { ...options, transforms: { ...options.transforms, modules: false } };
 
@@ -26,3 +26,4 @@ export default function buble(options: RollupBubleOptions = {}): Plugin {
     }
   };
 }
+export default buble;

--- a/packages/buble/types/index.d.ts
+++ b/packages/buble/types/index.d.ts
@@ -17,4 +17,5 @@ export interface RollupBubleOptions extends TransformOptions {
 /**
  * Convert ES2015 with buble.
  */
-export default function buble(options?: RollupBubleOptions): Plugin;
+declare function buble(options?: RollupBubleOptions): Plugin;
+export { buble, buble as default };

--- a/packages/commonjs/README.md
+++ b/packages/commonjs/README.md
@@ -40,6 +40,13 @@ export default {
 };
 ```
 
+> [!NOTE]
+> If your editor complains that _"commonjs is not a function"_, then use the named export instead:
+>
+> ```js
+> import { commonjs } from '@rollup/plugin-commonjs';
+> ```
+
 Then call `rollup` either via the [CLI](https://www.rollupjs.org/guide/en/#command-line-reference) or the [API](https://www.rollupjs.org/guide/en/#javascript-api).
 
 When used together with the node-resolve plugin

--- a/packages/commonjs/src/index.js
+++ b/packages/commonjs/src/index.js
@@ -35,7 +35,7 @@ import { getName, getStrictRequiresFilter, normalizePathSlashes } from './utils'
 
 const PLUGIN_NAME = 'commonjs';
 
-export default function commonjs(options = {}) {
+export function commonjs(options = {}) {
   const {
     ignoreGlobal,
     ignoreDynamicRequires,
@@ -324,3 +324,4 @@ export default function commonjs(options = {}) {
     }
   };
 }
+export default commonjs;

--- a/packages/commonjs/types/index.d.ts
+++ b/packages/commonjs/types/index.d.ts
@@ -230,4 +230,5 @@ interface RollupCommonJSOptions {
 /**
  * Convert CommonJS modules to ES6, so they can be included in a Rollup bundle
  */
-export default function commonjs(options?: RollupCommonJSOptions): Plugin;
+declare function commonjs(options?: RollupCommonJSOptions): Plugin;
+export { commonjs, commonjs as default };

--- a/packages/data-uri/README.md
+++ b/packages/data-uri/README.md
@@ -30,7 +30,7 @@ Create a `rollup.config.js` [configuration file](https://www.rollupjs.org/guide/
 ```js
 import dataUri from '@rollup/plugin-data-uri';
 
-module.exports = {
+export default {
   input: 'src/index.js',
   output: {
     dir: 'output',
@@ -39,6 +39,13 @@ module.exports = {
   plugins: [dataUri()]
 };
 ```
+
+> [!NOTE]
+> If your editor complains that _"dataUri is not a function"_, then use the named export instead:
+>
+> ```js
+> import { dataUri } from '@rollup/plugin-data-uri';
+> ```
 
 Then call `rollup` either via the [CLI](https://www.rollupjs.org/guide/en/#command-line-reference) or the [API](https://www.rollupjs.org/guide/en/#javascript-api). If the build produces any errors, the plugin will write a "data-uri" character to stderr, which should be audible on most systems.
 

--- a/packages/data-uri/src/index.ts
+++ b/packages/data-uri/src/index.ts
@@ -10,7 +10,7 @@ const mimeTypes = {
   json: 'application/json'
 };
 
-export default function dataUri(): Plugin {
+export function dataUri(): Plugin {
   const resolved: { [key: string]: { mime: string | null; content: string | null } } = {};
 
   return {
@@ -84,3 +84,4 @@ export default function dataUri(): Plugin {
     }
   };
 }
+export default dataUri;

--- a/packages/data-uri/types/index.d.ts
+++ b/packages/data-uri/types/index.d.ts
@@ -3,4 +3,5 @@ import type { Plugin } from 'rollup';
 /**
  * A Rollup plugin which imports modules from Data URIs.
  */
-export default function dataUri(): Plugin;
+declare function dataUri(): Plugin;
+export { dataUri, dataUri as default };

--- a/packages/dsv/README.md
+++ b/packages/dsv/README.md
@@ -40,6 +40,13 @@ export default {
 };
 ```
 
+> [!NOTE]
+> If your editor complains that _"dsv is not a function"_, then use the named export instead:
+>
+> ```js
+> import { dsv } from '@rollup/plugin-dsv';
+> ```
+
 Then call `rollup` either via the [CLI](https://www.rollupjs.org/guide/en/#command-line-reference) or the [API](https://www.rollupjs.org/guide/en/#javascript-api).
 
 ## Practical Example

--- a/packages/dsv/src/index.js
+++ b/packages/dsv/src/index.js
@@ -7,7 +7,7 @@ import stripBom from 'strip-bom';
 
 const parsers = { '.csv': csvParse, '.tsv': tsvParse };
 
-export default function dsv(options = {}) {
+export function dsv(options = {}) {
   const filter = createFilter(options.include, options.exclude);
 
   return {
@@ -32,3 +32,4 @@ export default function dsv(options = {}) {
     }
   };
 }
+export default dsv;

--- a/packages/dsv/types/index.d.ts
+++ b/packages/dsv/types/index.d.ts
@@ -26,4 +26,5 @@ interface RollupDsvOptions {
 /**
  * Convert `.csv` and `.tsv `files into JavaScript modules with `d3-dsv`.
  */
-export default function dsv(options?: RollupDsvOptions): Plugin;
+declare function dsv(options?: RollupDsvOptions): Plugin;
+export { dsv, dsv as default };

--- a/packages/dynamic-import-vars/README.md
+++ b/packages/dynamic-import-vars/README.md
@@ -45,6 +45,13 @@ export default {
 };
 ```
 
+> [!NOTE]
+> If your editor complains that _"dynamicImportVars is not a function"_, then use the named export instead:
+>
+> ```js
+> import { dynamicImportVars } from '@rollup/plugin-dynamic-import-vars';
+> ```
+
 ### Options
 
 #### `include`

--- a/packages/dynamic-import-vars/src/index.js
+++ b/packages/dynamic-import-vars/src/index.js
@@ -122,4 +122,4 @@ ${`    default: return new Promise(function(resolve, reject) {
 }
 
 export default dynamicImportVariables;
-export { dynamicImportToGlob, VariableDynamicImportError };
+export { dynamicImportVariables, dynamicImportToGlob, VariableDynamicImportError };

--- a/packages/dynamic-import-vars/types/index.d.ts
+++ b/packages/dynamic-import-vars/types/index.d.ts
@@ -36,6 +36,5 @@ export function dynamicImportToGlob(node: BaseNode, sourceString: string): null 
 /**
  * Support variables in dynamic imports in Rollup.
  */
-export default function dynamicImportVariables(
-  options?: RollupDynamicImportVariablesOptions
-): Plugin;
+declare function dynamicImportVariables(options?: RollupDynamicImportVariablesOptions): Plugin;
+export { dynamicImportVariables, dynamicImportVariables as default };

--- a/packages/eslint/README.md
+++ b/packages/eslint/README.md
@@ -40,6 +40,13 @@ export default {
 };
 ```
 
+> [!NOTE]
+> If your editor complains that _"eslint is not a function"_, then use the named export instead:
+>
+> ```js
+> import { eslint } from '@rollup/plugin-eslint';
+> ```
+
 ## Options
 
 This plugin takes a configuration object intended for the [ESLint constructor](https://eslint.org/docs/developer-guide/nodejs-api#-new-eslintoptions) with the addition of a `throwOnWarning`, `throwOnError`, `formatter`, `include` and `exclude` prop.

--- a/packages/eslint/src/index.ts
+++ b/packages/eslint/src/index.ts
@@ -10,7 +10,7 @@ function normalizePath(id: string) {
   return relative(process.cwd(), id).split(sep).join('/');
 }
 
-export default function eslint(options = {} as RollupEslintOptions): Plugin {
+export function eslint(options = {} as RollupEslintOptions): Plugin {
   if (typeof options === 'string') {
     const configFile = resolve(process.cwd(), options);
     // eslint-disable-next-line global-require, import/no-dynamic-require, no-param-reassign
@@ -81,3 +81,4 @@ export default function eslint(options = {} as RollupEslintOptions): Plugin {
     }
   };
 }
+export default eslint;

--- a/packages/eslint/types/index.d.ts
+++ b/packages/eslint/types/index.d.ts
@@ -43,4 +43,5 @@ export interface RollupEslintOptions extends ESLint.Options {
 /**
  * 🍣 A Rollup plugin for verifing entry points and all imported files with ESLint.
  */
-export default function eslint(options?: RollupEslintOptions | string): Plugin;
+declare function eslint(options?: RollupEslintOptions | string): Plugin;
+export { eslint, eslint as default };

--- a/packages/esm-shim/README.md
+++ b/packages/esm-shim/README.md
@@ -46,6 +46,13 @@ export default {
 };
 ```
 
+> [!NOTE]
+> If your editor complains that _"esmShim is not a function"_, then use the named export instead:
+>
+> ```typescript
+> import { esmShim } from '@rollup/plugin-esm-shim';
+> ```
+
 Then call `rollup` either via the [CLI](https://www.rollupjs.org/guide/en/#command-line-reference) or the [API](https://www.rollupjs.org/guide/en/#javascript-api).
 
 ## Meta

--- a/packages/esm-shim/src/module.ts
+++ b/packages/esm-shim/src/module.ts
@@ -14,3 +14,4 @@ export function esmShim(): Plugin {
     }
   };
 }
+export default esmShim;

--- a/packages/esm-shim/types/index.d.ts
+++ b/packages/esm-shim/types/index.d.ts
@@ -5,10 +5,12 @@ interface Output {
   map?: SourceMapInput;
 }
 
+export function provideCJSSyntax(code: string): Output | null;
+
 /**
  * A Rollup plugin to replace cjs syntax for esm output bundles.
  *
  * @returns Plugin instance.
  */
-export default function commonjsShim(): Plugin;
-export function provideCJSSyntax(code: string): Output | null;
+declare function esShim(): Plugin;
+export { esShim, esShim as default };

--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -40,6 +40,13 @@ export default {
 };
 ```
 
+> [!NOTE]
+> If your editor complains that _"graphql is not a function"_, then use the named export instead:
+>
+> ```js
+> import { graphql } from '@rollup/plugin-graphql';
+> ```
+
 Then call `rollup` either via the [CLI](https://www.rollupjs.org/guide/en/#command-line-reference) or the [API](https://www.rollupjs.org/guide/en/#javascript-api).
 
 With an accompanying file `src/index.js`, you can import GraphQL files or named queries/mutations:

--- a/packages/graphql/src/index.js
+++ b/packages/graphql/src/index.js
@@ -3,7 +3,7 @@ import loader from 'graphql-tag/loader.js';
 
 import { toESModules } from './toESModules';
 
-export default function graphql({ include, exclude } = {}) {
+export function graphql({ include, exclude } = {}) {
   // path filter
   const filter = createFilter(include, exclude);
   // only .graphql, .graphqls (schema), and .gql files
@@ -34,3 +34,4 @@ export default function graphql({ include, exclude } = {}) {
     }
   };
 }
+export default graphql;

--- a/packages/graphql/types/index.d.ts
+++ b/packages/graphql/types/index.d.ts
@@ -17,4 +17,5 @@ export interface RollupGraphqlOptions {
 /**
  * Convert .gql/.graphql files to ES6 modules
  */
-export default function graphql(options?: RollupGraphqlOptions): Plugin;
+declare function graphql(options?: RollupGraphqlOptions): Plugin;
+export { graphql, graphql as default };

--- a/packages/html/README.md
+++ b/packages/html/README.md
@@ -30,9 +30,9 @@ npm install @rollup/plugin-html --save-dev
 Create a `rollup.config.js` [configuration file](https://www.rollupjs.org/guide/en/#configuration-files) and import the plugin:
 
 ```js
-const html = require('@rollup/plugin-html');
+import html from '@rollup/plugin-html';
 
-module.exports = {
+export default {
   input: 'src/index.js',
   output: {
     dir: 'output',
@@ -41,6 +41,13 @@ module.exports = {
   plugins: [html()]
 };
 ```
+
+> [!NOTE]
+> If your editor complains that _"html is not a function"_, then use the named export instead:
+>
+> ```js
+> import { html } from '@rollup/plugin-html';
+> ```
 
 Then call `rollup` either via the [CLI](https://www.rollupjs.org/guide/en/#command-line-reference) or the [API](https://www.rollupjs.org/guide/en/#javascript-api).
 

--- a/packages/html/src/index.ts
+++ b/packages/html/src/index.ts
@@ -92,7 +92,7 @@ const defaults: Required<RollupHtmlOptions> = {
   addScriptsToHead: false
 };
 
-export default function html(opts: RollupHtmlOptions = {}): Plugin {
+export function html(opts: RollupHtmlOptions = {}): Plugin {
   const {
     addScriptsToHead,
     attributes,
@@ -145,3 +145,4 @@ export default function html(opts: RollupHtmlOptions = {}): Plugin {
     }
   };
 }
+export default html;

--- a/packages/html/types/index.d.ts
+++ b/packages/html/types/index.d.ts
@@ -27,4 +27,5 @@ export function makeHtmlAttributes(attributes: Record<string, string>): string;
  * @param options - Plugin options.
  * @returns Plugin instance.
  */
-export default function html(options?: RollupHtmlOptions): Plugin;
+declare function html(options?: RollupHtmlOptions): Plugin;
+export { html, html as default };

--- a/packages/image/README.md
+++ b/packages/image/README.md
@@ -50,6 +50,13 @@ export default {
 };
 ```
 
+> [!NOTE]
+> If your editor complains that _"image is not a function"_, then use the named export instead:
+>
+> ```js
+> import { image } from '@rollup/plugin-image';
+> ```
+
 Then call `rollup` either via the [CLI](https://www.rollupjs.org/guide/en/#command-line-reference) or the [API](https://www.rollupjs.org/guide/en/#javascript-api).
 
 Once the bundle is executed, the `console.log` will display the Base64 encoded representation of the image.

--- a/packages/image/src/index.js
+++ b/packages/image/src/index.js
@@ -33,7 +33,7 @@ const constTemplate = ({ dataUri }) => `
 const getDataUri = ({ format, isSvg, mime, source }) =>
   isSvg ? svgToMiniDataURI(source) : `data:${mime};${format},${source}`;
 
-export default function image(opts = {}) {
+export function image(opts = {}) {
   const options = Object.assign({}, defaults, opts);
   const filter = createFilter(options.include, options.exclude);
 
@@ -62,3 +62,4 @@ export default function image(opts = {}) {
     }
   };
 }
+export default image;

--- a/packages/image/types/index.d.ts
+++ b/packages/image/types/index.d.ts
@@ -31,4 +31,5 @@ interface RollupImageOptions {
   dom?: boolean;
 }
 
-export default function image(options?: RollupImageOptions): Plugin;
+declare function image(options?: RollupImageOptions): Plugin;
+export { image, image as default };

--- a/packages/inject/README.md
+++ b/packages/inject/README.md
@@ -44,6 +44,13 @@ export default {
 };
 ```
 
+> [!NOTE]
+> If your editor complains that _"inject is not a function"_, then use the named export instead:
+>
+> ```js
+> import { inject } from '@rollup/plugin-inject';
+> ```
+
 Then call `rollup` either via the [CLI](https://www.rollupjs.org/guide/en/#command-line-reference) or the [API](https://www.rollupjs.org/guide/en/#javascript-api).
 
 This configuration above will scan all your files for global Promise usage and plugin will add import to desired module (`import { Promise } from 'es6-promise'` in this case).

--- a/packages/inject/src/index.js
+++ b/packages/inject/src/index.js
@@ -51,7 +51,7 @@ const flatten = (startNode) => {
   return { name, keypath: parts.join('.') };
 };
 
-export default function inject(options) {
+export function inject(options) {
   if (!options) throw new Error('Missing options');
 
   const filter = createFilter(options.include, options.exclude);
@@ -207,3 +207,4 @@ export default function inject(options) {
     }
   };
 }
+export default inject;

--- a/packages/inject/types/index.d.ts
+++ b/packages/inject/types/index.d.ts
@@ -39,4 +39,5 @@ export interface RollupInjectOptions {
 /**
  * inject strings in files while bundling them.
  */
-export default function inject(options?: RollupInjectOptions): Plugin;
+declare function inject(options?: RollupInjectOptions): Plugin;
+export { inject, inject as default };

--- a/packages/json/README.md
+++ b/packages/json/README.md
@@ -40,6 +40,13 @@ export default {
 };
 ```
 
+> [!NOTE]
+> If your editor complains that _"json is not a function"_, then use the named export instead:
+>
+> ```js
+> import { json } from '@rollup/plugin-json';
+> ```
+
 Then call `rollup` either via the [CLI](https://www.rollupjs.org/guide/en/#command-line-reference) or the [API](https://www.rollupjs.org/guide/en/#javascript-api).
 
 With an accompanying file `src/index.js`, the local `package.json` file would now be importable as seen below:

--- a/packages/json/src/index.js
+++ b/packages/json/src/index.js
@@ -1,6 +1,6 @@
 import { createFilter, dataToEsm } from '@rollup/pluginutils';
 
-export default function json(options = {}) {
+export function json(options = {}) {
   const filter = createFilter(options.include, options.exclude);
   const indent = 'indent' in options ? options.indent : '\t';
 
@@ -31,3 +31,4 @@ export default function json(options = {}) {
     }
   };
 }
+export default json;

--- a/packages/json/types/index.d.ts
+++ b/packages/json/types/index.d.ts
@@ -38,4 +38,5 @@ export interface RollupJsonOptions {
 /**
  * Convert .json files to ES6 modules
  */
-export default function json(options?: RollupJsonOptions): Plugin;
+declare function json(options?: RollupJsonOptions): Plugin;
+export { json, json as default };

--- a/packages/legacy/README.md
+++ b/packages/legacy/README.md
@@ -40,6 +40,13 @@ export default {
 };
 ```
 
+> [!NOTE]
+> If your editor complains that _"legacy is not a function"_, then use the named export instead:
+>
+> ```js
+> import { legacy } from '@rollup/plugin-legacy';
+> ```
+
 Then call `rollup` either via the [CLI](https://www.rollupjs.org/guide/en/#command-line-reference) or the [API](https://www.rollupjs.org/guide/en/#javascript-api).
 
 ## Options

--- a/packages/legacy/src/index.js
+++ b/packages/legacy/src/index.js
@@ -4,7 +4,7 @@ import { normalizePath } from '@rollup/pluginutils';
 
 const validName = /^[a-zA-Z_$][a-zA-Z$_0-9]*$/;
 
-export default function legacy(options) {
+export function legacy(options) {
   const exports = {};
   Object.keys(options).forEach((file) => {
     exports[normalizePath(resolve(file))] = options[file];
@@ -50,3 +50,4 @@ export default function legacy(options) {
     }
   };
 }
+export default legacy;

--- a/packages/legacy/types/index.d.ts
+++ b/packages/legacy/types/index.d.ts
@@ -7,4 +7,5 @@ interface RollupLegacyOptions {
 /**
  * A Rollup plugin which adds `export` declarations to legacy non-module scripts.
  */
-export default function legacy(options: RollupLegacyOptions): Plugin;
+declare function legacy(options: RollupLegacyOptions): Plugin;
+export { legacy, legacy as default };

--- a/packages/multi-entry/README.md
+++ b/packages/multi-entry/README.md
@@ -49,16 +49,23 @@ export const color = 'purple';
 Then, create a `rollup.config.js` [configuration file](https://www.rollupjs.org/guide/en/#configuration-files) and import the plugin:
 
 ```js
-import multi from '@rollup/plugin-multi-entry';
+import multiEntry from '@rollup/plugin-multi-entry';
 
 export default {
   input: ['batman.js', 'robin.js', 'joker.js'],
   output: {
     dir: 'output'
   },
-  plugins: [multi()]
+  plugins: [multiEntry()]
 };
 ```
+
+> [!NOTE]
+> If your editor complains that _"multiEntry is not a function"_, then use the named export instead:
+>
+> ```js
+> import { multiEntry } from '@rollup/plugin-multi-entry';
+> ```
 
 Then call `rollup` either via the [CLI](https://www.rollupjs.org/guide/en/#command-line-reference) or the [API](https://www.rollupjs.org/guide/en/#javascript-api).
 

--- a/packages/multi-entry/src/index.js
+++ b/packages/multi-entry/src/index.js
@@ -7,7 +7,7 @@ const DEFAULT_OUTPUT = 'multi-entry.js';
 const AS_IMPORT = 'import';
 const AS_EXPORT = 'export * from';
 
-export default function multiEntry(conf = {}) {
+export function multiEntry(conf = {}) {
   const config = {
     include: [],
     exclude: [],
@@ -75,3 +75,4 @@ export default function multiEntry(conf = {}) {
     }
   };
 }
+export default multiEntry;

--- a/packages/multi-entry/types/index.d.ts
+++ b/packages/multi-entry/types/index.d.ts
@@ -41,4 +41,5 @@ interface RollupMultiEntryOptions {
  * _Note: `default` exports cannot be combined and exported by this plugin. Only named exports
  * will be exported._
  */
-export default function multiEntry(options?: RollupMultiEntryOptions): Plugin;
+declare function multiEntry(options?: RollupMultiEntryOptions): Plugin;
+export { multiEntry, multiEntry as default };

--- a/packages/replace/README.md
+++ b/packages/replace/README.md
@@ -46,6 +46,13 @@ export default {
 };
 ```
 
+> [!NOTE]
+> If your editor complains that _"replace is not a function"_, then use the named export instead:
+>
+> ```js
+> import { replace } from '@rollup/plugin-replace';
+> ```
+
 Then call `rollup` either via the [CLI](https://www.rollupjs.org/guide/en/#command-line-reference) or the [API](https://www.rollupjs.org/guide/en/#javascript-api).
 
 The configuration above will replace every instance of `process.env.NODE_ENV` with `"production"` and `__buildDate__` with the result of the given function in any file included in the build.

--- a/packages/replace/src/index.js
+++ b/packages/replace/src/index.js
@@ -52,7 +52,7 @@ function expandTypeofReplacements(replacements) {
   });
 }
 
-export default function replace(options = {}) {
+export function replace(options = {}) {
   const filter = createFilter(options.include, options.exclude);
   const { delimiters = ['\\b', '\\b(?!\\.)'], preventAssignment, objectGuards } = options;
   const replacements = getReplacements(options);
@@ -125,3 +125,4 @@ export default function replace(options = {}) {
     return options.sourceMap !== false && options.sourcemap !== false;
   }
 }
+export default replace;

--- a/packages/replace/types/index.d.ts
+++ b/packages/replace/types/index.d.ts
@@ -54,4 +54,5 @@ export interface RollupReplaceOptions {
 /**
  * Replace strings in files while bundling them.
  */
-export default function replace(options?: RollupReplaceOptions): Plugin;
+declare function replace(options?: RollupReplaceOptions): Plugin;
+export { replace, replace as default };

--- a/packages/run/README.md
+++ b/packages/run/README.md
@@ -42,6 +42,13 @@ export default {
 };
 ```
 
+> [!NOTE]
+> If your editor complains that _"run is not a function"_, then use the named export instead:
+>
+> ```js
+> import { run } from '@rollup/plugin-run';
+> ```
+
 Then call `rollup` either via the [CLI](https://www.rollupjs.org/guide/en/#command-line-reference) or the [API](https://www.rollupjs.org/guide/en/#javascript-api). If the build produces any errors, the plugin will write a 'alias' character to stderr, which should be audible on most systems.
 
 The plugin `forks` a child process with the generated file, every time the bundle is rebuilt (after first closing the previous process, if it's not the first run).

--- a/packages/run/src/index.ts
+++ b/packages/run/src/index.ts
@@ -6,7 +6,7 @@ import type { Plugin, RenderedChunk } from 'rollup';
 
 import type { RollupRunOptions } from '../types';
 
-export default function run(opts: RollupRunOptions = {}): Plugin {
+export function run(opts: RollupRunOptions = {}): Plugin {
   let input: string;
   let proc: ChildProcess;
 
@@ -82,3 +82,4 @@ export default function run(opts: RollupRunOptions = {}): Plugin {
     }
   };
 }
+export default run;

--- a/packages/run/types/index.d.ts
+++ b/packages/run/types/index.d.ts
@@ -13,4 +13,5 @@ export interface RollupRunOptions extends ForkOptions {
  * Run your bundles in Node once they're built
  * @param options These are passed through to `child_process.fork(..)`
  */
-export default function run(options?: RollupRunOptions): Plugin;
+declare function run(options?: RollupRunOptions): Plugin;
+export { run, run as default };

--- a/packages/strip/README.md
+++ b/packages/strip/README.md
@@ -44,6 +44,13 @@ export default {
 };
 ```
 
+> [!NOTE]
+> If your editor complains that _"strip is not a function"_, then use the named export instead:
+>
+> ```js
+> import { strip } from '@rollup/plugin-strip';
+> ```
+
 Then call `rollup` either via the [CLI](https://www.rollupjs.org/guide/en/#command-line-reference) or the [API](https://www.rollupjs.org/guide/en/#javascript-api).
 
 ## Options

--- a/packages/strip/src/index.js
+++ b/packages/strip/src/index.js
@@ -31,7 +31,7 @@ function flatten(node) {
   return parts.join('.');
 }
 
-export default function strip(options = {}) {
+export function strip(options = {}) {
   const include = options.include || '**/*.js';
   const { exclude } = options;
   const filter = createFilter(include, exclude);
@@ -151,3 +151,4 @@ export default function strip(options = {}) {
     }
   };
 }
+export default strip;

--- a/packages/strip/types/index.d.ts
+++ b/packages/strip/types/index.d.ts
@@ -47,4 +47,5 @@ interface RollupStripOptions {
  * A Rollup plugin to remove debugger statements and functions like `assert.equal` and
  * `console.log` from your code.
  */
-export default function strip(options?: RollupStripOptions): Plugin;
+declare function strip(options?: RollupStripOptions): Plugin;
+export { strip, strip as default };

--- a/packages/sucrase/README.md
+++ b/packages/sucrase/README.md
@@ -49,6 +49,13 @@ export default {
 };
 ```
 
+> [!NOTE]
+> If your editor complains that _"sucrase is not a function"_, then use the named export instead:
+>
+> ```js
+> import { sucrase } from '@rollup/plugin-sucrase';
+> ```
+
 Then call `rollup` either via the [CLI](https://www.rollupjs.org/guide/en/#command-line-reference) or the [API](https://www.rollupjs.org/guide/en/#javascript-api).
 
 ## Options

--- a/packages/sucrase/src/index.js
+++ b/packages/sucrase/src/index.js
@@ -4,7 +4,7 @@ import path from 'path';
 import { transform } from 'sucrase';
 import { createFilter } from '@rollup/pluginutils';
 
-export default function sucrase(opts = {}) {
+export function sucrase(opts = {}) {
   const filter = createFilter(opts.include, opts.exclude);
 
   return {
@@ -60,3 +60,4 @@ export default function sucrase(opts = {}) {
     }
   };
 }
+export default sucrase;

--- a/packages/sucrase/types/index.d.ts
+++ b/packages/sucrase/types/index.d.ts
@@ -31,4 +31,5 @@ interface RollupSucraseOptions
  * A Rollup plugin which compiles TypeScript, Flow, JSX, etc with
  * [Sucrase](https://github.com/alangpierce/sucrase).
  */
-export default function sucrase(options?: RollupSucraseOptions): Plugin;
+declare function sucrase(options?: RollupSucraseOptions): Plugin;
+export { sucrase, sucrase as default };

--- a/packages/swc/README.md
+++ b/packages/swc/README.md
@@ -43,6 +43,13 @@ export default {
 };
 ```
 
+> [!NOTE]
+> If your editor complains that _"swc is not a function"_, then use the named export instead:
+>
+> ```typescript
+> import { swc } from '@rollup/plugin-swc';
+> ```
+
 Then call `rollup` either via the [CLI](https://www.rollupjs.org/guide/en/#command-line-reference) or the [API](https://www.rollupjs.org/guide/en/#javascript-api).
 
 ## Options

--- a/packages/swc/types/index.d.ts
+++ b/packages/swc/types/index.d.ts
@@ -8,4 +8,5 @@ import type { Options } from '../src';
  * @param options - Plugin options.
  * @returns Plugin instance.
  */
-export default function swc(options?: Options): Plugin;
+declare function swc(options?: Options): Plugin;
+export { swc, swc as default };

--- a/packages/terser/README.md
+++ b/packages/terser/README.md
@@ -40,6 +40,13 @@ export default {
 };
 ```
 
+> [!NOTE]
+> If your editor complains that _"terser is not a function"_, then use the named export instead:
+>
+> ```typescript
+> import { terser } from '@rollup/plugin-terser';
+> ```
+
 Then call `rollup` either via the [CLI](https://www.rollupjs.org/guide/en/#command-line-reference) or the [API](https://www.rollupjs.org/guide/en/#javascript-api).
 
 ## Options

--- a/packages/terser/src/index.ts
+++ b/packages/terser/src/index.ts
@@ -5,4 +5,4 @@ runWorker();
 
 export * from './type';
 
-export default terser;
+export { terser, terser as default };

--- a/packages/terser/types/index.d.ts
+++ b/packages/terser/types/index.d.ts
@@ -12,4 +12,5 @@ export interface Options extends MinifyOptions {
  * @param options - Plugin options.
  * @returns Plugin instance.
  */
-export default function terser(options?: Options): Plugin;
+declare function terser(options?: Options): Plugin;
+export { terser, terser as default };

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -47,6 +47,13 @@ export default {
 };
 ```
 
+> [!NOTE]
+> If your editor complains that _"typescript is not a function"_, then use the named export instead:
+>
+> ```js
+> import { typescript } from '@rollup/plugin-typescript';
+> ```
+
 Then call `rollup` either via the [CLI](https://www.rollupjs.org/guide/en/#command-line-reference) or the [API](https://www.rollupjs.org/guide/en/#javascript-api).
 
 ## Options

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -23,7 +23,7 @@ import { preflight } from './preflight';
 import createWatchProgram, { WatchProgramHelper } from './watchProgram';
 import TSCache from './tscache';
 
-export default function typescript(options: RollupTypescriptOptions = {}): Plugin {
+export function typescript(options: RollupTypescriptOptions = {}): Plugin {
   const {
     cacheDir,
     compilerOptions,
@@ -207,3 +207,4 @@ export default function typescript(options: RollupTypescriptOptions = {}): Plugi
     }
   };
 }
+export default typescript;

--- a/packages/typescript/types/index.d.ts
+++ b/packages/typescript/types/index.d.ts
@@ -16,7 +16,7 @@ type ElementType<T extends Array<any> | undefined> = T extends (infer U)[] ? U :
 
 export type TransformerStage = keyof CustomTransformers;
 type StagedTransformerFactory<T extends TransformerStage> = ElementType<CustomTransformers[T]>;
-type TransformerFactory<T extends TransformerStage> =
+export type TransformerFactory<T extends TransformerStage> =
   | StagedTransformerFactory<T>
   | ProgramTransformerFactory<T>
   | TypeCheckerTransformerFactory<T>;
@@ -112,4 +112,5 @@ export type RollupTypescriptOptions = RollupTypescriptPluginOptions & PartialCom
 /**
  * Seamless integration between Rollup and Typescript.
  */
-export default function typescript(options?: RollupTypescriptOptions): Plugin;
+declare function typescript(options?: RollupTypescriptOptions): Plugin;
+export { typescript, typescript as default };

--- a/packages/url/README.md
+++ b/packages/url/README.md
@@ -40,6 +40,12 @@ export default {
 };
 ```
 
+> If your editor complains that _"url is not a function"_, then use the named export instead:
+>
+> ```js
+> import { url } from '@rollup/plugin-url';
+> ```
+
 Then call `rollup` either via the [CLI](https://www.rollupjs.org/guide/en/#command-line-reference) or the [API](https://www.rollupjs.org/guide/en/#javascript-api).
 
 With an accompanying file `src/index.js`, the local `image.svg` file would now be importable as seen below:

--- a/packages/url/src/index.js
+++ b/packages/url/src/index.js
@@ -12,7 +12,7 @@ const fsReadFilePromise = util.promisify(fs.readFile);
 const { posix, sep } = path;
 const defaultInclude = ['**/*.svg', '**/*.png', '**/*.jp(e)?g', '**/*.gif', '**/*.webp'];
 
-export default function url(options = {}) {
+export function url(options = {}) {
   const {
     limit = 14 * 1024,
     include = defaultInclude,
@@ -87,6 +87,7 @@ export default function url(options = {}) {
     }
   };
 }
+export default url;
 
 function copy(src, dest) {
   return new Promise((resolve, reject) => {

--- a/packages/url/types/index.d.ts
+++ b/packages/url/types/index.d.ts
@@ -63,4 +63,5 @@ interface RollupUrlOptions {
 /**
  * A Rollup plugin which imports files as data-URIs or ES Modules.
  */
-export default function url(options?: RollupUrlOptions): Plugin;
+declare function url(options?: RollupUrlOptions): Plugin;
+export { url, url as default };

--- a/packages/virtual/README.md
+++ b/packages/virtual/README.md
@@ -54,6 +54,12 @@ export default {
 };
 ```
 
+> If your editor complains that _"virtual is not a function"_, then use the named export instead:
+>
+> ```js
+> import { virtual } from '@rollup/plugin-virtual';
+> ```
+
 Then call `rollup` either via the [CLI](https://www.rollupjs.org/guide/en/#command-line-reference) or the [API](https://www.rollupjs.org/guide/en/#javascript-api).
 
 ## Options

--- a/packages/virtual/src/index.ts
+++ b/packages/virtual/src/index.ts
@@ -6,7 +6,7 @@ import type { RollupVirtualOptions } from '../types';
 
 const PREFIX = `\0virtual:`;
 
-export default function virtual(modules: RollupVirtualOptions): Plugin {
+export function virtual(modules: RollupVirtualOptions): Plugin {
   const resolvedIds = new Map<string, string>();
 
   Object.keys(modules).forEach((id) => {
@@ -41,3 +41,4 @@ export default function virtual(modules: RollupVirtualOptions): Plugin {
     }
   };
 }
+export default virtual;

--- a/packages/virtual/types/index.d.ts
+++ b/packages/virtual/types/index.d.ts
@@ -7,4 +7,5 @@ export interface RollupVirtualOptions {
 /**
  * A Rollup plugin which loads virtual modules from memory.
  */
-export default function virtual(modules: RollupVirtualOptions): Plugin;
+declare function virtual(modules: RollupVirtualOptions): Plugin;
+export { virtual, virtual as default };

--- a/packages/yaml/README.md
+++ b/packages/yaml/README.md
@@ -40,6 +40,13 @@ export default {
 };
 ```
 
+> [!NOTE]
+> If your editor complains that _"yaml is not a function"_, then use the named export instead:
+>
+> ```js
+> import { yaml } from '@rollup/plugin-yaml';
+> ```
+
 Then call `rollup` either via the [CLI](https://www.rollupjs.org/guide/en/#command-line-reference) or the [API](https://www.rollupjs.org/guide/en/#javascript-api).
 
 With an accompanying file `src/index.js`, the local `heroes.yaml` file would now be importable as seen below:

--- a/packages/yaml/src/index.js
+++ b/packages/yaml/src/index.js
@@ -8,7 +8,7 @@ const defaults = {
   extensions: ['.yaml', '.yml']
 };
 
-export default function yaml(opts = {}) {
+export function yaml(opts = {}) {
   const options = Object.assign({}, defaults, opts);
   const { documentMode, extensions } = options;
   const filter = createFilter(options.include, options.exclude);
@@ -54,3 +54,4 @@ export default function yaml(opts = {}) {
     }
   };
 }
+export default yaml;

--- a/packages/yaml/types/index.d.ts
+++ b/packages/yaml/types/index.d.ts
@@ -49,4 +49,5 @@ interface RollupYamlOptions {
 /**
  * A Rollup plugin which Converts YAML files to ES6 modules.
  */
-export default function yaml(options?: RollupYamlOptions): Plugin;
+declare function yaml(options?: RollupYamlOptions): Plugin;
+export { yaml, yaml as default };


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `{name}`

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no - read on! :)

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->
Fixes #1541, #1578
Supersedes #1744, #1782

### Description
Since #1782 is still failing in CI and since I still have no idea how to fix it, this new PR is a shameful attempt to work around the issue by providing named exports for all plugins, in addition to the default export.

```js
// ❌ fails with `type="module"` and `moduleResolution="node16"`
import typescript from '@rollup/plugin-typescript'

// ✅ works everywhere
import { typescript } from '@rollup/plugin-typescript'
```

I've also added a note in each README.md, right below the usage example, that reads like this:

> [!NOTE]
> If your editor complains that _"XXX is not a function"_, then use the named export instead:
>
> ```js
> import { XXX } from '@rollup/plugin-XXX';
> ```

Because there is absolutely no code change except for an additional export of the main factory function, I don't think new tests are necessary here. Please let me know if you feel otherwise.