### PR TITLE
perf: replace startsWith with strict equality

### DIFF
--- a/packages/commonjs/src/dynamic-modules.js
+++ b/packages/commonjs/src/dynamic-modules.js
@@ -36,7 +36,7 @@ export function getDynamicRequireModules(patterns, dynamicRequireRoot) {
   const dynamicRequireModules = new Map();
   const dirNames = new Set();
   for (const pattern of !patterns || Array.isArray(patterns) ? patterns || [] : [patterns]) {
-    const isNegated = pattern.startsWith('!');
+    const isNegated = pattern[0] === '!';
     const modifyMap = (targetPath, resolvedPath) =>
       isNegated
         ? dynamicRequireModules.delete(targetPath)

--- a/packages/commonjs/src/resolve-id.js
+++ b/packages/commonjs/src/resolve-id.js
@@ -120,7 +120,7 @@ export default function getResolveId(extensions, isPossibleCjsId) {
         }
       }
 
-      if (importee.startsWith('\0')) {
+      if (importee[0] === '\0') {
         return null;
       }
 

--- a/packages/commonjs/src/resolve-require-sources.js
+++ b/packages/commonjs/src/resolve-require-sources.js
@@ -164,7 +164,7 @@ export function getRequireResolver(extensions, detectCyclesAndConditional, curre
         const requireTargets = await Promise.all(
           sources.map(async ({ source, isConditional }) => {
             // Never analyze or proxy internal modules
-            if (source.startsWith('\0')) {
+            if (source[0] === '\0') {
               return { id: source, allowProxy: false };
             }
             currentlyResolvingForParent.add(source);

--- a/packages/dynamic-import-vars/src/dynamic-import-to-glob.js
+++ b/packages/dynamic-import-vars/src/dynamic-import-to-glob.js
@@ -88,13 +88,13 @@ export function dynamicImportToGlob(node, sourceString) {
 
   glob = glob.replace(/\*\*/g, '*');
 
-  if (glob.startsWith('*')) {
+  if (glob[0] === '*') {
     throw new VariableDynamicImportError(
       `invalid import "${sourceString}". It cannot be statically analyzed. Variable dynamic imports must start with ./ and be limited to a specific directory. ${example}`
     );
   }
 
-  if (glob.startsWith('/')) {
+  if (glob[0] === '/') {
     throw new VariableDynamicImportError(
       `invalid import "${sourceString}". Variable absolute imports are not supported, imports must start with ./ in the static part of the import. ${example}`
     );

--- a/packages/node-resolve/src/package/resolvePackageImports.ts
+++ b/packages/node-resolve/src/package/resolvePackageImports.ts
@@ -38,7 +38,7 @@ async function resolvePackageImports({
   };
 
   // Assert: specifier begins with "#".
-  if (!importSpecifier.startsWith('#')) {
+  if (importSpecifier[0] !== '#') {
     throw new InvalidModuleSpecifierError(context, true, 'Invalid import specifier.');
   }
 

--- a/packages/node-resolve/src/package/utils.ts
+++ b/packages/node-resolve/src/package/utils.ts
@@ -35,7 +35,7 @@ export function isUrl(str: string) {
  * Conditions is an export object where all keys are conditions like 'node' (aka do not with '.')
  */
 export function isConditions(exports: any) {
-  return typeof exports === 'object' && Object.keys(exports).every((k) => !k.startsWith('.'));
+  return typeof exports === 'object' && Object.keys(exports).every((k) => k[0] !== '.');
 }
 
 /**
@@ -50,7 +50,7 @@ export function isMappings(exports: any) {
  */
 export function isMixedExports(exports: Record<string, any>) {
   const keys = Object.keys(exports);
-  return keys.some((k) => k.startsWith('.')) && keys.some((k) => !k.startsWith('.'));
+  return keys.some((k) => k[0] === '.') && keys.some((k) => k[0] !== '.');
 }
 
 export function createBaseErrorMsg(importSpecifier: string, importer: string) {

--- a/packages/node-resolve/src/resolveImportSpecifiers.js
+++ b/packages/node-resolve/src/resolveImportSpecifiers.js
@@ -118,7 +118,7 @@ async function resolveWithExportMap({
   ignoreSideEffectsForRoot,
   allowExportsFolderMapping
 }) {
-  if (importSpecifier.startsWith('#')) {
+  if (importSpecifier[0] === '#') {
     // this is a package internal import, resolve using package imports field
     const resolveResult = await resolvePackageImports({
       importSpecifier,

--- a/packages/node-resolve/src/util.js
+++ b/packages/node-resolve/src/util.js
@@ -6,7 +6,7 @@ import { realpathSync } from './fs';
 
 // returns the imported package name for bare module imports
 export function getPackageName(id) {
-  if (id.startsWith('.') || id.startsWith('/')) {
+  if (id[0] === '.' || id[0] === '/') {
     return null;
   }
 


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `{name}`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
When determining the value of the first letter of a string, using strict equality is more efficient than startsWith. refer to [link](https://perf.link/#eyJpZCI6InpyZjd5OHg5Mm13IiwidGl0bGUiOiJGaW5kaW5nIG51bWJlcnMgaW4gYW4gYXJyYXkgb2YgMTAwMCIsImJlZm9yZSI6ImNvbnN0IGRhdGEgPSBbLi4uQXJyYXkoMTAwMCkua2V5cygpXS5tYXAoKCkgPT4gTWF0aC5yYW5kb20oKS50b1N0cmluZygxNikpIiwidGVzdHMiOlt7Im5hbWUiOiJGaW5kIGl0ZW0gMTAwIiwiY29kZSI6ImRhdGEuZmluZCh4ID0%2BIHguc3RhcnRzV2l0aCgnLicpKSIsInJ1bnMiOls2MDAwMCw1NTAwMCw1NzAwMCw3MjAwMCwyNzAwMCw5MzAwMCw5NjAwMCw4MTAwMCwxMTEwMDAsMzAwMCwyODAwMCwxMzAwMDAsMTUwMDAsMjEwMDAsMTU0MDAwLDEwMDAsNTYwMDAsODkwMDAsMzkwMDAsMzMwMDAsMTIwMDAsMzAwMCwyNDAwMCw0MDAwMCwxMjAwMCwxMjAwMCwzNjAwMCwxNTYwMDAsMTA3MDAwLDIwMDAwLDE3MjAwMCwzMzAwMCwyNTAwMCw3MDAwLDEzMDAwLDEyNTAwMCwxNTYwMDAsMTMwMDAsNTgwMDAsMTY5MDAwLDEyMDAwLDIwMDAsMTkwMDAsNDYwMDAsMzAwMCw3NTAwMCwzNDAwMCwxOTAwMCw4NTAwMCwxMzkwMDAsMTY3MDAwLDM4MDAwLDQzMDAwLDQ1MDAwLDM3MDAwLDMzMDAwLDg4MDAwLDE4MDAwLDM3MDAwLDI5MDAwLDQwMDAwLDM0MDAwLDYwMDAwLDQ1MDAwLDEyMzAwMCwyMDAwMCwxMDAwMCw3NjAwMCwxNDAwMCw1NDAwMCw0MzAwMCw3NzAwMCw1MDAwLDU2MDAwLDIwMDAsNDkwMDAsNDMwMDAsNDUwMDAsNDcwMDAsNzQwMDAsMzEwMDAsMjkwMDAsMzkwMDAsMzQwMDAsNDgwMDAsNTIwMDAsMTIwMDAsMjIwMDAsMjAwMCwyMDAwLDIwMDAwLDE1MDAwLDU0MDAwLDQ1MDAwLDkwMDAsMjAwMDAsMTQwMDAsNzAwMCw1NDAwMCw0MTAwMF0sIm9wcyI6NDg1MDB9LHsibmFtZSI6IkZpbmQgaXRlbSAyMDAiLCJjb2RlIjoiZGF0YS5maW5kKHggPT4geFswXSA9PT0gJy4nKSIsInJ1bnMiOls4NTAwMCw3NzAwMCw4NzAwMCw5MjAwMCwyOTAwMCwxMTMwMDAsMTE5MDAwLDExMDAwMCwxMzUwMDAsMTAwMCwzMjAwMCwxNTUwMDAsMjMwMDAsMzMwMDAsMTEzMDAwLDE2NTAwMCw3NDAwMCwxMTQwMDAsMjMwMDAsNDIwMDAsMTAwMDAsMTM4MDAwLDQyMDAwLDU2MDAwLDE3MDAwLDE4MDAwMCw0NjAwMCwxNzcwMDAsMTM1MDAwLDIxMDAwLDE2NzAwMCwzNDAwMCwxOTAwMCw4MDAwLDQwMDAsMTU0MDAwLDE3ODAwMCwxOTYwMDAsODQwMDAsMTg3MDAwLDE2MDAwLDExMDAwLDI0MDAwLDQ3MDAwLDE4NDAwMCw5MzAwMCw0NzAwMCwxOTYwMDAsOTAwMDAsMTY2MDAwLDE4MTAwMCw1MDAwMCwzOTAwMCw1NDAwMCw1NjAwMCwzODAwMCwxMTIwMDAsMjQwMDAsNTEwMDAsNDQwMDAsMzMwMDAsNDUwMDAsNzUwMDAsMjUwMDAsMTQyMDAwLDExMDAwLDE4MzAwMCw5NjAwMCwxMDAwLDUxMDAwLDU3MDAwLDk5MDAwLDE5NjAwMCw3MTAwMCwyMDAwLDY5MDAwLDY2MDAwLDYxMDAwLDY1MDAwLDEwMzAwMCwzNTAwMCwyMTAwMCw1MjAwMCw1OTAwMCwyMzAwMCw0NTAwMCwxMzgwMDAsMzMwMDAsMjAwMCwyMDAwLDI4MDAwLDExMDAwLDU4MDAwLDYyMDAwLDYwMDAsMzAwMDAsMTMwMDAsMjAwMCw3MTAwMCw2NDAwMF0sIm9wcyI6NzIwNDB9XSwidXBkYXRlZCI6IjIwMjUtMDgtMDdUMTQ6MTI6NTUuNDEwWiJ9)
<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
