### PR TITLE
perf(yaml)!: use hook filters

### DIFF
--- a/packages/yaml/README.md
+++ b/packages/yaml/README.md
@@ -13,7 +13,7 @@
 
 ## Requirements
 
-This plugin requires an [LTS](https://github.com/nodejs/Release) Node version (v14.0.0+) and Rollup v1.20.0+.
+This plugin requires an [LTS](https://github.com/nodejs/Release) Node version (v14.0.0+) and Rollup v2.78.0+.
 
 ## Install
 

--- a/packages/yaml/package.json
+++ b/packages/yaml/package.json
@@ -50,7 +50,7 @@
     "rollup-plugin"
   ],
   "peerDependencies": {
-    "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+    "rollup": "^2.78.0||^3.0.0||^4.0.0"
   },
   "peerDependenciesMeta": {
     "rollup": {
@@ -58,7 +58,7 @@
     }
   },
   "dependencies": {
-    "@rollup/pluginutils": "^5.0.1",
+    "@rollup/pluginutils": "^5.3.0",
     "js-yaml": "^4.1.0",
     "tosource": "^2.0.0-alpha.3"
   },

--- a/packages/yaml/src/index.js
+++ b/packages/yaml/src/index.js
@@ -1,6 +1,6 @@
 import YAML from 'js-yaml';
 import toSource from 'tosource';
-import { createFilter, makeLegalIdentifier } from '@rollup/pluginutils';
+import { createFilter, makeLegalIdentifier, suffixRegex } from '@rollup/pluginutils';
 
 const defaults = {
   documentMode: 'single',
@@ -24,33 +24,40 @@ export default function yaml(opts = {}) {
     );
   }
 
+  const extensionsFilter = suffixRegex(extensions, 'i');
+
   return {
     name: 'yaml',
 
-    transform(content, id) {
-      if (!extensions.some((ext) => id.toLowerCase().endsWith(ext))) return null;
-      if (!filter(id)) return null;
+    transform: {
+      filter: {
+        id: extensionsFilter
+      },
+      handler(content, id) {
+        if (!extensionsFilter.test(id)) return null;
+        if (!filter(id)) return null;
 
-      let data = loadMethod(content);
+        let data = loadMethod(content);
 
-      if (typeof options.transform === 'function') {
-        const result = options.transform(data, id);
-        // eslint-disable-next-line no-undefined
-        if (result !== undefined) {
-          data = result;
+        if (typeof options.transform === 'function') {
+          const result = options.transform(data, id);
+          // eslint-disable-next-line no-undefined
+          if (result !== undefined) {
+            data = result;
+          }
         }
+
+        const keys = Object.keys(data).filter((key) => key === makeLegalIdentifier(key));
+        const code = `var data = ${toSource(data)};\n\n`;
+        const exports = ['export default data;']
+          .concat(keys.map((key) => `export var ${key} = data.${key};`))
+          .join('\n');
+
+        return {
+          code: code + exports,
+          map: { mappings: '' }
+        };
       }
-
-      const keys = Object.keys(data).filter((key) => key === makeLegalIdentifier(key));
-      const code = `var data = ${toSource(data)};\n\n`;
-      const exports = ['export default data;']
-        .concat(keys.map((key) => `export var ${key} = data.${key};`))
-        .join('\n');
-
-      return {
-        code: code + exports,
-        map: { mappings: '' }
-      };
     }
   };
 }

--- a/packages/yaml/src/index.js
+++ b/packages/yaml/src/index.js
@@ -34,7 +34,7 @@ export default function yaml(opts = {}) {
         id: extensionsFilter
       },
       handler(content, id) {
-        if (!extensionsFilter.test(id)) return null;
+        if (extensions.length === 0 || !extensionsFilter.test(id)) return null;
         if (!filter(id)) return null;
 
         let data = loadMethod(content);

--- a/packages/yaml/test/test.js
+++ b/packages/yaml/test/test.js
@@ -102,7 +102,7 @@ test('file extension not in the list', async () => {
   const content = 'some content';
   const id = 'testfile.unknown';
   const plugin = yaml();
-  const output = plugin.transform(content, id);
+  const output = plugin.transform.handler(content, id);
 
   expect(output).toBeNull();
 });
@@ -111,7 +111,7 @@ test('file passes the filter', async () => {
   const content = 'some content';
   const id = 'testfile.yaml';
   const plugin = yaml({ include: '**/*.yaml' });
-  const output = plugin.transform(content, id);
+  const output = plugin.transform.handler(content, id);
 
   expect(output).not.toBeNull();
 });
@@ -120,7 +120,7 @@ test('file does not pass the filter', async () => {
   const content = 'some content';
   const id = 'testfile.yaml';
   const plugin = yaml({ exclude: '**/*.yaml' });
-  const output = plugin.transform(content, id);
+  const output = plugin.transform.handler(content, id);
 
   expect(output).toBeNull();
 });
@@ -129,7 +129,7 @@ test('uses custom extensions', async () => {
   const content = 'some content';
   const id = 'testfile.custom';
   const plugin = yaml({ extensions: ['.custom'] });
-  const output = plugin.transform(content, id);
+  const output = plugin.transform.handler(content, id);
 
   expect(output).not.toBeNull();
 });
@@ -138,7 +138,7 @@ test('does not process non-custom extensions', async () => {
   const content = 'some content';
   const id = 'testfile.yaml';
   const plugin = yaml({ extensions: ['.custom'] });
-  const output = plugin.transform(content, id);
+  const output = plugin.transform.handler(content, id);
 
   expect(output).toBeNull();
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -805,8 +805,8 @@ importers:
   packages/yaml:
     dependencies:
       '@rollup/pluginutils':
-        specifier: ^5.0.1
-        version: 5.0.1(rollup@4.0.0-24)
+        specifier: ^5.3.0
+        version: 5.3.0(rollup@4.0.0-24)
       js-yaml:
         specifier: ^4.1.0
         version: 4.1.0
@@ -1829,6 +1829,15 @@ packages:
 
   '@rollup/pluginutils@5.1.0':
     resolution: {integrity: sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@rollup/pluginutils@5.3.0':
+    resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
@@ -6501,6 +6510,14 @@ snapshots:
       '@types/estree': 1.0.0
       estree-walker: 2.0.2
       picomatch: 2.3.1
+    optionalDependencies:
+      rollup: 4.0.0-24
+
+  '@rollup/pluginutils@5.3.0(rollup@4.0.0-24)':
+    dependencies:
+      '@types/estree': 1.0.8
+      estree-walker: 2.0.2
+      picomatch: 4.0.3
     optionalDependencies:
       rollup: 4.0.0-24
 


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->

## Rollup Plugin Name: `yaml`

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no (covered by existing tests)

Breaking Changes?

- [x] yes (_breaking changes will not be merged unless absolutely necessary_)
- [ ] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

Similar to https://github.com/rollup/plugins/pull/1954, but for yaml plugin. This PR adds plugin hook filters for improved performance for Rolldown.
Object style hooks are added by https://github.com/rollup/rollup/pull/4600 which is released in 2.78.0, so I bumped the minimum required Rollup version.