### PR TITLE
feat(pluginutils): named exports for reserved-word keys + fix duplicate default export in dataToEsm

### DIFF
--- a/packages/pluginutils/src/dataToEsm.ts
+++ b/packages/pluginutils/src/dataToEsm.ts
@@ -115,7 +115,10 @@ const dataToEsm: DataToEsm = function dataToEsm(data, options = {}) {
       defaultExportRows.push(
         `${stringify(key)}:${_}${serialize(value, options.compact ? null : t, '')}`
       );
-      if (options.includeArbitraryNames && isWellFormedString(key)) {
+      // A `default` key is skipped here and exposed only through the default
+      // export object: a `... as default` re-export would clash with the trailing
+      // `export default` and produce a duplicate default export (a SyntaxError).
+      if (key !== 'default' && options.includeArbitraryNames && isWellFormedString(key)) {
         const variableName = `${arbitraryNamePrefix}${arbitraryNameExportRows.length}`;
         namedExportCode += `${declarationType} ${variableName}${_}=${_}${serialize(
           value,

--- a/packages/pluginutils/src/dataToEsm.ts
+++ b/packages/pluginutils/src/dataToEsm.ts
@@ -70,6 +70,11 @@ function isWellFormedString(input: string): boolean {
   return !/\p{Surrogate}/u.test(input);
 }
 
+// Matches the ECMAScript `IdentifierName` grammar, which (unlike a binding
+// identifier) also accepts reserved words such as `switch`/`await`. Such names
+// can be re-exported with the `export { _x as switch }` form, valid since ES2015.
+const identifierNameRE = /^[$_\p{ID_Start}][$\u200c\u200d\p{ID_Continue}]*$/u;
+
 const dataToEsm: DataToEsm = function dataToEsm(data, options = {}) {
   const t = options.compact ? '' : 'indent' in options ? options.indent : '\t';
   const _ = options.compact ? '' : ' ';
@@ -115,17 +120,27 @@ const dataToEsm: DataToEsm = function dataToEsm(data, options = {}) {
       defaultExportRows.push(
         `${stringify(key)}:${_}${serialize(value, options.compact ? null : t, '')}`
       );
-      // A `default` key is skipped here and exposed only through the default
-      // export object: a `... as default` re-export would clash with the trailing
-      // `export default` and produce a duplicate default export (a SyntaxError).
-      if (key !== 'default' && options.includeArbitraryNames && isWellFormedString(key)) {
-        const variableName = `${arbitraryNamePrefix}${arbitraryNameExportRows.length}`;
-        namedExportCode += `${declarationType} ${variableName}${_}=${_}${serialize(
-          value,
-          options.compact ? null : t,
-          ''
-        )};${n}`;
-        arbitraryNameExportRows.push(`${variableName} as ${JSON.stringify(key)}`);
+      // A `default` key is exposed only through the default export object: a
+      // `... as default` re-export would clash with the trailing `export default`
+      // and produce a duplicate default export (a SyntaxError).
+      if (key !== 'default') {
+        // A valid `IdentifierName` that is not a legal binding identifier (a
+        // reserved word or global, e.g. `switch`, `await`) is re-exported with the
+        // unquoted `export { _x as switch }` form, valid since ES2015. Any other
+        // key needs the quoted arbitrary-namespace form (ES2022+), which remains
+        // opt-in via `includeArbitraryNames`.
+        const isIdentifierName = identifierNameRE.test(key);
+        if (isIdentifierName || (options.includeArbitraryNames && isWellFormedString(key))) {
+          const variableName = `${arbitraryNamePrefix}${arbitraryNameExportRows.length}`;
+          namedExportCode += `${declarationType} ${variableName}${_}=${_}${serialize(
+            value,
+            options.compact ? null : t,
+            ''
+          )};${n}`;
+          arbitraryNameExportRows.push(
+            `${variableName} as ${isIdentifierName ? key : JSON.stringify(key)}`
+          );
+        }
       }
     }
   }

--- a/packages/pluginutils/test/dataToEsm.ts
+++ b/packages/pluginutils/test/dataToEsm.ts
@@ -116,3 +116,12 @@ test('support arbitrary module namespace identifier names', () => {
     'export var foo="foo";var _arbitrary0="foo.bar";export{_arbitrary0 as "foo.bar"};export default{foo:foo,"foo.bar":"foo.bar","\\udfff":"non wellformed"};'
   );
 });
+
+test('does not emit a named export for a `default` key with includeArbitraryNames', () => {
+  // `export { _x as "default" }` alongside the trailing `export default {...}`
+  // would be a duplicate default export (a SyntaxError), so a `default` key is
+  // only reachable through the default export object.
+  expect(
+    dataToEsm({ default: 'a', normal: 'b' }, { namedExports: true, includeArbitraryNames: true })
+  ).toBe('export var normal = "b";\nexport default {\n\t"default": "a",\n\tnormal: normal\n};\n');
+});

--- a/packages/pluginutils/test/dataToEsm.ts
+++ b/packages/pluginutils/test/dataToEsm.ts
@@ -44,7 +44,7 @@ test('supports a compact argument', () => {
       { compact: true, objectShorthand: false }
     )
   ).toBe(
-    'export var some={deep:{object:"definition",here:"here"}};export default{some:some,"else":{deep:{object:"definition",here:"here"}}};'
+    'export var some={deep:{object:"definition",here:"here"}};var _arbitrary0={deep:{object:"definition",here:"here"}};export{_arbitrary0 as else};export default{some:some,"else":{deep:{object:"definition",here:"here"}}};'
   );
 });
 
@@ -63,7 +63,10 @@ test('supports nested arrays', () => {
 });
 
 test('serializes null', () => {
-  expect(dataToEsm({ null: null })).toBe('export default {\n\t"null": null\n};\n');
+  // `null` is a valid IdentifierName, so it is re-exported with the unquoted form.
+  expect(dataToEsm({ null: null })).toBe(
+    'var _arbitrary0 = null;\nexport {\n\t_arbitrary0 as null\n};\nexport default {\n\t"null": null\n};\n'
+  );
 });
 
 test('supports default only', () => {
@@ -124,4 +127,31 @@ test('does not emit a named export for a `default` key with includeArbitraryName
   expect(
     dataToEsm({ default: 'a', normal: 'b' }, { namedExports: true, includeArbitraryNames: true })
   ).toBe('export var normal = "b";\nexport default {\n\t"default": "a",\n\tnormal: normal\n};\n');
+});
+
+test('exports reserved-word / global keys as ES2015-safe named exports', () => {
+  // `switch` is a reserved word, `Promise` is a global — both are valid
+  // IdentifierNames, so they are re-exported with the unquoted form without
+  // `includeArbitraryNames`. `default` stays object-only.
+  expect(
+    dataToEsm(
+      { switch: 'a', Promise: 'b', default: 'c', normal: 'd' },
+      { namedExports: true, preferConst: true }
+    )
+  ).toBe(
+    'const _arbitrary0 = "a";\nconst _arbitrary1 = "b";\nexport const normal = "d";\nexport {\n\t_arbitrary0 as switch,\n\t_arbitrary1 as Promise\n};\nexport default {\n\t"switch": "a",\n\t"Promise": "b",\n\t"default": "c",\n\tnormal: normal\n};\n'
+  );
+});
+
+test('keeps reserved-word exports unquoted even with includeArbitraryNames', () => {
+  // Reserved words use the unquoted ES2015 form; only non-identifier-name keys
+  // (e.g. `foo-bar`) use the quoted ES2022 arbitrary-namespace form.
+  expect(
+    dataToEsm(
+      { switch: 'a', 'foo-bar': 'b' },
+      { namedExports: true, preferConst: true, includeArbitraryNames: true }
+    )
+  ).toBe(
+    'const _arbitrary0 = "a";\nconst _arbitrary1 = "b";\nexport {\n\t_arbitrary0 as switch,\n\t_arbitrary1 as "foo-bar"\n};\nexport default {\n\t"switch": "a",\n\t"foo-bar": "b"\n};\n'
+  );
 });


### PR DESCRIPTION
…in dataToEsm

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

<!-- the plugin(s) this PR is for -->
## Rollup Plugin Name: `@rollup/pluginutils`

This PR contains:

- [x] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

resolves #2001

### Description

Two related changes to `dataToEsm`:

**1. Feature — emit ES2015-safe named exports for reserved-word / identifier-name keys**

A key that is a valid `IdentifierName` but not a legal binding identifier (a
reserved word, global, or literal — `switch`, `await`, `null`, `true`, …) is now
re-exported with the unquoted `export { _x as switch }` form, which is valid
since ES2015. Previously such keys were emitted as named exports only under
`includeArbitraryNames`, and then via the quoted ES2022 form
(`export { _x as "switch" }`).

This is what Vite needs for CSS-modules named exports: a class such as `.switch`
or `.default` should produce a named export even when targeting browsers that
predate arbitrary module namespace names (https://github.com/vitejs/vite/pull/22393).
The unquoted form covers that without `includeArbitraryNames`; the quoted form
stays opt-in and is now used only for keys that are *not* valid `IdentifierName`s
(e.g. `foo-bar`).

> **Behavior change:** for callers not passing `includeArbitraryNames`,
> reserved-word / global / literal keys (e.g. `null`, `true`, `else`) now gain an
> ES2015-valid named export where previously they had none. This is strictly
> additive — it only emits syntax already required by the rest of the output, and
> existing imports are unaffected. Two existing test expectations
> (`serializes null`, `supports a compact argument`) are updated accordingly.

**2. Bugfix — avoid a duplicate default export for a `default` key**

`dataToEsm` always appends a trailing `export default {...}`. A key named
`default` was also emitted as `export { _x as "default" }` (under
`includeArbitraryNames`), producing two default exports and a
`SyntaxError: Duplicate export of 'default'`. A `default` key is now exposed only
through the default export object.

### Steps to execute / reproduce

```js
import { dataToEsm } from '@rollup/pluginutils';

// reserved-word named export (ES2015-safe), no includeArbitraryNames needed
dataToEsm({ switch: 'a', normal: 'b' }, { namedExports: true, preferConst: true });
// -> const _arbitrary0 = "a"; export const normal = "b";
//    export { _arbitrary0 as switch }; export default { "switch": "a", normal };

// the duplicate-default bug, before this PR:
const code = dataToEsm({ default: 'x' }, { namedExports: true, includeArbitraryNames: true });
await import('data:text/javascript,' + encodeURIComponent(code));
// previously threw: SyntaxError: Duplicate export of 'default'
```


<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
