### PR TITLE
fix(pluginutils): only normalize/parse patterns once in createFilter

### DIFF
--- a/packages/pluginutils/src/createFilter.ts
+++ b/packages/pluginutils/src/createFilter.ts
@@ -26,19 +26,16 @@ function getMatcherString(id: string, resolutionBase: string | false | null | un
 const createFilter: CreateFilter = function createFilter(include?, exclude?, options?) {
   const resolutionBase = options && options.resolve;
 
-  const getMatcher = (id: string | RegExp) =>
-    id instanceof RegExp
-      ? id
-      : {
-          test: (what: string) => {
-            // this refactor is a tad overly verbose but makes for easy debugging
-            const pattern = getMatcherString(id, resolutionBase);
-            const fn = pm(pattern, { dot: true });
-            const result = fn(what);
-
-            return result;
-          }
-        };
+  const getMatcher = (id: string | RegExp) => {
+    if (id instanceof RegExp) {
+      return id;
+    }
+    const pattern = getMatcherString(id, resolutionBase);
+    const fn = pm(pattern, { dot: true });
+    return {
+      test: (what: string) => fn(what)
+    };
+  };
 
   const includeMatchers = ensureArray(include).map(getMatcher);
   const excludeMatchers = ensureArray(exclude).map(getMatcher);


### PR DESCRIPTION
## Rollup Plugin Name: `pluginutils`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

### Description

When passing patterns to createFilter() it would normalize and parse the patterns on every call to the returned filter function.

Just do it once at the start instead.

Something I've noticed while working on #1916.
