### PR TITLE
fix(terser): update serialize-javascript to ^7.0.5

### DIFF
--- a/packages/terser/package.json
+++ b/packages/terser/package.json
@@ -62,7 +62,7 @@
     }
   },
   "dependencies": {
-    "serialize-javascript": "^7.0.3",
+    "serialize-javascript": "^7.0.5",
     "smob": "^1.0.0",
     "terser": "^5.17.4"
   },


### PR DESCRIPTION
## Rollup Plugin Name: `terser`

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no (dependency update only)

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. 

List any relevant issue numbers:
- resolves #1990
- Related: https://github.com/GoogleChrome/workbox/issues/3470
- https://github.com/advisories/GHSA-5c6j-r48x-rmvq
- https://github.com/advisories/GHSA-qj8w-gfj5-8c6v

### Description

This PR updates `serialize-javascript` dependency from `^7.0.3` to `^7.0.5` to fix two security vulnerabilities:

1. **GHSA-5c6j-r48x-rmvq** (High severity): Serialize JavaScript is Vulnerable to RCE via RegExp.flags and Date.prototype.toISOString()
   - Patched in: 7.0.3

2. **GHSA-qj8w-gfj5-8c6v** (Moderate severity): Serialize JavaScript has CPU Exhaustion Denial of Service via crafted array-like objects
   - Patched in: 7.0.5

### Impact on Downstream Libraries

This vulnerability affects multiple downstream libraries in the dependency chain:

```
serialize-javascript (vulnerable)
    ↓
@rollup/plugin-terser (uses serialize-javascript)
    ↓
workbox-build (uses @rollup/plugin-terser)
    ↓
vite-plugin-pwa (uses workbox-build)
```

Reference: https://github.com/GoogleChrome/workbox/issues/3470