### PR TITLE
fix(typescript): apply plugin defaults after parsing tsconfig files, honoring extension

### DIFF
--- a/packages/typescript/CHANGELOG.md
+++ b/packages/typescript/CHANGELOG.md
@@ -1,13 +1,5 @@
 # @rollup/plugin-typescript ChangeLog
 
-## v12.3.1
-
-_2026-05-27_
-
-### Bugfixes
-
-- fix: do not override `module`/`moduleResolution` inherited via tsconfig `extends` (resolves TS5110 when a base config sets `module: nodenext`) (#1726, #1583)
-
 ## v12.3.0
 
 _2025-10-23_

--- a/packages/typescript/CHANGELOG.md
+++ b/packages/typescript/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @rollup/plugin-typescript ChangeLog
 
+## v12.3.1
+
+_2026-05-27_
+
+### Bugfixes
+
+- fix: do not override `module`/`moduleResolution` inherited via tsconfig `extends` (resolves TS5110 when a base config sets `module: nodenext`) (#1726, #1583)
+
 ## v12.3.0
 
 _2025-10-23_

--- a/packages/typescript/src/options/tsconfig.ts
+++ b/packages/typescript/src/options/tsconfig.ts
@@ -125,6 +125,30 @@ function setModuleResolutionKind(parsedConfig: ParsedCommandLine): ParsedCommand
 const configCache = new Map() as typescript.ESMap<string, ExtendedConfigCacheEntry>;
 
 /**
+ * Fill plugin defaults from {@link DEFAULT_COMPILER_OPTIONS} for keys the resolved tsconfig
+ * left unset. Defaults are stored as JSON strings (e.g. `module: 'esnext'`) and must be coerced
+ * to the parsed {@link CompilerOptions} representation (e.g. `ts.ModuleKind.ESNext`) before
+ * being written onto the parsed options. This must run AFTER `parseJsonConfigFileContent` so
+ * that values inherited via `extends` are not clobbered.
+ */
+function applyPluginDefaults(
+  ts: typeof typescript,
+  options: CompilerOptions,
+  basePath: string
+): void {
+  const { options: coerced } = ts.convertCompilerOptionsFromJson(
+    DEFAULT_COMPILER_OPTIONS,
+    basePath
+  );
+  for (const key of Object.keys(coerced) as Array<keyof CompilerOptions>) {
+    if (options[key] == null) {
+      // Plugin-controlled defaults; runtime cast is safe.
+      (options as Record<string, unknown>)[key] = coerced[key];
+    }
+  }
+}
+
+/**
  * Parse the Typescript config to use with the plugin.
  * @param ts Typescript library instance.
  * @param tsconfig Path to the tsconfig file, or `false` to ignore the file.
@@ -155,16 +179,14 @@ export function parseTypescriptConfig(
 
   // If compilerOptions has enums, it represents an CompilerOptions object instead of parsed JSON.
   // This determines where the data is passed to the parser.
+  // Note: plugin defaults are intentionally NOT spread into the leaf tsconfig's compilerOptions
+  // slot here. Doing so would make them win over values inherited via `extends`, producing
+  // spurious diagnostics like TS5110 when extends sets `module`/`moduleResolution: nodenext`.
+  // Defaults are applied below, after parsing, only for keys the resolved config left unset.
   if (containsEnumOptions(compilerOptions)) {
     parsedConfig = setModuleResolutionKind(
       ts.parseJsonConfigFileContent(
-        {
-          ...tsConfigFile,
-          compilerOptions: {
-            ...DEFAULT_COMPILER_OPTIONS,
-            ...tsConfigFile.compilerOptions
-          }
-        },
+        tsConfigFile,
         ts.sys,
         basePath,
         { ...compilerOptions, ...makeForcedCompilerOptions(noForceEmit) },
@@ -180,7 +202,6 @@ export function parseTypescriptConfig(
         {
           ...tsConfigFile,
           compilerOptions: {
-            ...DEFAULT_COMPILER_OPTIONS,
             ...tsConfigFile.compilerOptions,
             ...compilerOptions
           }
@@ -195,6 +216,8 @@ export function parseTypescriptConfig(
       )
     );
   }
+
+  applyPluginDefaults(ts, parsedConfig.options, basePath);
 
   const autoSetSourceMap = normalizeCompilerOptions(ts, parsedConfig.options);
 

--- a/packages/typescript/test/fixtures/extends-nodenext/main.ts
+++ b/packages/typescript/test/fixtures/extends-nodenext/main.ts
@@ -1,0 +1,1 @@
+export const answer = 42;

--- a/packages/typescript/test/fixtures/extends-nodenext/tsconfig.base.json
+++ b/packages/typescript/test/fixtures/extends-nodenext/tsconfig.base.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "module": "nodenext",
+    "moduleResolution": "nodenext"
+  }
+}

--- a/packages/typescript/test/fixtures/extends-nodenext/tsconfig.json
+++ b/packages/typescript/test/fixtures/extends-nodenext/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./tsconfig.base.json"
+}

--- a/packages/typescript/test/helpers/index.js
+++ b/packages/typescript/test/helpers/index.js
@@ -37,6 +37,10 @@ const fakeTypescript = (custom) => {
       };
     },
 
+    convertCompilerOptionsFromJson(jsonOptions) {
+      return { options: { ...jsonOptions }, errors: [] };
+    },
+
     getOutputFileNames(_, id) {
       return [id.replace(/\.tsx?/, '.js')];
     },

--- a/packages/typescript/test/test.js
+++ b/packages/typescript/test/test.js
@@ -57,6 +57,45 @@ test.sequential('allows nodenext module', async () => {
   expect(code.includes('number'), code).toBe(false);
   expect(code.includes('const'), code).toBe(true);
 });
+test.sequential('inherits module/moduleResolution from extends without TS5110', async () => {
+  const warnings = [];
+  const bundle = await rollup({
+    input: 'fixtures/extends-nodenext/main.ts',
+    plugins: [
+      typescript({
+        tsconfig: 'fixtures/extends-nodenext/tsconfig.json'
+      })
+    ],
+    onwarn(warning) {
+      warnings.push(warning);
+    }
+  });
+  await getCode(bundle, outputOptions);
+  const ts5110 = warnings.find((w) => w.pluginCode === 'TS5110');
+  expect(
+    ts5110,
+    `expected no TS5110 warning, got: ${warnings.map((w) => w.pluginCode || w.code).join(', ')}`
+  ).toBeUndefined();
+});
+test.sequential(
+  'parseTypescriptConfig: extends-inherited module survives plugin defaults',
+  async () => {
+    const { parseTypescriptConfig } = await import('../src/options/tsconfig.ts');
+    const result = parseTypescriptConfig(ts, 'fixtures/extends-nodenext/tsconfig.json', {}, false);
+    expect(result.errors).toEqual([]);
+    expect(result.options.module).toBe(ts.ModuleKind.NodeNext);
+    expect(result.options.moduleResolution).toBe(ts.ModuleResolutionKind.NodeNext);
+  }
+);
+test.sequential(
+  'parseTypescriptConfig: applies plugin default module=ESNext + skipLibCheck',
+  async () => {
+    const { parseTypescriptConfig } = await import('../src/options/tsconfig.ts');
+    const result = parseTypescriptConfig(ts, 'fixtures/basic/tsconfig.json', {}, false);
+    expect(result.options.module).toBe(ts.ModuleKind.ESNext);
+    expect(result.options.skipLibCheck).toBe(true);
+  }
+);
 test.sequential('runs code through typescript with compilerOptions', async () => {
   const bundle = await rollup({
     input: 'fixtures/basic/main.ts',
@@ -481,7 +520,10 @@ test.sequential('ignore type errors if noEmitOnError is false', async () => {
     input: 'fixtures/syntax-error/missing-type.ts',
     plugins: [
       typescript({
-        noEmitOnError: false
+        noEmitOnError: false,
+        // Pin to esnext explicitly; falling back to the repo's dev tsconfig.base would
+        // otherwise inherit `module: commonjs` and trip the preflight ESM check.
+        module: 'esnext'
       })
     ],
     onwarn(warning) {
@@ -518,7 +560,8 @@ test.sequential('should use named exports for classes', async () => {
     input: 'fixtures/export-class/main.ts',
     plugins: [
       typescript({
-        include: 'fixtures/export-class/**/*'
+        include: 'fixtures/export-class/**/*',
+        module: 'esnext'
       })
     ],
     onwarn


