### PR TITLE
perf(graphql)!: use hook filters

### DIFF
--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -13,7 +13,7 @@
 
 ## Requirements
 
-This plugin requires an [LTS](https://github.com/nodejs/Release) Node version (v14.0.0+) and Rollup v1.20.0+.
+This plugin requires an [LTS](https://github.com/nodejs/Release) Node version (v14.0.0+) and Rollup v2.78.0+.
 
 ## Install
 

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -56,7 +56,7 @@
   ],
   "peerDependencies": {
     "graphql": ">=0.9.0",
-    "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+    "rollup": "^2.78.0||^3.0.0||^4.0.0"
   },
   "peerDependenciesMeta": {
     "rollup": {

--- a/packages/graphql/src/index.js
+++ b/packages/graphql/src/index.js
@@ -11,26 +11,31 @@ export default function graphql({ include, exclude } = {}) {
 
   return {
     name: 'graphql',
-    transform(source, id) {
-      if (!filter(id)) return null;
-      if (!filterExt.test(id)) return null;
+    transform: {
+      filter: {
+        id: filterExt
+      },
+      handler(source, id) {
+        if (!filter(id)) return null;
+        if (!filterExt.test(id)) return null;
 
-      // XXX: this.cachable() in graphql-tag/loader
-      const code = toESModules(
-        loader.call(
-          {
-            cacheable() {}
-          },
-          source
-        )
-      );
+        // XXX: this.cachable() in graphql-tag/loader
+        const code = toESModules(
+          loader.call(
+            {
+              cacheable() {}
+            },
+            source
+          )
+        );
 
-      const map = { mappings: '' };
+        const map = { mappings: '' };
 
-      return {
-        code,
-        map
-      };
+        return {
+          code,
+          map
+        };
+      }
     }
   };
 }


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `graphql`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no (covered by existing tests)

Breaking Changes?

- [x] yes (_breaking changes will not be merged unless absolutely necessary_)
- [ ] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

Similar to https://github.com/rollup/plugins/pull/1954, but for graphql plugin. This PR adds plugin hook filters for improved performance for Rolldown.
Object style hooks are added by https://github.com/rollup/rollup/pull/4600 which is released in 2.78.0, so I bumped the minimum required Rollup version.