### PR TITLE
feat(pluginutils): add `createHookFilter()`

### DIFF
--- a/packages/pluginutils/README.md
+++ b/packages/pluginutils/README.md
@@ -139,6 +139,54 @@ export default function myPlugin(options = {}) {
 }
 ```
 
+### createHookFilter
+
+Constructs a StringFilter object which can be passed to Rollup for module filtering. Provides the same filtering behavior as `createFilter()` but returns a declarative filter object instead of a function. The content of the
+returned object is not guaranteed to be stable between versions.
+
+Parameters: `(include?: <picomatch>, exclude?: <picomatch>, options?: Object)`<br>
+Returns: `StringFilter`
+
+_Note: Please see the TypeScript definition for complete documentation of the return type_
+
+#### `include` and `exclude`
+
+Type: `String | RegExp | Array[...String|RegExp]`<br>
+
+A valid [`picomatch`](https://github.com/micromatch/picomatch#globbing-features) pattern, or array of patterns. If `options.include` is omitted or has zero length, filter will return `true` by default. Otherwise, an ID must match one or more of the `picomatch` patterns, and must not match any of the `options.exclude` patterns.
+
+Note that `picomatch` patterns are very similar to [`minimatch`](https://github.com/isaacs/minimatch#readme) patterns, and in most use cases, they are interchangeable. If you have more specific pattern matching needs, you can view [this comparison table](https://github.com/micromatch/picomatch#library-comparisons) to learn more about where the libraries differ.
+
+#### `options`
+
+##### `resolve`
+
+Type: `String | Boolean | null`
+
+Optionally resolves the patterns against a directory other than `process.cwd()`. If a `String` is specified, then the value will be used as the base directory. Relative paths will be resolved against `process.cwd()` first. If `false`, then the patterns will not be resolved against any directory. This can be useful if you want to create a filter for virtual module names.
+
+#### Usage
+
+```js
+import { createHookFilter } from '@rollup/pluginutils';
+
+export default function myPlugin(options = {}) {
+  return {
+    transform: {
+      filter: {
+        // assume that the myPlugin accepts options of `options.include` and `options.exclude`
+        id: createHookFilter(options.include, options.exclude, {
+          resolve: '/my/base/dir'
+        })
+      },
+      handler(code) {
+        // implement the transformation...
+      }
+    }
+  };
+}
+```
+
 ### dataToEsm
 
 Transforms objects into tree-shakable ES Module imports.

--- a/packages/pluginutils/src/index.ts
+++ b/packages/pluginutils/src/index.ts
@@ -1,6 +1,6 @@
 import addExtension from './addExtension';
 import attachScopes from './attachScopes';
-import createFilter from './createFilter';
+import { createFilter, createHookFilter } from './createFilter';
 import dataToEsm from './dataToEsm';
 import extractAssignedNames from './extractAssignedNames';
 import makeLegalIdentifier from './makeLegalIdentifier';
@@ -11,6 +11,7 @@ export {
   addExtension,
   attachScopes,
   createFilter,
+  createHookFilter,
   dataToEsm,
   exactRegex,
   extractAssignedNames,
@@ -25,6 +26,7 @@ export default {
   addExtension,
   attachScopes,
   createFilter,
+  createHookFilter,
   dataToEsm,
   exactRegex,
   extractAssignedNames,

--- a/packages/pluginutils/types/index.d.ts
+++ b/packages/pluginutils/types/index.d.ts
@@ -56,6 +56,32 @@ export function createFilter(
   options?: { resolve?: string | false | null }
 ): (id: string | unknown) => boolean;
 
+export type StringFilter<Value = string | RegExp> =
+  | (Value | Value[])
+  | {
+      include?: Value | Value[];
+      exclude?: Value | Value[];
+    };
+
+/**
+ * Constructs a StringFilter object which can be passed to Rollup for module filtering.
+ * Provides the same filtering behavior as `createFilter()` but returns a declarative
+ * filter object instead of a function.
+ *
+ * @param include If omitted or empty, all modules are included by default.
+ * @param exclude ID must not match any of the `exclude` patterns.
+ * @param options Optionally resolves patterns against a directory other than `process.cwd()`.
+ * If a `string` is specified, it will be used as the base directory.
+ * Relative paths are resolved against `process.cwd()` first.
+ * If `false`, patterns will not be resolved (useful for virtual module names).
+ * @returns A StringFilter object compatible with Rollup's filter configuration.
+ */
+export function createHookFilter(
+  include?: FilterPattern,
+  exclude?: FilterPattern,
+  options?: { resolve?: string | false | null }
+): StringFilter;
+
 /**
  * Transforms objects into tree-shakable ES Module imports.
  * @param data An object to transform into an ES module.
@@ -102,6 +128,7 @@ export function suffixRegex(str: string | string[], flags?: string): RegExp;
 export type AddExtension = typeof addExtension;
 export type AttachScopes = typeof attachScopes;
 export type CreateFilter = typeof createFilter;
+export type CreateHookFilter = typeof createHookFilter;
 export type ExactRegex = typeof exactRegex;
 export type ExtractAssignedNames = typeof extractAssignedNames;
 export type MakeLegalIdentifier = typeof makeLegalIdentifier;
@@ -114,6 +141,7 @@ declare const defaultExport: {
   addExtension: AddExtension;
   attachScopes: AttachScopes;
   createFilter: CreateFilter;
+  createHookFilter: CreateHookFilter;
   dataToEsm: DataToEsm;
   exactRegex: ExactRegex;
   extractAssignedNames: ExtractAssignedNames;


### PR DESCRIPTION
## Rollup Plugin Name: `pluginutils`

This PR contains:

- [ ] bugfix
- [x] feature
- [x] refactor
- [x] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

- #1869 tried to port the yaml plugin, which would be easier with this, except the "extensions" filter there would still need to be checked in the handler, so it only solves one part of it.

### Description

When trying to port a plugin that uses `createFilter()` to hook filters it's hard keep the functionality 100% the same, as `createFilter()` does various pre-processing, like normalising paths and, resolving relative paths, exluding paths which contain \0, etc.

To make porting easier, provide a `createHookFilter()` which instead of returning a function, returns a filter object that can be assigned to "filter.id" or "filter.code", and behaves the same as if createFilter() was used and the returned function used in a hook.

To make sure that the implementation of `createHookFilter()` matches `createFilter()`, `createFilter()` now calls `createHookFilter()` internally and uses the same object to create the test function.

----

This was motivated by me trying to port a a plugin which used `createFilter()` to the new API for easy faster rolldown performance, and having a hard time figuring out how to port while making sure that nothing changed for existing users. Not that many new tests added, since all createFilter() calls now also go through the new code, but I can add more if wanted.

Note sure if this is something that would be accepted :) (and my typescript is wonky... keep that in mind)