### PR TITLE
fix(commonjs): handle global shorthand property correctly

### DIFF
--- a/packages/commonjs/src/transform-commonjs.js
+++ b/packages/commonjs/src/transform-commonjs.js
@@ -322,6 +322,12 @@ export default async function transformCommonjs(
             case 'global':
               uses.global = true;
               if (!ignoreGlobal) {
+                if (isShorthandProperty(parent)) {
+                  // as key and value are the same object, isReference regards
+                  // both as references, so we need to skip now
+                  skippedNodes.add(parent.value);
+                  magicString.prependRight(node.start, 'global: ');
+                }
                 replacedGlobal.push(node);
               }
               return;

--- a/packages/commonjs/test/fixtures/function/shorthand-global/_config.js
+++ b/packages/commonjs/test/fixtures/function/shorthand-global/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  description: 'correctly replaces shorthand `global` property in object'
+};

--- a/packages/commonjs/test/fixtures/function/shorthand-global/main.js
+++ b/packages/commonjs/test/fixtures/function/shorthand-global/main.js
@@ -1,0 +1,7 @@
+const HOST = {
+  global
+};
+
+module.exports = {
+  HOST
+};


### PR DESCRIPTION
## Problem

When `global` is used as a shorthand property in an object literal (e.g., `{global}`), the commonjs plugin replaces `global` with `commonjsHelpers.commonjsGlobal`, resulting in invalid syntax `{commonjsHelpers.commonjsGlobal}`.

This causes a parse error like:
```
Unexpected token \`.\`. Expected ... , *, (, [, :, , ?, = or an identifier
```

## Root Cause

As identified in rollup/rollup#6242 by @TrickyPi, the CommonJS plugin transforms `{global}` into `{commonjsHelpers.commonjsGlobal}`, which is invalid syntax because you can't have a dotted expression as a shorthand property.

## Solution

This fix follows the same pattern already used for the `require` shorthand case (see existing `shorthand-require` test): when detecting a shorthand property, prepend `global: ` to convert it to a full property before replacing the value.

The transformation now correctly produces:
- Before: `{global}` → `{commonjsHelpers.commonjsGlobal}` (invalid syntax)
- After: `{global}` → `{global: commonjsHelpers.commonjsGlobal}` (valid syntax)

## Changes

1. Added shorthand property handling for the `global` identifier in `transform-commonjs.js`
2. Added a test case in `test/fixtures/function/shorthand-global/`

## Related Issues

Fixes rollup/rollup#6242