### PR TITLE
Update resolve-require-sources.js

### DIFF
--- a/packages/commonjs/src/resolve-require-sources.js
+++ b/packages/commonjs/src/resolve-require-sources.js
@@ -210,7 +210,7 @@ export function getRequireResolver(extensions, detectCyclesAndConditional, curre
           fullyAnalyzedModules[dependencyId] = true;
           return {
             wrappedModuleSideEffects:
-              isWrappedCommonJS && rollupContext.getModuleInfo(dependencyId).moduleSideEffects,
+              isWrappedCommonJS && rollupContext.getModuleInfo(dependencyId)?.moduleSideEffects,
             source: sources[index].source,
             id: allowProxy
               ? wrapId(dependencyId, isWrappedCommonJS ? WRAPPED_SUFFIX : PROXY_SUFFIX)


### PR DESCRIPTION
`rollupContext.getModuleInfo(dependencyId)` maybe undefined when `isWrappedCommonJS` is true for `node:xxx` module

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `@rollup/plugin-commonjs`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