### PR DESCRIPTION
## Rollup Plugin Name: `typescript`

This PR contains:

- [x] bugfix

Are tests included?

- [x] yes

Breaking Changes?

- [x] no

List any relevant issue numbers:

resolves #1726
resolves #1583

### Description

The util function `parseTypescriptConfig` spreads `DEFAULT_COMPILER_OPTIONS` into `compilerOptions`, which is passed to `ts.parseJsonConfigFileContent`. So the plugin defaults win over anything inherited via `extends`, which in turn triggers TS5110 when using `typescript@5.x`.

The current state requires that users restate `module/moduleResolution: nodenext` in the rollup config in order to not be forced into default values (`{ module: 'esnext', skipLibCheck: true }`).  This is tenable for small projects, but cumbersome in large monorepos.

#### The fix

Apply defaults after `parseJsonConfigFileContent` returns, only for keys the resolved config left unset. `ts.convertCompilerOptionsFromJson` handles the JSON→enum coercion.

#### Tests

- Added a new `extends-nodenext` fixture
- Added one unit test on `parseTypescriptConfig` (version-independent, red on master) and one end-to-end TS5110 check.
- Two existing tests that fell back to the repo's dev tsconfig now pass `module: 'esnext'` explicitly; `fakeTypescript` helper gets a `convertCompilerOptionsFromJson` stub.

With the patch, tests pass on TS 4.8.4 (bundled) and TS 5.9.3
